### PR TITLE
Add generic implementation for FFTnum

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,9 @@
-use num_traits::{FromPrimitive, Num};
-use std::ops::Neg;
+use num_traits::{FromPrimitive, Signed};
 
-pub trait FFTnum: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static {}
+/// Generic floating point number
+pub trait FFTnum: Copy + FromPrimitive + Signed + Sync + Send + 'static {}
 
-impl<T> FFTnum for T where T: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static
-{}
+impl<T> FFTnum for T where T: Copy + FromPrimitive + Signed + Sync + Send + 'static {}
 
 #[inline(always)]
 pub fn verify_length<T>(input: &[T], output: &[T], expected: usize) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,6 @@
 use num_traits::{FromPrimitive, Num};
 use std::ops::Neg;
 
-/// Generic floating point number, implemented for f32 and f64
 pub trait FFTnum: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static {}
 
 impl<T> FFTnum for T where T: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,21 +1,46 @@
-use num_traits::{FromPrimitive, Signed};
+use num_traits::{FromPrimitive, Num};
+use std::ops::Neg;
 
 /// Generic floating point number, implemented for f32 and f64
-pub trait FFTnum: Copy + FromPrimitive + Signed + Sync + Send + 'static {}
+pub trait FFTnum: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static {}
 
-impl FFTnum for f32 {}
-impl FFTnum for f64 {}
-
+// impl FFTnum for f32 {}
+// impl FFTnum for f64 {}
+impl<T> FFTnum for T where T: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static
+{}
 
 #[inline(always)]
 pub fn verify_length<T>(input: &[T], output: &[T], expected: usize) {
-	assert_eq!(input.len(), expected, "Input is the wrong length. Expected {}, got {}", expected, input.len());
-	assert_eq!(output.len(), expected, "Output is the wrong length. Expected {}, got {}", expected, output.len());
+    assert_eq!(
+        input.len(),
+        expected,
+        "Input is the wrong length. Expected {}, got {}",
+        expected,
+        input.len()
+    );
+    assert_eq!(
+        output.len(),
+        expected,
+        "Output is the wrong length. Expected {}, got {}",
+        expected,
+        output.len()
+    );
 }
-
 
 #[inline(always)]
 pub fn verify_length_divisible<T>(input: &[T], output: &[T], expected: usize) {
-	assert_eq!(input.len() % expected, 0, "Input is the wrong length. Expected multiple of {}, got {}", expected, input.len());
-	assert_eq!(input.len(), output.len(), "Input and output must have the same length. Expected {}, got {}", input.len(), output.len());
+    assert_eq!(
+        input.len() % expected,
+        0,
+        "Input is the wrong length. Expected multiple of {}, got {}",
+        expected,
+        input.len()
+    );
+    assert_eq!(
+        input.len(),
+        output.len(),
+        "Input and output must have the same length. Expected {}, got {}",
+        input.len(),
+        output.len()
+    );
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,8 +4,6 @@ use std::ops::Neg;
 /// Generic floating point number, implemented for f32 and f64
 pub trait FFTnum: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static {}
 
-// impl FFTnum for f32 {}
-// impl FFTnum for f64 {}
 impl<T> FFTnum for T where T: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static
 {}
 
@@ -29,18 +27,6 @@ pub fn verify_length<T>(input: &[T], output: &[T], expected: usize) {
 
 #[inline(always)]
 pub fn verify_length_divisible<T>(input: &[T], output: &[T], expected: usize) {
-    assert_eq!(
-        input.len() % expected,
-        0,
-        "Input is the wrong length. Expected multiple of {}, got {}",
-        expected,
-        input.len()
-    );
-    assert_eq!(
-        input.len(),
-        output.len(),
-        "Input and output must have the same length. Expected {}, got {}",
-        input.len(),
-        output.len()
-    );
+    assert_eq!(input.len() % expected,0,"Input is the wrong length. Expected multiple of {}, got {}",expected,input.len());
+    assert_eq!(input.len(),output.len(),"Input and output must have the same length. Expected {}, got {}",input.len(),output.len());
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,6 +27,18 @@ pub fn verify_length<T>(input: &[T], output: &[T], expected: usize) {
 
 #[inline(always)]
 pub fn verify_length_divisible<T>(input: &[T], output: &[T], expected: usize) {
-    assert_eq!(input.len() % expected,0,"Input is the wrong length. Expected multiple of {}, got {}",expected,input.len());
-    assert_eq!(input.len(),output.len(),"Input and output must have the same length. Expected {}, got {}",input.len(),output.len());
+    assert_eq!(
+        input.len() % expected,
+        0,
+        "Input is the wrong length. Expected multiple of {}, got {}",
+        expected,
+        input.len()
+    );
+    assert_eq!(
+        input.len(),
+        output.len(),
+        "Input and output must have the same length. Expected {}, got {}",
+        input.len(),
+        output.len()
+    );
 }


### PR DESCRIPTION
This PR changes the supertraits of `FFTnum` from `Signed` to `Num + Neg<Output = Self>`.
`Signed` is overly restrictive and not used within the crate beyond `Neg`.

The generic impl:
```rust
impl<T> FFTnum for T where T: Copy + FromPrimitive + Num + Neg<Output = Self> + Sync + Send + 'static {}
```
enables usage of different structs that are defined outside the crate.

These changes are needed for our use case: We use own numeric types (HyperDual numbers, see [num-hyperdual](https://github.com/ITT-University-of-Stuttgart/num-hyperdual)) to calculate derivatives of convolution integrals.