### PR TITLE
Optimized butterflies for lengths 3,5 and 7

### DIFF
--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -40,6 +40,7 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 
 // Prime lengths
 #[bench] fn complex_prime_00005(b: &mut Bencher) { bench_fft(b, 5); }
+#[bench] fn complex_prime_00007(b: &mut Bencher) { bench_fft(b, 7); }
 #[bench] fn complex_prime_00017(b: &mut Bencher) { bench_fft(b, 17); }
 #[bench] fn complex_prime_00151(b: &mut Bencher) { bench_fft(b, 151); }
 #[bench] fn complex_prime_00257(b: &mut Bencher) { bench_fft(b, 257); }

--- a/benches/rustfft.rs
+++ b/benches/rustfft.rs
@@ -39,6 +39,7 @@ fn bench_fft(b: &mut Bencher, len: usize) {
 #[bench] fn complex_p7_16807(b: &mut Bencher) { bench_fft(b, 16807); }
 
 // Prime lengths
+#[bench] fn complex_prime_00003(b: &mut Bencher) { bench_fft(b, 3); }
 #[bench] fn complex_prime_00005(b: &mut Bencher) { bench_fft(b, 5); }
 #[bench] fn complex_prime_00007(b: &mut Bencher) { bench_fft(b, 7); }
 #[bench] fn complex_prime_00017(b: &mut Bencher) { bench_fft(b, 17); }

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -134,15 +134,16 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly3<T> {
 //    }
     #[inline(always)]
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-        let sum = *buffer.get_unchecked(0) + *buffer.get_unchecked(1) + *buffer.get_unchecked(2);
         let temp_a = *buffer.get_unchecked(1) + *buffer.get_unchecked(2);
         let temp_b = *buffer.get_unchecked(1) - *buffer.get_unchecked(2);
+        let sum = *buffer.get_unchecked(0) + temp_a;
 
         let d1re = *buffer.get_unchecked(0) + Complex{re: self.twiddle.re * temp_a.re, im: self.twiddle.re * temp_a.im};
-    
-        *buffer.get_unchecked_mut(1) = d1re + Complex{re: -self.twiddle.im * temp_b.im, im: self.twiddle.im * temp_b.re };
-        *buffer.get_unchecked_mut(2) = d1re + Complex{re: self.twiddle.im * temp_b.im, im: -self.twiddle.im * temp_b.re };
+        let d1im = Complex{re: -self.twiddle.im * temp_b.im, im: self.twiddle.im * temp_b.re };
+
         *buffer.get_unchecked_mut(0) = sum;
+        *buffer.get_unchecked_mut(1) = d1re + d1im;
+        *buffer.get_unchecked_mut(2) = d1re - d1im;
     }
     #[inline(always)]
     unsafe fn process_multi_inplace(&self, buffer: &mut [Complex<T>]) {

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -354,11 +354,11 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly5<T> {
         // The final step is to write out real and imaginary parts of x14n etc, and replacing using j*j=-1
         // After this it's easy to remove any repeated calculation of the same values.
 
-        let sum = *buffer.get_unchecked(0) + *buffer.get_unchecked(1) + *buffer.get_unchecked(2) + *buffer.get_unchecked(3) + *buffer.get_unchecked(4);
         let x14p = *buffer.get_unchecked(1) + *buffer.get_unchecked(4);
         let x14n = *buffer.get_unchecked(1) - *buffer.get_unchecked(4);
         let x23p = *buffer.get_unchecked(2) + *buffer.get_unchecked(3);
         let x23n = *buffer.get_unchecked(2) - *buffer.get_unchecked(3);
+        let sum = *buffer.get_unchecked(0) + x14p + x23p;
 
         let x14re_a = buffer.get_unchecked(0).re + self.twiddle1.re*x14p.re + self.twiddle2.re*x23p.re;
         let x14re_b = self.twiddle1.im*x14n.im + self.twiddle2.im*x23n.im;
@@ -562,13 +562,13 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly7<T> {
         //
         // From here it's just about eliminating repeated calculations, following the same procedure as for the 5-point butterfly.
 
-        let sum = *buffer.get_unchecked(0) + *buffer.get_unchecked(1) + *buffer.get_unchecked(2) + *buffer.get_unchecked(3) + *buffer.get_unchecked(4) + *buffer.get_unchecked(5) + *buffer.get_unchecked(6);
         let x16p = *buffer.get_unchecked(1) + *buffer.get_unchecked(6);
         let x16n = *buffer.get_unchecked(1) - *buffer.get_unchecked(6);
         let x25p = *buffer.get_unchecked(2) + *buffer.get_unchecked(5);
         let x25n = *buffer.get_unchecked(2) - *buffer.get_unchecked(5);
         let x34p = *buffer.get_unchecked(3) + *buffer.get_unchecked(4);
         let x34n = *buffer.get_unchecked(3) - *buffer.get_unchecked(4);
+        let sum = *buffer.get_unchecked(0) + x16p + x25p + x34p;
 
         let x16re_a = buffer.get_unchecked(0).re + self.twiddle1.re*x16p.re + self.twiddle2.re*x25p.re + self.twiddle3.re*x34p.re;
         let x16re_b = self.twiddle1.im*x16n.im + self.twiddle2.im*x25n.im + self.twiddle3.im*x34n.im;

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -1,5 +1,4 @@
 use num_complex::Complex;
-use num_traits::{FromPrimitive, Zero};
 
 use common::{FFTnum, verify_length, verify_length_divisible};
 

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -118,20 +118,6 @@ impl<T: FFTnum> Butterfly3<T> {
     }
 }
 impl<T: FFTnum> FFTButterfly<T> for Butterfly3<T> {
-//    #[inline(always)]
-//    unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-//        let butterfly2 = Butterfly2::new(self.inverse);
-//
-//        butterfly2.process_inplace(&mut buffer[1..]);
-//        let temp = *buffer.get_unchecked(0);
-//
-//        *buffer.get_unchecked_mut(0) = temp + *buffer.get_unchecked(1);
-//
-//        *buffer.get_unchecked_mut(1) = *buffer.get_unchecked(1) * self.twiddle.re + temp;
-//        *buffer.get_unchecked_mut(2) = *buffer.get_unchecked(2) * Complex{re: Zero::zero(), im: self.twiddle.im};
-//
-//        butterfly2.process_inplace(&mut buffer[1..]);
-//    }
     #[inline(always)]
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
         let temp_a = *buffer.get_unchecked(1) + *buffer.get_unchecked(2);
@@ -261,76 +247,23 @@ impl IsInverse for Butterfly4 {
 
 
 pub struct Butterfly5<T> {
-    //inner_fft_multiply: [Complex<T>; 4],
     twiddle1: Complex<T>,
     twiddle2: Complex<T>,
 	inverse: bool,
 }
 impl<T: FFTnum> Butterfly5<T> {
-//    pub fn new(inverse: bool) -> Self {
-//
-//    	//we're going to hardcode a raders algorithm of size 5 and an inner FFT of size 4
-//    	let quarter: T = FromPrimitive::from_f32(0.25f32).unwrap();
-//    	let twiddle1: Complex<T> = twiddles::single_twiddle(1, 5, inverse) * quarter;
-//    	let twiddle2: Complex<T> = twiddles::single_twiddle(2, 5, inverse) * quarter;
-//
-//    	//our primitive root will be 2, and our inverse will be 3. the powers of 3 mod 5 are 1.3.4.2, so we hardcode to use the twiddles in that order
-//    	let mut fft_data = [twiddle1, twiddle2.conj(), twiddle1.conj(), twiddle2];
-//
-//    	let butterfly = Butterfly4::new(inverse);
-//    	unsafe { butterfly.process_inplace(&mut fft_data) };
-//
-//        Butterfly5 { 
-//        	inner_fft_multiply: fft_data,
-//        	inverse: inverse,
-//        }
-//    }
     pub fn new(inverse: bool) -> Self {
-
         let twiddle1: Complex<T> = twiddles::single_twiddle(1, 5, inverse);
         let twiddle2: Complex<T> = twiddles::single_twiddle(2, 5, inverse);
-
         Butterfly5 { 
             twiddle1, 
             twiddle2,
         	inverse,
         }
     }
-
 }
 
 impl<T: FFTnum> FFTButterfly<T> for Butterfly5<T> {
-//    #[inline(always)]
-//    unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-//        //we're going to reorder the buffer directly into our scratch vec
-//        //our primitive root is 2. the powers of 2 mod 5 are 1, 2,4,3 so use that ordering
-//        let mut scratch = [*buffer.get_unchecked(1), *buffer.get_unchecked(2), *buffer.get_unchecked(4), *buffer.get_unchecked(3)];
-//
-//        //perform the first inner FFT
-//        Butterfly4::new(self.inverse).process_inplace(&mut scratch);
-//
-//        //multiply the fft result with our precomputed data
-//        for i in 0..4 {
-//            scratch[i] = scratch[i] * self.inner_fft_multiply[i];
-//        }
-//
-//        //perform the second inner FFT
-//        Butterfly4::new(!self.inverse).process_inplace(&mut scratch);
-//
-//        //the first element of the output is the sum of the rest
-//        let first_input = *buffer.get_unchecked_mut(0);
-//        let mut sum = first_input;
-//        for i in 1..5 {
-//            sum = sum + *buffer.get_unchecked_mut(i);
-//        }
-//        *buffer.get_unchecked_mut(0) = sum;
-//
-//        //use the inverse root ordering to copy data back out
-//        *buffer.get_unchecked_mut(1) = scratch[0] + first_input;
-//        *buffer.get_unchecked_mut(3) = scratch[1] + first_input;
-//        *buffer.get_unchecked_mut(4) = scratch[2] + first_input;
-//        *buffer.get_unchecked_mut(2) = scratch[3] + first_input;
-//    }
     #[inline(always)]
     unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
         let sum = *buffer.get_unchecked(0) + *buffer.get_unchecked(1) + *buffer.get_unchecked(2) + *buffer.get_unchecked(3) + *buffer.get_unchecked(4);
@@ -362,7 +295,6 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly5<T> {
         *buffer.get_unchecked_mut(2) = Complex{re: b2re, im: b2im };
         *buffer.get_unchecked_mut(3) = Complex{re: b3re, im: b3im };
         *buffer.get_unchecked_mut(4) = Complex{re: b4re, im: b4im };
-        
     }
     #[inline(always)]
     unsafe fn process_multi_inplace(&self, buffer: &mut [Complex<T>]) {
@@ -499,31 +431,10 @@ pub struct Butterfly7<T> {
     inverse: bool,
 }
 impl<T: FFTnum> Butterfly7<T> {
-//    pub fn new(inverse: bool) -> Self {
-//
-//        //we're going to hardcode a raders algorithm of size 5 and an inner FFT of size 4
-//        let sixth: T = FromPrimitive::from_f64(1f64/6f64).unwrap();
-//        let twiddle1: Complex<T> = twiddles::single_twiddle(1, 7, inverse) * sixth;
-//        let twiddle2: Complex<T> = twiddles::single_twiddle(2, 7, inverse) * sixth;
-//        let twiddle3: Complex<T> = twiddles::single_twiddle(3, 7, inverse) * sixth;
-//
-//        //our primitive root will be 3, and our inverse will be 5. the powers of 5 mod 7 are 1,5,4,6,2,3, so we hardcode to use the twiddles in that order
-//        let mut fft_data = [twiddle1, twiddle2.conj(), twiddle3.conj(), twiddle1.conj(), twiddle2, twiddle3];
-//
-//        let butterfly = Butterfly6::new(inverse);
-//        unsafe { butterfly.process_inplace(&mut fft_data) };
-//
-//        Butterfly7 { 
-//            inner_fft: butterfly,
-//            inner_fft_multiply: fft_data,
-//        }
-//    }
     pub fn new(inverse: bool) -> Self {
-
         let twiddle1: Complex<T> = twiddles::single_twiddle(1, 7, inverse);
         let twiddle2: Complex<T> = twiddles::single_twiddle(2, 7, inverse);
         let twiddle3: Complex<T> = twiddles::single_twiddle(3, 7, inverse);
-
         Butterfly7 { 
             twiddle1, 
             twiddle2,
@@ -533,47 +444,6 @@ impl<T: FFTnum> Butterfly7<T> {
     }
 }
 impl<T: FFTnum> FFTButterfly<T> for Butterfly7<T> {
-//    #[inline(always)]
-//    unsafe fn process_inplace(&self, buffer: &mut [Complex<T>]) {
-//        //we're going to reorder the buffer directly into our scratch vec
-//        //our primitive root is 3. use 3^n mod 7 to determine which index to copy from
-//        let mut scratch = [
-//            *buffer.get_unchecked(3),
-//            *buffer.get_unchecked(2),
-//            *buffer.get_unchecked(6),
-//            *buffer.get_unchecked(4),
-//            *buffer.get_unchecked(5),
-//            *buffer.get_unchecked(1),
-//            ];
-//
-//        //perform the first inner FFT
-//        self.inner_fft.process_inplace(&mut scratch);
-//
-//        //multiply the fft result with our precomputed data
-//        for i in 0..6 {
-//            scratch[i] = scratch[i] * self.inner_fft_multiply[i];
-//        }
-//
-//        //perform the second inner FFT
-//        let inverse6 = Butterfly6::inverse_of(&self.inner_fft);
-//        inverse6.process_inplace(&mut scratch);
-//
-//        //the first element of the output is the sum of the rest
-//        let first_input = *buffer.get_unchecked(0);
-//        let mut sum = first_input;
-//        for i in 1..7 {
-//            sum = sum + *buffer.get_unchecked_mut(i);
-//        }
-//        *buffer.get_unchecked_mut(0) = sum;
-//
-//        //use the inverse root ordering to copy data back out
-//        *buffer.get_unchecked_mut(5) = scratch[0] + first_input;
-//        *buffer.get_unchecked_mut(4) = scratch[1] + first_input;
-//        *buffer.get_unchecked_mut(6) = scratch[2] + first_input;
-//        *buffer.get_unchecked_mut(2) = scratch[3] + first_input;
-//        *buffer.get_unchecked_mut(3) = scratch[4] + first_input;
-//        *buffer.get_unchecked_mut(1) = scratch[5] + first_input;
-//    }
     #[inline(always)]
     unsafe fn process_multi_inplace(&self, buffer: &mut [Complex<T>]) {
         for chunk in buffer.chunks_mut(self.len()) {
@@ -623,7 +493,6 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly7<T> {
         *buffer.get_unchecked_mut(4) = Complex{re: b4re, im: b4im };
         *buffer.get_unchecked_mut(5) = Complex{re: b5re, im: b5im };
         *buffer.get_unchecked_mut(6) = Complex{re: b6re, im: b6im };
-        
     }
 }
 impl<T: FFTnum> FFT<T> for Butterfly7<T> {
@@ -649,7 +518,6 @@ impl<T> Length for Butterfly7<T> {
 impl<T> IsInverse for Butterfly7<T> {
     #[inline(always)]
     fn is_inverse(&self) -> bool {
-        //self.inner_fft.is_inverse()
         self.inverse
     }
 }

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -460,17 +460,17 @@ impl<T: FFTnum> FFTButterfly<T> for Butterfly7<T> {
         let temp34n = *buffer.get_unchecked(3) - *buffer.get_unchecked(4);
 
         let b16re_a = buffer.get_unchecked(0).re + self.twiddle1.re*temp16p.re + self.twiddle2.re*temp25p.re + self.twiddle3.re*temp34p.re;
-        let b16re_b =                  self.twiddle1.im*temp16n.im + self.twiddle2.im*temp25n.im + self.twiddle3.im*temp34n.im;
+        let b16re_b = self.twiddle1.im*temp16n.im + self.twiddle2.im*temp25n.im + self.twiddle3.im*temp34n.im;
         let b25re_a = buffer.get_unchecked(0).re + self.twiddle1.re*temp34p.re + self.twiddle2.re*temp16p.re + self.twiddle3.re*temp25p.re;
-        let b25re_b =                 -self.twiddle1.im*temp34n.im + self.twiddle2.im*temp16n.im - self.twiddle3.im*temp25n.im;
+        let b25re_b = -self.twiddle1.im*temp34n.im + self.twiddle2.im*temp16n.im - self.twiddle3.im*temp25n.im;
         let b34re_a = buffer.get_unchecked(0).re + self.twiddle1.re*temp25p.re + self.twiddle2.re*temp34p.re + self.twiddle3.re*temp16p.re;
-        let b34re_b =                 -self.twiddle1.im*temp25n.im + self.twiddle2.im*temp34n.im + self.twiddle3.im*temp16n.im;
+        let b34re_b = -self.twiddle1.im*temp25n.im + self.twiddle2.im*temp34n.im + self.twiddle3.im*temp16n.im;
         let b16im_a = buffer.get_unchecked(0).im + self.twiddle1.re*temp16p.im + self.twiddle2.re*temp25p.im + self.twiddle3.re*temp34p.im;
-        let b16im_b =                  self.twiddle1.im*temp16n.re + self.twiddle2.im*temp25n.re + self.twiddle3.im*temp34n.re;
+        let b16im_b = self.twiddle1.im*temp16n.re + self.twiddle2.im*temp25n.re + self.twiddle3.im*temp34n.re;
         let b25im_a = buffer.get_unchecked(0).im + self.twiddle1.re*temp34p.im + self.twiddle2.re*temp16p.im + self.twiddle3.re*temp25p.im;
-        let b25im_b =                 -self.twiddle1.im*temp34n.re + self.twiddle2.im*temp16n.re - self.twiddle3.im*temp25n.re;
+        let b25im_b = -self.twiddle1.im*temp34n.re + self.twiddle2.im*temp16n.re - self.twiddle3.im*temp25n.re;
         let b34im_a = buffer.get_unchecked(0).im + self.twiddle1.re*temp25p.im + self.twiddle2.re*temp34p.im + self.twiddle3.re*temp16p.im;
-        let b34im_b =                  self.twiddle1.im*temp25n.re - self.twiddle2.im*temp34n.re - self.twiddle3.im*temp16n.re;
+        let b34im_b = self.twiddle1.im*temp25n.re - self.twiddle2.im*temp34n.re - self.twiddle3.im*temp16n.re;
 
         let b1re = b16re_a - b16re_b;
         let b1im = b16im_a + b16im_b;

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -158,51 +158,36 @@ fn prepare_radix4<T: FFTnum>(size: usize,
                            signal: &[Complex<T>],
                            spectrum: &mut [Complex<T>],
                            stride: usize) {
-    if size<=16 {
-        unsafe {
-            for i in 0..size {
+    match size {
+        16 => unsafe {
+            for i in 0..16 {
                 *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        8 => unsafe {
+            for i in 0..8 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        4 => unsafe {
+            for i in 0..4 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        2 => unsafe {
+            for i in 0..2 {
+                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
+            }
+        },
+        _ => {
+            for i in 0..4 {
+                prepare_radix4(size / 4,
+                               &signal[i * stride..],
+                               &mut spectrum[i * (size / 4)..],
+                               stride * 4);
             }
         }
     }
-    else {
-        for i in 0..4 {
-            prepare_radix4(size / 4,
-                           &signal[i * stride..],
-                           &mut spectrum[i * (size / 4)..],
-                           stride * 4);
-        }
-    }
-//    match size {
-//        16 => unsafe {
-//            for i in 0..16 {
-//                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
-//            }
-//        },
-//        8 => unsafe {
-//            for i in 0..8 {
-//                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
-//            }
-//        },
-//        4 => unsafe {
-//            for i in 0..4 {
-//                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
-//            }
-//        },
-//        2 => unsafe {
-//            for i in 0..2 {
-//                *spectrum.get_unchecked_mut(i) = *signal.get_unchecked(i * stride);
-//            }
-//        },
-//        _ => {
-//            for i in 0..4 {
-//                prepare_radix4(size / 4,
-//                               &signal[i * stride..],
-//                               &mut spectrum[i * (size / 4)..],
-//                               stride * 4);
-//            }
-//        }
-//    }
 }
 
 unsafe fn butterfly_4<T: FFTnum>(data: &mut [Complex<T>],
@@ -212,31 +197,27 @@ unsafe fn butterfly_4<T: FFTnum>(data: &mut [Complex<T>],
 {
     let mut idx = 0usize;
     let mut tw_idx = 0usize;
-    //let mut scratch: [Complex<T>; 6] = [Zero::zero(); 6];
+    let mut scratch: [Complex<T>; 6] = [Zero::zero(); 6];
     for _ in 0..num_ffts {
-        let idx_numffts = idx + num_ffts;
-        let idx_2numffts = idx + 2*num_ffts;
-        let idx_3numffts = idx + 3*num_ffts;
-
-        let scratch0 = data.get_unchecked(idx_numffts) * twiddles.get_unchecked(tw_idx);
-        let scratch1 = data.get_unchecked(idx_2numffts) * twiddles.get_unchecked(tw_idx + 1);
-        let scratch2 = data.get_unchecked(idx_3numffts) * twiddles.get_unchecked(tw_idx + 2);
-        let scratch5 = data.get_unchecked(idx) - scratch1;
-        *data.get_unchecked_mut(idx) = data.get_unchecked(idx) + scratch1;
-        let scratch3 = scratch0 + scratch2;
-        let scratch4 = scratch0 - scratch2;
-        *data.get_unchecked_mut(idx_2numffts) = data.get_unchecked(idx) - scratch3;
-        *data.get_unchecked_mut(idx) = data.get_unchecked(idx) + scratch3;
+        scratch[0] = data.get_unchecked(idx + 1 * num_ffts) * twiddles[tw_idx];
+        scratch[1] = data.get_unchecked(idx + 2 * num_ffts) * twiddles[tw_idx + 1];
+        scratch[2] = data.get_unchecked(idx + 3 * num_ffts) * twiddles[tw_idx + 2];
+        scratch[5] = data.get_unchecked(idx) - scratch[1];
+        *data.get_unchecked_mut(idx) = data.get_unchecked(idx) + scratch[1];
+        scratch[3] = scratch[0] + scratch[2];
+        scratch[4] = scratch[0] - scratch[2];
+        *data.get_unchecked_mut(idx + 2 * num_ffts) = data.get_unchecked(idx) - scratch[3];
+        *data.get_unchecked_mut(idx) = data.get_unchecked(idx) + scratch[3];
         if inverse {
-            data.get_unchecked_mut(idx_numffts).re = scratch5.re - scratch4.im;
-            data.get_unchecked_mut(idx_numffts).im = scratch5.im + scratch4.re;
-            data.get_unchecked_mut(idx_3numffts).re = scratch5.re + scratch4.im;
-            data.get_unchecked_mut(idx_3numffts).im = scratch5.im - scratch4.re;
+            data.get_unchecked_mut(idx + num_ffts).re = scratch[5].re - scratch[4].im;
+            data.get_unchecked_mut(idx + num_ffts).im = scratch[5].im + scratch[4].re;
+            data.get_unchecked_mut(idx + 3 * num_ffts).re = scratch[5].re + scratch[4].im;
+            data.get_unchecked_mut(idx + 3 * num_ffts).im = scratch[5].im - scratch[4].re;
         } else {
-            data.get_unchecked_mut(idx_numffts).re = scratch5.re + scratch4.im;
-            data.get_unchecked_mut(idx_numffts).im = scratch5.im - scratch4.re;
-            data.get_unchecked_mut(idx_3numffts).re = scratch5.re - scratch4.im;
-            data.get_unchecked_mut(idx_3numffts).im = scratch5.im + scratch4.re;
+            data.get_unchecked_mut(idx + num_ffts).re = scratch[5].re + scratch[4].im;
+            data.get_unchecked_mut(idx + num_ffts).im = scratch[5].im - scratch[4].re;
+            data.get_unchecked_mut(idx + 3 * num_ffts).re = scratch[5].re - scratch[4].im;
+            data.get_unchecked_mut(idx + 3 * num_ffts).im = scratch[5].im + scratch[4].re;
         }
 
         tw_idx += 3;


### PR DESCRIPTION
This PR adds optimized DFTs for butterflies of lengths 3, 5 and 7. This replaces the hardcoded Raders that were used so far. The speedup is quite significant, see the attached file for the bench results.
The highlights are here:
```
name                           newmaster ns/iter  new357 ns/iter  diff ns/iter   diff %  speedup 
 complex_prime_00003            5                  4                         -1  -20.00%   x 1.25 
 complex_prime_00005            13                 9                         -4  -30.77%   x 1.44 
 complex_prime_00007            25                 13                       -12  -48.00%   x 1.92 
```
These are the "star" numbers. Longer FFTs with more steps don't get such a large speedup. The full list (almost, I disabled the slowest ones to save time): [butterflies.txt](https://github.com/ejmahler/RustFFT/files/5638885/butterflies.txt)
("newmaster" is the base, "new357" is with the proposed changes)