### PR TITLE
Bluestein's algorithm

### DIFF
--- a/src/algorithm/bluestein.rs
+++ b/src/algorithm/bluestein.rs
@@ -1,0 +1,250 @@
+use std::sync::Arc;
+
+use num_complex::Complex;
+use num_traits::Zero;
+
+use common::{FFTnum, verify_length, verify_length_divisible};
+
+use ::{Length, IsInverse, FFT};
+
+/// Implementation of Rader's Algorithm
+///
+/// This algorithm computes a prime-sized FFT in O(nlogn) time. It does this by converting this size n FFT into a
+/// size (n - 1) FFT, which is guaranteed to be composite.
+///
+/// The worst case for this algorithm is when (n - 1) is 2 * prime, resulting in a
+/// [Cunningham Chain](https://en.wikipedia.org/wiki/Cunningham_chain)
+///
+/// ~~~
+/// // Computes a forward FFT of size 1201 (prime number), using Rader's Algorithm
+/// use rustfft::algorithm::RadersAlgorithm;
+/// use rustfft::{FFT, FFTplanner};
+/// use rustfft::num_complex::Complex;
+/// use rustfft::num_traits::Zero;
+///
+/// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1201];
+/// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1201];
+///
+/// // plan a FFT of size n - 1 = 1200
+/// let mut planner = FFTplanner::new(false);
+/// let inner_fft = planner.plan_fft(1200);
+///
+/// let fft = RadersAlgorithm::new(1201, inner_fft);
+/// fft.process(&mut input, &mut output);
+/// ~~~
+///
+/// Rader's Algorithm is relatively expensive compared to other FFT algorithms. Benchmarking shows that it is up to
+/// an order of magnitude slower than similar composite sizes. In the example size above of 1201, benchmarking shows
+/// that it takes 2.5x more time to compute than a FFT of size 1200.
+
+pub struct Bluesteins<T> {
+    len: usize,
+    inner_fft_fw: Arc<FFT<T>>,
+    inner_fft_inv: Arc<FFT<T>>,
+    w_forward: Box<[Complex<T>]>,
+    w_inverse: Box<[Complex<T>]>,
+    x_forward: Box<[Complex<T>]>,
+    x_inverse: Box<[Complex<T>]>,
+    //scratch_a: Box<[Complex<T>]>,
+    //scratch_b: Box<[Complex<T>]>,
+    inverse: bool,
+}
+
+fn compute_half_twiddle<T: FFTnum>(index: f64, size: usize) -> Complex<T> {
+    let theta = index * core::f64::consts::PI / size as f64;
+    Complex::new(
+        T::from_f64(theta.cos()).unwrap(),
+        T::from_f64(-theta.sin()).unwrap(),
+    )
+}
+
+/// Initialize the "w" twiddles.
+fn initialize_w_twiddles<T: FFTnum>(
+    len: usize,
+    fft: &Arc<FFT<T>>,
+    forward_twiddles: &mut [Complex<T>],
+    inverse_twiddles: &mut [Complex<T>],
+) {
+    let mut forward_twiddles_temp = vec![Complex::zero(); fft.len()];
+    let mut inverse_twiddles_temp = vec![Complex::zero(); fft.len()];
+    for i in 0..fft.len() {
+        if let Some(index) = {
+            if i < len {
+                Some((i as f64).powi(2))
+            } else if i > fft.len() - len {
+                Some(((i as f64) - (fft.len() as f64)).powi(2))
+            } else {
+                None
+            }
+        } {
+            let twiddle = compute_half_twiddle(index, len);
+            forward_twiddles_temp[i] = twiddle.conj();
+            inverse_twiddles_temp[i] = twiddle;
+        } else {
+            forward_twiddles_temp[i] = Complex::zero();
+            inverse_twiddles_temp[i] = Complex::zero();
+        }
+    }
+    fft.process(&mut forward_twiddles_temp, &mut forward_twiddles[..]);
+    fft.process(&mut inverse_twiddles_temp, &mut inverse_twiddles[..]);
+}
+
+/// Initialize the "x" twiddles.
+fn initialize_x_twiddles<T: FFTnum>(
+    len: usize,
+    forward_twiddles: &mut [Complex<T>],
+    inverse_twiddles: &mut [Complex<T>],
+) {
+    for i in 0..len {
+        let twiddle = compute_half_twiddle(-(i as f64).powi(2), len);
+        forward_twiddles[i] = twiddle.conj();
+        inverse_twiddles[i] = twiddle;
+    }
+}
+
+impl<T: FFTnum > Bluesteins<T> {
+    /// Creates a FFT instance which will process inputs/outputs of size `len`. `inner_fft.len()` must be `len - 1`
+    ///
+    /// Note that this constructor is quite expensive to run; This algorithm must run a FFT of size n - 1 within the
+    /// constructor. This further underlines the fact that Rader's Algorithm is more expensive to run than other
+    /// FFT algorithms
+    ///
+    /// Note also that if `len` is not prime, this algorithm may silently produce garbage output
+    pub fn new(len: usize, inner_fft_fw: Arc<FFT<T>>, inner_fft_inv: Arc<FFT<T>>, inverse: bool) -> Self {
+        let inner_fft_len = (2 * len - 1).checked_next_power_of_two().unwrap();
+        assert_eq!(inner_fft_len, inner_fft_fw.len(), "For Bluesteins algorithm, inner_fft.len() must be a power of to larger than or equal to 2*self.len() - 1. Expected {}, got {}", inner_fft_len, inner_fft_fw.len());
+
+        let mut w_forward = vec![Complex::zero(); inner_fft_len];
+        let mut w_inverse = vec![Complex::zero(); inner_fft_len];
+        let mut x_forward = vec![Complex::zero(); len];
+        let mut x_inverse = vec![Complex::zero(); len];
+        //let mut scratch_a = vec![Complex::zero(); inner_fft_len];
+        //let mut scratch_b = vec![Complex::zero(); inner_fft_len];
+        initialize_w_twiddles(len, &inner_fft_fw, &mut w_forward, &mut w_inverse);
+        initialize_x_twiddles(len, &mut x_forward, &mut x_inverse);
+        //println!("w_forward");
+        //for tw in w_forward.iter() {
+        //    println!("{:?}, {:?}", tw.re, tw.im);
+        //}
+        //println!("w_inverse");
+        //for tw in w_inverse.iter() {
+        //    println!("{:?}, {:?}", tw.re, tw.im);
+        //}
+        //println!("x_forward");
+        //for tw in x_forward.iter() {
+        //    println!("{:?}, {:?}", tw.re, tw.im);
+        //}
+        //println!("x_inverse");
+        //for tw in x_inverse.iter() {
+        //    println!("{:?}, {:?}", tw.re, tw.im);
+        //}
+        Self {
+            len,
+            inner_fft_fw: inner_fft_fw,
+            inner_fft_inv: inner_fft_inv,
+            w_forward: w_forward.into_boxed_slice(),
+            w_inverse: w_inverse.into_boxed_slice(),
+            x_forward: x_forward.into_boxed_slice(),
+            x_inverse: x_inverse.into_boxed_slice(),
+            //scratch_a: scratch_a.into_boxed_slice(),
+            //scratch_b: scratch_b.into_boxed_slice(),
+            inverse,
+        }
+    }
+
+    fn perform_fft(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
+        //assert_eq!(self.x_forward.len(), input.len());
+        
+        let size = input.len();
+        let mut scratch_a = vec![Complex::zero(); self.inner_fft_fw.len()];
+        let mut scratch_b = vec![Complex::zero(); self.inner_fft_fw.len()];
+        if !self.inverse {
+            for (w, (x, i)) in scratch_a.iter_mut().zip(self.x_forward.iter().zip(input.iter())) {
+                *w = x * i;
+            }
+            //for w in scratch_a[size..].iter_mut() {
+            //    *w = Complex::zero();
+            //}
+            self.inner_fft_fw.process(&mut scratch_a, &mut scratch_b);
+            for (w, wi) in scratch_b.iter_mut().zip(self.w_forward.iter()) {
+                *w = *w * wi;
+            }
+            self.inner_fft_inv.process(&mut scratch_b, &mut scratch_a);
+            let scale = T::one() / T::from_usize(self.inner_fft_inv.len()).unwrap();
+            for (i, (w, xi)) in output.iter_mut().zip(scratch_a.iter().zip(self.x_forward.iter())) {
+                *i = w * xi * scale;
+            }
+        }
+        else {
+            for (w, (x, i)) in scratch_a.iter_mut().zip(self.x_inverse.iter().zip(input.iter())) {
+                *w = x * i;
+            }
+            //for w in scratch_a[size..].iter_mut() {
+            //    *w = Complex::zero();
+            //}
+            self.inner_fft_fw.process(&mut scratch_a, &mut scratch_b);
+            for (w, wi) in scratch_b.iter_mut().zip(self.w_inverse.iter()) {
+                *w = *w * wi;
+            }
+            self.inner_fft_inv.process(&mut scratch_b, &mut scratch_a);
+            let scale = T::one() / T::from_usize(self.inner_fft_inv.len()).unwrap();
+            for (i, (w, xi)) in output.iter_mut().zip(scratch_a.iter().zip(self.x_inverse.iter())) {
+                *i = w * xi * scale;
+            }
+        } 
+    }
+
+   
+}
+
+impl<T: FFTnum> FFT<T> for Bluesteins<T> {
+    fn process(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
+        verify_length(input, output, self.len());
+
+        self.perform_fft(input, output);
+    }
+    fn process_multi(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
+        verify_length_divisible(input, output, self.len());
+
+        for (in_chunk, out_chunk) in input.chunks_mut(self.len()).zip(output.chunks_mut(self.len())) {
+            self.perform_fft(in_chunk, out_chunk);
+        }
+    }
+}
+impl<T> Length for Bluesteins<T> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+impl<T> IsInverse for Bluesteins<T> {
+    #[inline(always)]
+    fn is_inverse(&self) -> bool {
+        self.inverse
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use std::sync::Arc;
+    use test_utils::check_fft_algorithm;
+    use algorithm::DFT;
+
+    #[test]
+    fn test_bluestein() {
+        for &len in &[3,5,7,11,13] {
+            test_bluestein_with_length(len, false);
+            test_bluestein_with_length(len, true);
+        }
+    }
+
+    fn test_bluestein_with_length(len: usize, inverse: bool) {
+        let inner_fft_len = (2 * len - 1).checked_next_power_of_two().unwrap();
+        let inner_fft_fw = Arc::new(DFT::new(inner_fft_len, false));
+        let inner_fft_inv = Arc::new(DFT::new(inner_fft_len, true));
+        let fft = Bluesteins::new(len, inner_fft_fw, inner_fft_inv, inverse);
+
+        check_fft_algorithm(&fft, len, inverse);
+    }
+}

--- a/src/algorithm/bluestein.rs
+++ b/src/algorithm/bluestein.rs
@@ -12,6 +12,7 @@ use ::{Length, IsInverse, FFT};
 /// This algorithm computes a FFT of any size by using converting it to a convolution, where a longer power-of-two length FFT is used. 
 /// The primary use is for prime-sized FFTs of lengths where Rader's alorithm is slow.
 ///
+/// This implementation is based on the one in the [fourier library](https://github.com/calebzulawski/fourier) by Caleb Zulawski.
 /// ~~~
 /// // Computes a forward FFT of size 1201 (prime number), using Bluesteins's Algorithm
 /// use rustfft::algorithm::Bluesteins;

--- a/src/algorithm/bluestein.rs
+++ b/src/algorithm/bluestein.rs
@@ -7,17 +7,14 @@ use common::{FFTnum, verify_length, verify_length_divisible};
 
 use ::{Length, IsInverse, FFT};
 
-/// Implementation of Rader's Algorithm
+/// Implementation of Bluestein's Algorithm
 ///
-/// This algorithm computes a prime-sized FFT in O(nlogn) time. It does this by converting this size n FFT into a
-/// size (n - 1) FFT, which is guaranteed to be composite.
-///
-/// The worst case for this algorithm is when (n - 1) is 2 * prime, resulting in a
-/// [Cunningham Chain](https://en.wikipedia.org/wiki/Cunningham_chain)
+/// This algorithm computes a FFT of any size by using converting it to a convolution, where a longer power-of-two length FFT is used. 
+/// The primary use is for prime-sized FFTs of lengths where Rader's alorithm is slow.
 ///
 /// ~~~
-/// // Computes a forward FFT of size 1201 (prime number), using Rader's Algorithm
-/// use rustfft::algorithm::RadersAlgorithm;
+/// // Computes a forward FFT of size 1201 (prime number), using Bluesteins's Algorithm
+/// use rustfft::algorithm::Bluesteins;
 /// use rustfft::{FFT, FFTplanner};
 /// use rustfft::num_complex::Complex;
 /// use rustfft::num_traits::Zero;
@@ -25,49 +22,50 @@ use ::{Length, IsInverse, FFT};
 /// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1201];
 /// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1201];
 ///
-/// // plan a FFT of size n - 1 = 1200
+/// // plan a forward FFT for the nearest power of two larger or equal to 2 * 1201 - 1 -> 4096
 /// let mut planner = FFTplanner::new(false);
-/// let inner_fft = planner.plan_fft(1200);
+/// let inner_fft_fw = planner.plan_fft(4096);
 ///
-/// let fft = RadersAlgorithm::new(1201, inner_fft);
+/// // plan an inverse FFT for the nearest power of two larger or equal to 2 * 1201 - 1 -> 4096
+/// let mut planner = FFTplanner::new(true);
+/// let inner_fft_inv = planner.plan_fft(4096);
+///
+/// let fft = Bluesteins::new(1201, inner_fft_fw, inner_fft_inv, false);
 /// fft.process(&mut input, &mut output);
 /// ~~~
 ///
-/// Rader's Algorithm is relatively expensive compared to other FFT algorithms. Benchmarking shows that it is up to
-/// an order of magnitude slower than similar composite sizes. In the example size above of 1201, benchmarking shows
-/// that it takes 2.5x more time to compute than a FFT of size 1200.
+/// Bluestein's algorithm is mainly useful for prime-length FFTs, and in particular for the lengths where
+/// Rader's algorithm is slow due to hitting a Cunningham Chain. 
 
 pub struct Bluesteins<T> {
     len: usize,
     inner_fft_fw: Arc<FFT<T>>,
     inner_fft_inv: Arc<FFT<T>>,
-    w_forward: Box<[Complex<T>]>,
-    w_inverse: Box<[Complex<T>]>,
-    x_forward: Box<[Complex<T>]>,
-    x_inverse: Box<[Complex<T>]>,
-    //scratch_a: Box<[Complex<T>]>,
-    //scratch_b: Box<[Complex<T>]>,
+    w_twiddles: Box<[Complex<T>]>,
+    x_twiddles: Box<[Complex<T>]>,
     inverse: bool,
 }
 
-fn compute_half_twiddle<T: FFTnum>(index: f64, size: usize) -> Complex<T> {
-    let theta = index * core::f64::consts::PI / size as f64;
+fn calculate_twiddle<T: FFTnum>(index: f64, len: usize) -> Complex<T> {
+    let theta = index * core::f64::consts::PI / len as f64;
     Complex::new(
         T::from_f64(theta.cos()).unwrap(),
         T::from_f64(-theta.sin()).unwrap(),
     )
 }
 
-/// Initialize the "w" twiddles.
-fn initialize_w_twiddles<T: FFTnum>(
+
+
+/// Calculate the "w" twiddles.
+fn calculate_w_twiddles<T: FFTnum>(
     len: usize,
     fft: &Arc<FFT<T>>,
-    forward_twiddles: &mut [Complex<T>],
-    inverse_twiddles: &mut [Complex<T>],
+    twiddles: &mut [Complex<T>],
+    inverse: bool,
 ) {
-    let mut forward_twiddles_temp = vec![Complex::zero(); fft.len()];
-    let mut inverse_twiddles_temp = vec![Complex::zero(); fft.len()];
-    for i in 0..fft.len() {
+    let mut scratch = vec![Complex::zero(); fft.len()];
+    let scale = T::one() / T::from_usize(fft.len()).unwrap();
+    for (i, tw) in scratch.iter_mut().enumerate() {
         if let Some(index) = {
             if i < len {
                 Some((i as f64).powi(2))
@@ -77,121 +75,79 @@ fn initialize_w_twiddles<T: FFTnum>(
                 None
             }
         } {
-            let twiddle = compute_half_twiddle(index, len);
-            forward_twiddles_temp[i] = twiddle.conj();
-            inverse_twiddles_temp[i] = twiddle;
-        } else {
-            forward_twiddles_temp[i] = Complex::zero();
-            inverse_twiddles_temp[i] = Complex::zero();
+            let twiddle = calculate_twiddle(index, len)*scale;
+            if inverse {
+                *tw = twiddle;
+            }
+            else {
+                *tw = twiddle.conj();
+            }
+        } 
+    }
+    fft.process(&mut scratch, &mut twiddles[..]);
+}
+
+
+/// Calculate the "x" twiddles.
+fn calculate_x_twiddles<T: FFTnum>(
+    len: usize,
+    twiddles: &mut [Complex<T>],
+    inverse: bool,
+) {
+    if inverse {
+        for (i, tw) in twiddles.iter_mut().enumerate() {
+            *tw = calculate_twiddle(-(i as f64).powi(2), len);
         }
     }
-    fft.process(&mut forward_twiddles_temp, &mut forward_twiddles[..]);
-    fft.process(&mut inverse_twiddles_temp, &mut inverse_twiddles[..]);
-}
-
-/// Initialize the "x" twiddles.
-fn initialize_x_twiddles<T: FFTnum>(
-    len: usize,
-    forward_twiddles: &mut [Complex<T>],
-    inverse_twiddles: &mut [Complex<T>],
-) {
-    for i in 0..len {
-        let twiddle = compute_half_twiddle(-(i as f64).powi(2), len);
-        forward_twiddles[i] = twiddle.conj();
-        inverse_twiddles[i] = twiddle;
+    else {
+        for (i, tw) in twiddles.iter_mut().enumerate() {
+            *tw = calculate_twiddle(-(i as f64).powi(2), len).conj();
+        }
     }
 }
 
+
 impl<T: FFTnum > Bluesteins<T> {
-    /// Creates a FFT instance which will process inputs/outputs of size `len`. `inner_fft.len()` must be `len - 1`
+    /// Creates a FFT instance which will process inputs/outputs of size `len`. `inner_fft_fw.len()` and `inner_fft_inv.len()` must be the nearest 
+    /// power of two that is equal to or larger than `2 * len - 1`.
     ///
-    /// Note that this constructor is quite expensive to run; This algorithm must run a FFT of size n - 1 within the
-    /// constructor. This further underlines the fact that Rader's Algorithm is more expensive to run than other
-    /// FFT algorithms
-    ///
-    /// Note also that if `len` is not prime, this algorithm may silently produce garbage output
+    /// Note that this constructor is quite expensive to run; This algorithm must run a FFT within the
+    /// constructor. 
     pub fn new(len: usize, inner_fft_fw: Arc<FFT<T>>, inner_fft_inv: Arc<FFT<T>>, inverse: bool) -> Self {
         let inner_fft_len = (2 * len - 1).checked_next_power_of_two().unwrap();
-        assert_eq!(inner_fft_len, inner_fft_fw.len(), "For Bluesteins algorithm, inner_fft.len() must be a power of to larger than or equal to 2*self.len() - 1. Expected {}, got {}", inner_fft_len, inner_fft_fw.len());
+        assert_eq!(inner_fft_len, inner_fft_fw.len(), "For Bluesteins algorithm, inner_fft_fw.len() must be a power of to larger than or equal to 2*self.len() - 1. Expected {}, got {}", inner_fft_len, inner_fft_fw.len());
+        assert_eq!(inner_fft_len, inner_fft_inv.len(), "For Bluesteins algorithm, inner_fft_inv.len() must be a power of to larger than or equal to 2*self.len() - 1. Expected {}, got {}", inner_fft_len, inner_fft_inv.len());
 
-        let mut w_forward = vec![Complex::zero(); inner_fft_len];
-        let mut w_inverse = vec![Complex::zero(); inner_fft_len];
-        let mut x_forward = vec![Complex::zero(); len];
-        let mut x_inverse = vec![Complex::zero(); len];
-        //let mut scratch_a = vec![Complex::zero(); inner_fft_len];
-        //let mut scratch_b = vec![Complex::zero(); inner_fft_len];
-        initialize_w_twiddles(len, &inner_fft_fw, &mut w_forward, &mut w_inverse);
-        initialize_x_twiddles(len, &mut x_forward, &mut x_inverse);
-        //println!("w_forward");
-        //for tw in w_forward.iter() {
-        //    println!("{:?}, {:?}", tw.re, tw.im);
-        //}
-        //println!("w_inverse");
-        //for tw in w_inverse.iter() {
-        //    println!("{:?}, {:?}", tw.re, tw.im);
-        //}
-        //println!("x_forward");
-        //for tw in x_forward.iter() {
-        //    println!("{:?}, {:?}", tw.re, tw.im);
-        //}
-        //println!("x_inverse");
-        //for tw in x_inverse.iter() {
-        //    println!("{:?}, {:?}", tw.re, tw.im);
-        //}
+        let mut w_twiddles = vec![Complex::zero(); inner_fft_len];
+        let mut x_twiddles = vec![Complex::zero(); len];
+        calculate_w_twiddles(len, &inner_fft_fw, &mut w_twiddles, inverse);
+        calculate_x_twiddles(len, &mut x_twiddles, inverse);
         Self {
             len,
-            inner_fft_fw: inner_fft_fw,
-            inner_fft_inv: inner_fft_inv,
-            w_forward: w_forward.into_boxed_slice(),
-            w_inverse: w_inverse.into_boxed_slice(),
-            x_forward: x_forward.into_boxed_slice(),
-            x_inverse: x_inverse.into_boxed_slice(),
-            //scratch_a: scratch_a.into_boxed_slice(),
-            //scratch_b: scratch_b.into_boxed_slice(),
+            inner_fft_fw,
+            inner_fft_inv,
+            w_twiddles: w_twiddles.into_boxed_slice(),
+            x_twiddles: x_twiddles.into_boxed_slice(),
             inverse,
         }
     }
 
     fn perform_fft(&self, input: &mut [Complex<T>], output: &mut [Complex<T>]) {
-        //assert_eq!(self.x_forward.len(), input.len());
-        
-        let size = input.len();
+        assert_eq!(self.len(), input.len());
+
         let mut scratch_a = vec![Complex::zero(); self.inner_fft_fw.len()];
         let mut scratch_b = vec![Complex::zero(); self.inner_fft_fw.len()];
-        if !self.inverse {
-            for (w, (x, i)) in scratch_a.iter_mut().zip(self.x_forward.iter().zip(input.iter())) {
-                *w = x * i;
-            }
-            //for w in scratch_a[size..].iter_mut() {
-            //    *w = Complex::zero();
-            //}
-            self.inner_fft_fw.process(&mut scratch_a, &mut scratch_b);
-            for (w, wi) in scratch_b.iter_mut().zip(self.w_forward.iter()) {
-                *w = *w * wi;
-            }
-            self.inner_fft_inv.process(&mut scratch_b, &mut scratch_a);
-            let scale = T::one() / T::from_usize(self.inner_fft_inv.len()).unwrap();
-            for (i, (w, xi)) in output.iter_mut().zip(scratch_a.iter().zip(self.x_forward.iter())) {
-                *i = w * xi * scale;
-            }
+        for (w, (x, i)) in scratch_a.iter_mut().zip(self.x_twiddles.iter().zip(input.iter())) {
+            *w = x * i;
         }
-        else {
-            for (w, (x, i)) in scratch_a.iter_mut().zip(self.x_inverse.iter().zip(input.iter())) {
-                *w = x * i;
-            }
-            //for w in scratch_a[size..].iter_mut() {
-            //    *w = Complex::zero();
-            //}
-            self.inner_fft_fw.process(&mut scratch_a, &mut scratch_b);
-            for (w, wi) in scratch_b.iter_mut().zip(self.w_inverse.iter()) {
-                *w = *w * wi;
-            }
-            self.inner_fft_inv.process(&mut scratch_b, &mut scratch_a);
-            let scale = T::one() / T::from_usize(self.inner_fft_inv.len()).unwrap();
-            for (i, (w, xi)) in output.iter_mut().zip(scratch_a.iter().zip(self.x_inverse.iter())) {
-                *i = w * xi * scale;
-            }
-        } 
+        self.inner_fft_fw.process(&mut scratch_a, &mut scratch_b);
+        for (w, wi) in scratch_b.iter_mut().zip(self.w_twiddles.iter()) {
+            *w = *w * wi;
+        }
+        self.inner_fft_inv.process(&mut scratch_b, &mut scratch_a);
+        for (i, (w, xi)) in output.iter_mut().zip(scratch_a.iter().zip(self.x_twiddles.iter())) {
+            *i = w * xi;
+        }
     }
 
    

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -3,6 +3,7 @@ mod mixed_radix;
 mod raders_algorithm;
 mod radix4;
 mod dft;
+mod bluestein;
 
 /// Hardcoded size-specfic FFT algorithms
 pub mod butterflies;
@@ -12,3 +13,4 @@ pub use self::raders_algorithm::RadersAlgorithm;
 pub use self::radix4::Radix4;
 pub use self::good_thomas_algorithm::{GoodThomasAlgorithm, GoodThomasAlgorithmDoubleButterfly};
 pub use self::dft::DFT;
+pub use self::bluestein::Bluesteins;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -206,28 +206,15 @@ impl<T: FFTnum> FFTplanner<T> {
         }
     }
 
-    //fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
-    //    let inner_fft_len = len - 1;
-    //    let factors = math_utils::prime_factors(inner_fft_len);
-    //
-    //    let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
-    //
-    //    Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
-    //}
-
     fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
         let inner_fft_len = len - 1;
         if math_utils::distinct_prime_factors(inner_fft_len as u64/2).len() <= 2 {  
             let inner_fft_len = (2 * len - 1).checked_next_power_of_two().unwrap();
-            let factors = math_utils::prime_factors(inner_fft_len);
-            let mut planner_fw = FFTplanner::new(false);
-            let mut planner_inv = FFTplanner::new(true);
-            let inner_fft_fw = planner_fw.plan_fft_with_factors(inner_fft_len, &factors);
-            let inner_fft_inv = planner_inv.plan_fft_with_factors(inner_fft_len, &factors);
+            let inner_fft_fw = Arc::new(Radix4::new(inner_fft_len, false));
+            let inner_fft_inv = Arc::new(Radix4::new(inner_fft_len, true));
             Arc::new(Bluesteins::new(len, inner_fft_fw, inner_fft_inv, self.inverse)) as Arc<FFT<T>>
         }
         else {
-            //let inner_fft_len = len - 1;
             let factors = math_utils::prime_factors(inner_fft_len);
             let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
             Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -206,12 +206,31 @@ impl<T: FFTnum> FFTplanner<T> {
         }
     }
 
+    //fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
+    //    let inner_fft_len = len - 1;
+    //    let factors = math_utils::prime_factors(inner_fft_len);
+    //
+    //    let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
+    //
+    //    Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
+    //}
+
     fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
         let inner_fft_len = len - 1;
-        let factors = math_utils::prime_factors(inner_fft_len);
-
-        let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
-
-        Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
+        if math_utils::distinct_prime_factors(inner_fft_len as u64/2).len() <= 2 {  
+            let inner_fft_len = (2 * len - 1).checked_next_power_of_two().unwrap();
+            let factors = math_utils::prime_factors(inner_fft_len);
+            let mut planner_fw = FFTplanner::new(false);
+            let mut planner_inv = FFTplanner::new(true);
+            let inner_fft_fw = planner_fw.plan_fft_with_factors(inner_fft_len, &factors);
+            let inner_fft_inv = planner_inv.plan_fft_with_factors(inner_fft_len, &factors);
+            Arc::new(Bluesteins::new(len, inner_fft_fw, inner_fft_inv, self.inverse)) as Arc<FFT<T>>
+        }
+        else {
+            //let inner_fft_len = len - 1;
+            let factors = math_utils::prime_factors(inner_fft_len);
+            let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
+            Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
+        }
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -15,6 +15,8 @@ const MIN_RADIX4_BITS: u32 = 5; // smallest size to consider radix 4 an option i
 const MAX_RADIX4_BITS: u32 = 16; // largest size to consider radix 4 an option is 2^16 = 65536
 const BUTTERFLIES: [usize; 9] = [2, 3, 4, 5, 6, 7, 8, 16, 32];
 const COMPOSITE_BUTTERFLIES: [usize; 5] = [4, 6, 8, 16, 32];
+const MAX_RADER_PRIME_FACTOR: usize = 7; // don't use Raders if the inner fft length has prime factor larger than this
+const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
 
 /// The FFT planner is used to make new FFT algorithm instances.
 ///
@@ -207,17 +209,25 @@ impl<T: FFTnum> FFTplanner<T> {
     }
 
     fn plan_prime(&mut self, len: usize) -> Arc<FFT<T>> {
-        let inner_fft_len = len - 1;
-        let factors = math_utils::prime_factors(inner_fft_len);
-        // If any of the prime factors is larger than 7, Rader's gets slow and Bluestein's is the better choice
-        if factors.iter().any(|val| *val > 7) {
-            let inner_fft_len = (2 * len - 1).checked_next_power_of_two().unwrap();
-            let inner_fft_fw = Arc::new(Radix4::new(inner_fft_len, false));
-            let inner_fft_inv = Arc::new(Radix4::new(inner_fft_len, true));
-            Arc::new(Bluesteins::new(len, inner_fft_fw, inner_fft_inv, self.inverse)) as Arc<FFT<T>>
+        let inner_fft_len_rader = len - 1;
+        let factors = math_utils::prime_factors(inner_fft_len_rader);
+        // If any of the prime factors is too large, Rader's gets slow and Bluestein's is the better choice
+        if factors.iter().any(|val| *val > MAX_RADER_PRIME_FACTOR) {
+            let inner_fft_len_pow2 = (2 * len - 1).checked_next_power_of_two().unwrap();
+            // for long ffts a mixed radix inner fft is faster than a longer radix4
+            let min_inner_len = 2 * len - 1;
+            let mixed_radix_len = 3*inner_fft_len_pow2/4;
+            let inner_fft = if mixed_radix_len >= min_inner_len && len >= MIN_BLUESTEIN_MIXED_RADIX_LEN {
+                let inner_factors = math_utils::prime_factors(mixed_radix_len);
+                self.plan_fft_with_factors(mixed_radix_len, &inner_factors)
+            }
+            else {
+                Arc::new(Radix4::new(inner_fft_len_pow2, self.inverse))
+            };
+            Arc::new(Bluesteins::new(len, inner_fft)) as Arc<FFT<T>>
         }
         else {
-            let inner_fft = self.plan_fft_with_factors(inner_fft_len, &factors);
+            let inner_fft = self.plan_fft_with_factors(inner_fft_len_rader, &factors);
             Arc::new(RadersAlgorithm::new(len, inner_fft)) as Arc<FFT<T>>
         }
     }


### PR DESCRIPTION
This PR adds an implementation of Bluesteins algorithm. This is often but not always faster than Raders algorithm. 
The code is based on the implementation in "fourier" by @calebzulawski
https://github.com/calebzulawski/fourier/blob/master/fourier-algorithms/src/bluesteins.rs

This is useful for prime length FFTs, especially the ones where Rader's gets slow.
The planner has been modified to use Raders when the prime factors of (len-1)/2 are all 7 or less, and Bluesteins for other cases. This seems to give the fastest implementation for nearly all lengths, and all the ones where the difference is large are correct.

This graph shows the average time to compute a FFT for all prime lengths below 1000, for Rader and Bluestein:
![rader_vs_bluestein](https://user-images.githubusercontent.com/6504678/100394545-c61f2400-303d-11eb-8ec6-40a63bda0661.png)
The plot was made with this simple tool: https://github.com/HEnquist/fftbenching/tree/bluestein_vs_rader
