### PR TITLE
Bump source code to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["fft", "dft", "discrete", "fourier", "transform"]
 categories = ["algorithms", "compression", "multimedia::encoding", "science"]
 license = "MIT OR Apache-2.0"
 
+edition = "2018"
+
 [dependencies]
 num-complex = "0.3"
 num-integer = "0.1.43"

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 extern crate test;
-extern crate rustfft;
+use rustfft;
 
 use std::sync::Arc;
 use test::Bencher;
@@ -72,7 +72,7 @@ fn bench_good_thomas(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = planner.plan_fft(width);
     let height_fft = planner.plan_fft(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(GoodThomasAlgorithm::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(GoodThomasAlgorithm::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -97,7 +97,7 @@ fn bench_good_thomas_setup(b: &mut Bencher, width: usize, height: usize) {
     let height_fft = planner.plan_fft(height);
 
     b.iter(|| { 
-        let fft : Arc<FFT<f32>> = Arc::new(GoodThomasAlgorithm::new(Arc::clone(&width_fft), Arc::clone(&height_fft)));
+        let fft : Arc<dyn FFT<f32>> = Arc::new(GoodThomasAlgorithm::new(Arc::clone(&width_fft), Arc::clone(&height_fft)));
         test::black_box(fft);
     });
 }
@@ -119,7 +119,7 @@ fn bench_mixed_radix(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = planner.plan_fft(width);
     let height_fft = planner.plan_fft(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(MixedRadix::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(MixedRadix::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -137,7 +137,7 @@ fn bench_mixed_radix(b: &mut Bencher, width: usize, height: usize) {
 
 
 
-fn plan_butterfly(len: usize) -> Arc<FFTButterfly<f32>> {
+fn plan_butterfly(len: usize) -> Arc<dyn FFTButterfly<f32>> {
         match len {
             2 => Arc::new(Butterfly2::new(false)),
             3 => Arc::new(Butterfly3::new(false)),
@@ -159,7 +159,7 @@ fn bench_mixed_radix_butterfly(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = plan_butterfly(width);
     let height_fft = plan_butterfly(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(MixedRadixDoubleButterfly::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(MixedRadixDoubleButterfly::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -178,7 +178,7 @@ fn bench_good_thomas_butterfly(b: &mut Bencher, width: usize, height: usize) {
     let width_fft = plan_butterfly(width);
     let height_fft = plan_butterfly(height);
 
-    let fft : Arc<FFT<_>> = Arc::new(GoodThomasAlgorithmDoubleButterfly::new(width_fft, height_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(GoodThomasAlgorithmDoubleButterfly::new(width_fft, height_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; width * height];
     let mut spectrum = signal.clone();
@@ -198,7 +198,7 @@ fn bench_raders(b: &mut Bencher, len: usize) {
     let mut planner = rustfft::FFTplanner::new(false);
     let inner_fft = planner.plan_fft(len - 1);
 
-    let fft : Arc<FFT<_>> = Arc::new(RadersAlgorithm::new(len, inner_fft));
+    let fft : Arc<dyn FFT<_>> = Arc::new(RadersAlgorithm::new(len, inner_fft));
 
     let mut signal = vec![Complex{re: 0_f32, im: 0_f32}; len];
     let mut spectrum = signal.clone();
@@ -222,7 +222,7 @@ fn bench_raders_setup(b: &mut Bencher, len: usize) {
     let inner_fft = planner.plan_fft(len - 1);
 
     b.iter(|| { 
-        let fft : Arc<FFT<f32>> = Arc::new(RadersAlgorithm::new(len, Arc::clone(&inner_fft)));
+        let fft : Arc<dyn FFT<f32>> = Arc::new(RadersAlgorithm::new(len, Arc::clone(&inner_fft)));
         test::black_box(fft);
     });
 }

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -1,7 +1,5 @@
 //! Show how to use an `FFT` object from multiple threads
 
-extern crate rustfft;
-
 use std::thread;
 use std::sync::Arc;
 

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -1,10 +1,10 @@
 use num_complex::Complex;
 use num_traits::{FromPrimitive, Zero};
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use crate::common::{FFTnum, verify_length, verify_length_divisible};
 
-use twiddles;
-use ::{Length, IsInverse, FFT};
+use crate::twiddles;
+use crate::{Length, IsInverse, FFT};
 
 
 pub trait FFTButterfly<T: FFTnum>: Length + IsInverse + Sync + Send {
@@ -972,8 +972,8 @@ impl<T> IsInverse for Butterfly32<T> {
 #[cfg(test)]
 mod unit_tests {
 	use super::*;
-	use test_utils::{random_signal, compare_vectors, check_fft_algorithm};
-	use algorithm::DFT;
+	use crate::test_utils::{random_signal, compare_vectors, check_fft_algorithm};
+	use crate::algorithm::DFT;
 	use num_traits::Zero;
 
     //the tests for all butterflies will be identical except for the identifiers used and size

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -1,10 +1,10 @@
 use num_complex::Complex;
 use num_traits::Zero;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use crate::common::{FFTnum, verify_length, verify_length_divisible};
 
-use ::{Length, IsInverse, FFT};
-use twiddles;
+use crate::{Length, IsInverse, FFT};
+use crate::twiddles;
 
 /// Naive O(n^2 ) Discrete Fourier Transform implementation
 ///
@@ -91,7 +91,7 @@ impl<T> IsInverse for DFT<T> {
 mod unit_tests {
     use super::*;
     use std::f32;
-    use test_utils::{random_signal, compare_vectors};
+    use crate::test_utils::{random_signal, compare_vectors};
     use num_complex::Complex;
     use num_traits::Zero;
 

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -4,13 +4,13 @@ use num_complex::Complex;
 use strength_reduce::StrengthReducedUsize;
 use transpose;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use crate::common::{FFTnum, verify_length, verify_length_divisible};
 
-use math_utils;
-use array_utils;
+use crate::math_utils;
+use crate::array_utils;
 
-use ::{Length, IsInverse, FFT};
-use algorithm::butterflies::FFTButterfly;
+use crate::{Length, IsInverse, FFT};
+use crate::algorithm::butterflies::FFTButterfly;
 
 /// Implementation of the [Good-Thomas Algorithm (AKA Prime Factor Algorithm)](https://en.wikipedia.org/wiki/Prime-factor_FFT_algorithm)
 ///
@@ -311,8 +311,8 @@ impl<T> IsInverse for GoodThomasAlgorithmDoubleButterfly<T> {
 mod unit_tests {
     use super::*;
     use std::sync::Arc;
-    use test_utils::{check_fft_algorithm, make_butterfly};
-    use algorithm::DFT;
+    use crate::test_utils::{check_fft_algorithm, make_butterfly};
+    use crate::algorithm::DFT;
     use num_integer::gcd;
 
     #[test]

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use num_complex::Complex;
 use transpose;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use crate::common::{FFTnum, verify_length, verify_length_divisible};
 
-use ::{Length, IsInverse, FFT};
-use algorithm::butterflies::FFTButterfly;
-use array_utils;
-use twiddles;
+use crate::{Length, IsInverse, FFT};
+use crate::algorithm::butterflies::FFTButterfly;
+use crate::array_utils;
+use crate::twiddles;
 
 /// Implementation of the Mixed-Radix FFT algorithm
 ///
@@ -267,8 +267,8 @@ impl<T> IsInverse for MixedRadixDoubleButterfly<T> {
 mod unit_tests {
     use super::*;
     use std::sync::Arc;
-    use test_utils::{check_fft_algorithm, make_butterfly};
-    use algorithm::DFT;
+    use crate::test_utils::{check_fft_algorithm, make_butterfly};
+    use crate::algorithm::DFT;
 
     #[test]
     fn test_mixed_radix() {

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -4,11 +4,11 @@ use num_complex::Complex;
 use num_traits::Zero;
 use strength_reduce::StrengthReducedUsize;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use crate::common::{FFTnum, verify_length, verify_length_divisible};
 
-use math_utils;
-use twiddles;
-use ::{Length, IsInverse, FFT};
+use crate::math_utils;
+use crate::twiddles;
+use crate::{Length, IsInverse, FFT};
 
 /// Implementation of Rader's Algorithm
 ///
@@ -164,8 +164,8 @@ impl<T> IsInverse for RadersAlgorithm<T> {
 mod unit_tests {
     use super::*;
     use std::sync::Arc;
-    use test_utils::check_fft_algorithm;
-    use algorithm::DFT;
+    use crate::test_utils::check_fft_algorithm;
+    use crate::algorithm::DFT;
 
     #[test]
     fn test_raders() {

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -1,11 +1,11 @@
 use num_complex::Complex;
 use num_traits::Zero;
 
-use common::{FFTnum, verify_length, verify_length_divisible};
+use crate::common::{FFTnum, verify_length, verify_length_divisible};
 
-use algorithm::butterflies::{Butterfly2, Butterfly4, Butterfly8, Butterfly16, FFTButterfly};
-use ::{Length, IsInverse, FFT};
-use twiddles;
+use crate::algorithm::butterflies::{Butterfly2, Butterfly4, Butterfly8, Butterfly16, FFTButterfly};
+use crate::{Length, IsInverse, FFT};
+use crate::twiddles;
 
 /// FFT algorithm optimized for power-of-two sizes
 ///
@@ -228,7 +228,7 @@ unsafe fn butterfly_4<T: FFTnum>(data: &mut [Complex<T>],
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use test_utils::check_fft_algorithm;
+    use crate::test_utils::check_fft_algorithm;
 
     #[test]
     fn test_radix4() {

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -18,7 +18,7 @@ pub unsafe fn transpose_small<T: Copy>(width: usize, height: usize, input: &[T],
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use test_utils::random_signal;
+    use crate::test_utils::random_signal;
     use num_complex::Complex;
     use num_traits::Zero;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,8 @@
 #![allow(unknown_lints)] // The "bare trait objects" lint is unknown on rustc 1.26
 #![allow(bare_trait_objects)]
 
-pub extern crate num_complex;
-pub extern crate num_traits;
-extern crate num_integer;
-extern crate strength_reduce;
-extern crate transpose;
+pub use num_complex;
+pub use num_traits;
 
 
 
@@ -78,8 +75,8 @@ mod common;
 
 use num_complex::Complex;
 
-pub use plan::FFTplanner;
-pub use common::FFTnum;
+pub use crate::plan::FFTplanner;
+pub use crate::common::FFTnum;
 
 
 
@@ -118,7 +115,6 @@ pub trait FFT<T: FFTnum>: Length + IsInverse + Sync + Send {
     fn process_multi(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]);
 }
 
-#[cfg(test)]
-extern crate rand;
+
 #[cfg(test)]
 mod test_utils;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use num_integer::gcd;
 
-use common::FFTnum;
+use crate::common::FFTnum;
 
-use FFT;
-use algorithm::*;
-use algorithm::butterflies::*;
+use crate::FFT;
+use crate::algorithm::*;
+use crate::algorithm::butterflies::*;
 
-use math_utils;
+use crate::math_utils;
 
 
 const MIN_RADIX4_BITS: u32 = 5; // smallest size to consider radix 4 an option is 2^5 = 32

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use rand::{StdRng, SeedableRng};
 use rand::distributions::{Normal, Distribution};
 
-use algorithm::{DFT, butterflies};
-use FFT;
+use crate::algorithm::{DFT, butterflies};
+use crate::FFT;
 
 
 /// The seed for the random number generator used to generate

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -4,7 +4,7 @@ use std::f64;
 use num_complex::Complex;
 use num_traits::{FromPrimitive, One};
 
-use common::FFTnum;
+use crate::common::FFTnum;
 
 pub fn generate_twiddle_factors<T: FFTnum>(fft_len: usize, inverse: bool) -> Vec<Complex<T>> {
     (0..fft_len).map(|i| single_twiddle(i, fft_len, inverse)).collect()
@@ -39,7 +39,7 @@ pub fn rotate_90<T: FFTnum>(value: Complex<T>, inverse:bool) -> Complex<T>
 mod unit_tests {
 	use super::*;
 	use std::f32;
-    use test_utils::{compare_vectors};
+    use crate::test_utils::{compare_vectors};
 
     #[test]
     fn test_generate() {

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -5,8 +5,6 @@
 //! DFT calculation for those signals.
 
 
-extern crate rustfft;
-extern crate rand;
 
 use std::f32;
 


### PR DESCRIPTION
We now requiere rustc 1.31 or higher. This means there is no benefit in maintaining the code in the 2015 edition.