### PR TITLE
Make master more similar to simd?

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -13,7 +13,8 @@ pub trait FFTnum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static 
 }
 
 impl<T> FFTnum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {
-    default fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
+    //default fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
+	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
         let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
 		let angle = constant * index;
 
@@ -30,40 +31,40 @@ impl<T> FFTnum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debu
     }
 }
 
-impl FFTnum for f32 {
-	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
-		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
-		let angle = constant * index;
-
-	    let result = Complex {
-	    	re: angle.cos() as f32,
-	    	im: angle.sin() as f32,
-	    };
-
-	    if inverse {
-	    	result.conj()
-	    } else {
-	    	result
-	    }
-    }
-}
-impl FFTnum for f64 {
-	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
-		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
-		let angle = constant * index;
-
-	    let result = Complex {
-	    	re: angle.cos(),
-	    	im: angle.sin(),
-	    };
-
-	    if inverse {
-	    	result.conj()
-	    } else {
-	    	result
-	    }
-    }
-}
+//impl FFTnum for f32 {
+//	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
+//		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
+//		let angle = constant * index;
+//
+//	    let result = Complex {
+//	    	re: angle.cos() as f32,
+//	    	im: angle.sin() as f32,
+//	    };
+//
+//	    if inverse {
+//	    	result.conj()
+//	    } else {
+//	    	result
+//	    }
+//    }
+//}
+//impl FFTnum for f64 {
+//	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, inverse: bool) -> Complex<Self> {
+//		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
+//		let angle = constant * index;
+//
+//	    let result = Complex {
+//	    	re: angle.cos(),
+//	    	im: angle.sin(),
+//	    };
+//
+//	    if inverse {
+//	    	result.conj()
+//	    } else {
+//	    	result
+//	    }
+//    }
+//}
 
 macro_rules! boilerplate_fft_oop {
     ($struct_name:ident, $len_fn:expr) => (

--- a/src/common.rs
+++ b/src/common.rs
@@ -20,7 +20,7 @@ impl<T> FFTnum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debu
 
 	    let result = Complex {
 	    	re: Self::from_f64(angle.cos()).unwrap(),
-	    	im: Self::from_f64(angle.cos()).unwrap(),
+	    	im: Self::from_f64(angle.sin()).unwrap(),
 	    };
 
 	    if inverse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,9 @@
 //!
 //! Elements in the output are ordered by ascending frequency, with the first element corresponding to frequency 0.
 
-#![feature(min_specialization)]
-#![feature(maybe_uninit_extra)]
-#![feature(maybe_uninit_slice)]
+//#![feature(min_specialization)]
+//#![feature(maybe_uninit_extra)]
+//#![feature(maybe_uninit_slice)]
 
 
 pub use num_complex;
@@ -218,31 +218,31 @@ pub trait Fft<T: FFTnum>: Length + IsInverse + Sync + Send {
     fn get_out_of_place_scratch_len(&self) -> usize;
 }
 
-// Algorithms implemented to use AVX instructions. Only compiled on x86_64.
-#[cfg(target_arch="x86_64")]
-mod avx;
-
-// When we're not on avx, keep a stub implementation around that just does nothing
-#[cfg(not(target_arch="x86_64"))]
-mod avx{
-   pub mod avx_planner {
-        use crate::{Fft, FFTnum};
-        use std::sync::Arc;
-        pub struct FftPlannerAvx<T: FFTnum> {
-            _phantom: std::marker::PhantomData<T>,
-        }
-        impl<T: FFTnum> FftPlannerAvx<T> {
-            pub fn new(_inverse: bool) -> Result<Self, ()> {
-                Err(())
-            }
-            pub fn plan_fft(&mut self, _len: usize) -> Arc<dyn Fft<T>> {
-                unreachable!();
-            }
-        }
-    }
-}
-
-pub use self::avx::avx_planner::FftPlannerAvx;
+//// Algorithms implemented to use AVX instructions. Only compiled on x86_64.
+//#[cfg(target_arch="x86_64")]
+//mod avx;
+//
+//// When we're not on avx, keep a stub implementation around that just does nothing
+//#[cfg(not(target_arch="x86_64"))]
+//mod avx{
+//   pub mod avx_planner {
+//        use crate::{Fft, FFTnum};
+//        use std::sync::Arc;
+//        pub struct FftPlannerAvx<T: FFTnum> {
+//            _phantom: std::marker::PhantomData<T>,
+//        }
+//        impl<T: FFTnum> FftPlannerAvx<T> {
+//            pub fn new(_inverse: bool) -> Result<Self, ()> {
+//                Err(())
+//            }
+//            pub fn plan_fft(&mut self, _len: usize) -> Arc<dyn Fft<T>> {
+//                unreachable!();
+//            }
+//        }
+//    }
+//}
+//
+//pub use self::avx::avx_planner::FftPlannerAvx;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -8,7 +8,7 @@ use crate::Fft;
 use crate::algorithm::*;
 use crate::algorithm::butterflies::*;
 
-use crate::FftPlannerAvx;
+//use crate::FftPlannerAvx;
 
 use crate::math_utils::{ PrimeFactors, PrimeFactor };
 
@@ -50,7 +50,7 @@ pub struct FftPlanner<T: FFTnum> {
     inverse: bool,
 
     // None if this machine doesn't support avx
-    avx_planner: Option<FftPlannerAvx<T>>,
+    //avx_planner: Option<FftPlannerAvx<T>>,
 }
 
 impl<T: FFTnum> FftPlanner<T> {
@@ -62,7 +62,7 @@ impl<T: FFTnum> FftPlanner<T> {
             inverse: inverse,
             algorithm_cache: HashMap::new(),
 
-            avx_planner: FftPlannerAvx::new(inverse).ok()
+            //avx_planner: FftPlannerAvx::new(inverse).ok()
         }
     }
 
@@ -70,12 +70,13 @@ impl<T: FFTnum> FftPlanner<T> {
     ///
     /// If this is called multiple times, the planner will attempt to re-use internal data between calls, reducing memory usage and FFT initialization time.
     pub fn plan_fft(&mut self, len: usize) -> Arc<dyn Fft<T>> {
-        if let Some(avx_planner) = &mut self.avx_planner {
-            // If we have an AVX planner, defer to that for all construction needs
-            // TODO: eventually, "FftPlanner" could be an enum of different planner types? "ScalarPlanner" etc
-            // That way, we wouldn't need to waste memory storing the scalar planner's algorithm cache when we're not gonna use it
-            avx_planner.plan_fft(len)
-        } else if let Some(instance) = self.algorithm_cache.get(&len) {
+        //if let Some(avx_planner) = &mut self.avx_planner {
+        //    // If we have an AVX planner, defer to that for all construction needs
+        //    // TODO: eventually, "FftPlanner" could be an enum of different planner types? "ScalarPlanner" etc
+        //    // That way, we wouldn't need to waste memory storing the scalar planner's algorithm cache when we're not gonna use it
+        //    avx_planner.plan_fft(len)
+        //} else 
+        if let Some(instance) = self.algorithm_cache.get(&len) {
             Arc::clone(instance)
         } else {
             let instance = self.plan_new_fft_with_factors(len, PrimeFactors::compute(len));

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -33,7 +33,7 @@ mod unit_tests {
             let actual: Vec<Complex<f32>> = generate_twiddle_factors(len, false);
             let expected: Vec<Complex<f32>> = (0..len).map(|i| Complex::from_polar(1f32, constant * i as f32 / len as f32)).collect();
 
-            assert!(compare_vectors(&actual, &expected), "len = {}", len)
+            assert!(compare_vectors(&actual, &expected), "len = {}, actual {:?}, expected {:?}", len, actual, expected)
         }
 
         //for each len, verify that each element in the inverse is the conjugate of the non-inverse


### PR DESCRIPTION
I was thinking a bit and playing around a little. There is a slight annoyance now in that the future (simd) branch and the current master are quite different, with the new traits and all. So any improvement that is made to master must be modified later to fit into the future one. That was the background to this question: https://github.com/ejmahler/RustFFT/issues/16
How about we make master more similar to the simd branch? Then any improvements fit nicely into both the present and future versions. I could get "simd" to compile and run fine on stable rust by just commenting out the avx parts, and the specialization. This PR is just to show what I did (don't merge it!). 
One possible path:
1. Release 4.1 on current master. This is a very useful improvement over 4.0.
2. Merge the parts of simd that work on stable into master (including the new names Fft, FftPlanner etc)
3. Continue development of that, until it has improved enough for it to make sense to make a new release as 5.0. Depending on how things go with avx without specialization, 5.0 could then be with or without avx (with avx then pushed to 6.0, or maybe 5.1).

BTW note the small but important typo I fixed here: https://github.com/HEnquist/RustFFT/commit/9d305ce4514deebe7009c4ee504749162d0664dc