### PR TITLE
Rename FFTnum to FftNum to satisfy naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [4.1.0]
 Released 24 December 2020
 ### Added
-- Added a blanked impl of `FFTnum` to any type that implements the required traits (#7)
+- Added a blanked impl of `FftNum` to any type that implements the required traits (#7)
 - Added butterflies for many prime sizes, up to 31, and optimized the size-3, size-5, and size-7 buitterflies (#10)
 - Added an implementation of Bluestein's Algorithm (#6)
 

--- a/benches/bench_rustfft.rs
+++ b/benches/bench_rustfft.rs
@@ -6,7 +6,7 @@ extern crate rustfft;
 
 use std::sync::Arc;
 use test::Bencher;
-use rustfft::{Direction, FFTnum, Fft, FftDirection, Length};
+use rustfft::{Direction, FftNum, Fft, FftDirection, Length};
 use rustfft::num_complex::Complex;
 use rustfft::num_traits::Zero;
 use rustfft::algorithm::*;
@@ -16,7 +16,7 @@ struct Noop {
     len: usize,
     direction: FftDirection,
 }
-impl<T: FFTnum> Fft<T> for Noop {
+impl<T: FftNum> Fft<T> for Noop {
     fn process_with_scratch(&self, _input: &mut [Complex<T>], _output: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {}
     fn process_multi(&self, _input: &mut [Complex<T>], _output: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {}
     fn process_inplace_with_scratch(&self, _buffer: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {}

--- a/benches/compare_3n2m_strategies.rs
+++ b/benches/compare_3n2m_strategies.rs
@@ -10,7 +10,7 @@ use rustfft::algorithm::butterflies::*;
 use rustfft::algorithm::DFT;
 use rustfft::num_complex::Complex;
 use rustfft::num_traits::Zero;
-use rustfft::{FFTnum, Fft};
+use rustfft::{FftNum, Fft};
 use rustfft::{FftPlanner, FftPlannerAvx};
 
 use primal_check::miller_rabin;
@@ -488,7 +488,7 @@ fn generate_raders_benchmarks(_: &mut test::Bencher) {
     }
 }
 
-fn wrap_fft<T: FFTnum>(fft: impl Fft<T> + 'static) -> Arc<dyn Fft<T>> {
+fn wrap_fft<T: FftNum>(fft: impl Fft<T> + 'static) -> Arc<dyn Fft<T>> {
     Arc::new(fft) as Arc<dyn Fft<T>>
 }
 

--- a/benches/compare_3n2m_strategies.rs
+++ b/benches/compare_3n2m_strategies.rs
@@ -10,7 +10,7 @@ use rustfft::algorithm::butterflies::*;
 use rustfft::algorithm::DFT;
 use rustfft::num_complex::Complex;
 use rustfft::num_traits::Zero;
-use rustfft::{FftNum, Fft};
+use rustfft::{Fft, FftNum};
 use rustfft::{FftPlanner, FftPlannerAvx};
 
 use primal_check::miller_rabin;

--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::{common::FFTnum, FftDirection};
+use crate::{common::FftNum, FftDirection};
 
 use crate::{Direction, Fft, Length};
 
@@ -46,7 +46,7 @@ pub struct BluesteinsAlgorithm<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> BluesteinsAlgorithm<T> {
+impl<T: FftNum> BluesteinsAlgorithm<T> {
     fn compute_bluesteins_twiddle(
         index: usize,
         size: usize,

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex;
 
-use crate::{common::FFTnum, FftDirection};
+use crate::{common::FftNum, FftDirection};
 
 use crate::array_utils::{RawSlice, RawSliceMut};
 use crate::twiddles;
@@ -9,13 +9,13 @@ use crate::{Direction, Fft, Length};
 #[allow(unused)]
 macro_rules! boilerplate_fft_butterfly {
     ($struct_name:ident, $len:expr, $direction_fn:expr) => {
-        impl<T: FFTnum> $struct_name<T> {
+        impl<T: FftNum> $struct_name<T> {
             #[inline(always)]
             pub(crate) unsafe fn perform_fft_butterfly(&self, buffer: &mut [Complex<T>]) {
                 self.perform_fft_contiguous(RawSlice::new(buffer), RawSliceMut::new(buffer));
             }
         }
-        impl<T: FFTnum> Fft<T> for $struct_name<T> {
+        impl<T: FftNum> Fft<T> for $struct_name<T> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -133,7 +133,7 @@ pub struct Butterfly1<T> {
     direction: FftDirection,
     _phantom: std::marker::PhantomData<T>,
 }
-impl<T: FFTnum> Butterfly1<T> {
+impl<T: FftNum> Butterfly1<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -142,7 +142,7 @@ impl<T: FFTnum> Butterfly1<T> {
         }
     }
 }
-impl<T: FFTnum> Fft<T> for Butterfly1<T> {
+impl<T: FftNum> Fft<T> for Butterfly1<T> {
     fn process_with_scratch(
         &self,
         input: &mut [Complex<T>],
@@ -194,7 +194,7 @@ pub struct Butterfly2<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 boilerplate_fft_butterfly!(Butterfly2, 2, |this: &Butterfly2<_>| this.direction);
-impl<T: FFTnum> Butterfly2<T> {
+impl<T: FftNum> Butterfly2<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -227,7 +227,7 @@ pub struct Butterfly3<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly3, 3, |this: &Butterfly3<_>| this.direction);
-impl<T: FFTnum> Butterfly3<T> {
+impl<T: FftNum> Butterfly3<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -273,7 +273,7 @@ pub struct Butterfly4<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 boilerplate_fft_butterfly!(Butterfly4, 4, |this: &Butterfly4<_>| this.direction);
-impl<T: FFTnum> Butterfly4<T> {
+impl<T: FftNum> Butterfly4<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -323,7 +323,7 @@ pub struct Butterfly5<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly5, 5, |this: &Butterfly5<_>| this.direction);
-impl<T: FFTnum> Butterfly5<T> {
+impl<T: FftNum> Butterfly5<T> {
     pub fn new(direction: FftDirection) -> Self {
         Self {
             twiddle1: T::generate_twiddle_factor(1, 5, direction),
@@ -478,7 +478,7 @@ pub struct Butterfly6<T> {
 boilerplate_fft_butterfly!(Butterfly6, 6, |this: &Butterfly6<_>| this
     .butterfly3
     .fft_direction());
-impl<T: FFTnum> Butterfly6<T> {
+impl<T: FftNum> Butterfly6<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -537,7 +537,7 @@ pub struct Butterfly7<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly7, 7, |this: &Butterfly7<_>| this.direction);
-impl<T: FFTnum> Butterfly7<T> {
+impl<T: FftNum> Butterfly7<T> {
     pub fn new(direction: FftDirection) -> Self {
         Self {
             twiddle1: T::generate_twiddle_factor(1, 7, direction),
@@ -730,7 +730,7 @@ pub struct Butterfly8<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly8, 8, |this: &Butterfly8<_>| this.direction);
-impl<T: FFTnum> Butterfly8<T> {
+impl<T: FftNum> Butterfly8<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -789,7 +789,7 @@ pub struct Butterfly11<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly11, 11, |this: &Butterfly11<_>| this.direction);
-impl<T: FFTnum> Butterfly11<T> {
+impl<T: FftNum> Butterfly11<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 11, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 11, direction);
@@ -1043,7 +1043,7 @@ pub struct Butterfly13<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly13, 13, |this: &Butterfly13<_>| this.direction);
-impl<T: FFTnum> Butterfly13<T> {
+impl<T: FftNum> Butterfly13<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 13, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 13, direction);
@@ -1363,7 +1363,7 @@ pub struct Butterfly16<T> {
 boilerplate_fft_butterfly!(Butterfly16, 16, |this: &Butterfly16<_>| this
     .butterfly8
     .fft_direction());
-impl<T: FFTnum> Butterfly16<T> {
+impl<T: FftNum> Butterfly16<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
@@ -1457,7 +1457,7 @@ pub struct Butterfly17<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly17, 17, |this: &Butterfly17<_>| this.direction);
-impl<T: FFTnum> Butterfly17<T> {
+impl<T: FftNum> Butterfly17<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 17, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 17, direction);
@@ -1941,7 +1941,7 @@ pub struct Butterfly19<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly19, 19, |this: &Butterfly19<_>| this.direction);
-impl<T: FFTnum> Butterfly19<T> {
+impl<T: FftNum> Butterfly19<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 19, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 19, direction);
@@ -2520,7 +2520,7 @@ pub struct Butterfly23<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly23, 23, |this: &Butterfly23<_>| this.direction);
-impl<T: FFTnum> Butterfly23<T> {
+impl<T: FftNum> Butterfly23<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 23, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 23, direction);
@@ -3320,7 +3320,7 @@ pub struct Butterfly29<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly29, 29, |this: &Butterfly29<_>| this.direction);
-impl<T: FFTnum> Butterfly29<T> {
+impl<T: FftNum> Butterfly29<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 29, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 29, direction);
@@ -4495,7 +4495,7 @@ pub struct Butterfly31<T> {
     direction: FftDirection,
 }
 boilerplate_fft_butterfly!(Butterfly31, 31, |this: &Butterfly31<_>| this.direction);
-impl<T: FFTnum> Butterfly31<T> {
+impl<T: FftNum> Butterfly31<T> {
     pub fn new(direction: FftDirection) -> Self {
         let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 31, direction);
         let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 31, direction);
@@ -5800,7 +5800,7 @@ pub struct Butterfly32<T> {
 boilerplate_fft_butterfly!(Butterfly32, 32, |this: &Butterfly32<_>| this
     .butterfly8
     .fft_direction());
-impl<T: FFTnum> Butterfly32<T> {
+impl<T: FftNum> Butterfly32<T> {
     pub fn new(direction: FftDirection) -> Self {
         Self {
             butterfly16: Butterfly16::new(direction),

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -2,7 +2,7 @@ use num_complex::Complex;
 use num_traits::Zero;
 
 use crate::{twiddles, FftDirection};
-use crate::{Direction, FftNum, Fft, Length};
+use crate::{Direction, Fft, FftNum, Length};
 
 /// Naive O(n^2 ) Discrete Fourier Transform implementation
 ///

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -2,7 +2,7 @@ use num_complex::Complex;
 use num_traits::Zero;
 
 use crate::{twiddles, FftDirection};
-use crate::{Direction, FFTnum, Fft, Length};
+use crate::{Direction, FftNum, Fft, Length};
 
 /// Naive O(n^2 ) Discrete Fourier Transform implementation
 ///
@@ -28,7 +28,7 @@ pub struct DFT<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> DFT<T> {
+impl<T: FftNum> DFT<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute DFT
     pub fn new(len: usize, direction: FftDirection) -> Self {
         Self {

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -6,7 +6,7 @@ use num_integer::Integer;
 use strength_reduce::StrengthReducedUsize;
 use transpose;
 
-use crate::{common::FFTnum, FftDirection};
+use crate::{common::FftNum, FftDirection};
 
 use crate::array_utils;
 
@@ -57,7 +57,7 @@ pub struct GoodThomasAlgorithm<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> GoodThomasAlgorithm<T> {
+impl<T: FftNum> GoodThomasAlgorithm<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
     ///
     /// GCD(width_fft.len(), height_fft.len()) must be equal to 1
@@ -309,7 +309,7 @@ pub struct GoodThomasAlgorithmSmall<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> GoodThomasAlgorithmSmall<T> {
+impl<T: FftNum> GoodThomasAlgorithmSmall<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
     ///
     /// GCD(n1.len(), n2.len()) must be equal to 1

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use transpose;
 
-use crate::{common::FFTnum, FftDirection};
+use crate::{common::FftNum, FftDirection};
 
 use crate::array_utils;
 use crate::{Direction, Fft, Length};
@@ -49,7 +49,7 @@ pub struct MixedRadix<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> MixedRadix<T> {
+impl<T: FftNum> MixedRadix<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
     pub fn new(width_fft: Arc<dyn Fft<T>>, height_fft: Arc<dyn Fft<T>>) -> Self {
         assert_eq!(
@@ -225,7 +225,7 @@ pub struct MixedRadixSmall<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> MixedRadixSmall<T> {
+impl<T: FftNum> MixedRadixSmall<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `width_fft.len() * height_fft.len()`
     pub fn new(width_fft: Arc<dyn Fft<T>>, height_fft: Arc<dyn Fft<T>>) -> Self {
         assert_eq!(

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
-use crate::{common::FFTnum, FftDirection};
+use crate::{common::FftNum, FftDirection};
 
 use crate::math_utils;
 use crate::{Direction, Fft, Length};
@@ -54,7 +54,7 @@ pub struct RadersAlgorithm<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> RadersAlgorithm<T> {
+impl<T: FftNum> RadersAlgorithm<T> {
     /// Creates a FFT instance which will process inputs/outputs of size `len`. `inner_fft.len()` must be `len - 1`
     ///
     /// Note that this constructor is quite expensive to run; This algorithm must run a FFT of size n - 1 within the

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -5,7 +5,7 @@ use num_traits::Zero;
 
 use crate::{
     array_utils::{RawSlice, RawSliceMut},
-    common::FFTnum,
+    common::FftNum,
     FftDirection,
 };
 
@@ -38,7 +38,7 @@ pub struct Radix4<T> {
     direction: FftDirection,
 }
 
-impl<T: FFTnum> Radix4<T> {
+impl<T: FftNum> Radix4<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
     pub fn new(len: usize, direction: FftDirection) -> Self {
         assert!(
@@ -133,7 +133,7 @@ boilerplate_fft_oop!(Radix4, |this: &Radix4<_>| this.len);
 
 // after testing an iterative bit reversal algorithm, this recursive algorithm
 // was almost an order of magnitude faster at setting up
-fn prepare_radix4<T: FFTnum>(
+fn prepare_radix4<T: FftNum>(
     size: usize,
     base_len: usize,
     signal: &[Complex<T>],
@@ -159,7 +159,7 @@ fn prepare_radix4<T: FFTnum>(
     }
 }
 
-unsafe fn butterfly_4<T: FFTnum>(
+unsafe fn butterfly_4<T: FftNum>(
     data: &mut [Complex<T>],
     twiddles: &[Complex<T>],
     num_ffts: usize,

--- a/src/avx/avx32_butterflies.rs
+++ b/src/avx/avx32_butterflies.rs
@@ -4,7 +4,7 @@ use std::mem::MaybeUninit;
 
 use num_complex::Complex;
 
-use crate::common::FFTnum;
+use crate::common::FftNum;
 
 use crate::{Direction, Fft, FftDirection, Length};
 
@@ -36,7 +36,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
             }
         }
 
-        impl<T: FFTnum> Fft<T> for $struct_name<f32> {
+        impl<T: FftNum> Fft<T> for $struct_name<f32> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -181,7 +181,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                 }
             }
         }
-        impl<T: FFTnum> $struct_name<T> {
+        impl<T: FftNum> $struct_name<T> {
             #[inline]
             fn perform_fft_inplace(
                 &self,
@@ -212,7 +212,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                 unsafe { self.row_butterflies(RawSlice::new(output), RawSliceMut::new(output)) };
             }
         }
-        impl<T: FFTnum> Fft<T> for $struct_name<f32> {
+        impl<T: FftNum> Fft<T> for $struct_name<f32> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],

--- a/src/avx/avx64_butterflies.rs
+++ b/src/avx/avx64_butterflies.rs
@@ -4,7 +4,7 @@ use std::mem::MaybeUninit;
 
 use num_complex::Complex;
 
-use crate::common::FFTnum;
+use crate::common::FftNum;
 
 use crate::{Direction, Fft, FftDirection, Length};
 
@@ -34,7 +34,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
                 }
             }
         }
-        impl<T: FFTnum> Fft<T> for $struct_name<f64> {
+        impl<T: FftNum> Fft<T> for $struct_name<f64> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -212,7 +212,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                 unsafe { self.row_butterflies(RawSlice::new(output), RawSliceMut::new(output)) };
             }
         }
-        impl<T: FFTnum> Fft<T> for $struct_name<f64> {
+        impl<T: FftNum> Fft<T> for $struct_name<f64> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -6,7 +6,7 @@ use num_integer::div_ceil;
 use num_traits::Zero;
 
 use crate::{array_utils, FftDirection};
-use crate::{Direction, FftNum, Fft, Length};
+use crate::{Direction, Fft, FftNum, Length};
 
 use super::CommonSimdData;
 use super::{

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -6,7 +6,7 @@ use num_integer::div_ceil;
 use num_traits::Zero;
 
 use crate::{array_utils, FftDirection};
-use crate::{Direction, FFTnum, Fft, Length};
+use crate::{Direction, FftNum, Fft, Length};
 
 use super::CommonSimdData;
 use super::{
@@ -31,7 +31,7 @@ pub struct BluesteinsAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(BluesteinsAvx);
 
-impl<A: AvxNum, T: FFTnum> BluesteinsAvx<A, T> {
+impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
     fn compute_bluesteins_twiddle(index: usize, len: usize, direction: FftDirection) -> Complex<A> {
         let index_float = index as f64;
         let index_squared = index_float * index_float;

--- a/src/avx/avx_mixed_radix.rs
+++ b/src/avx/avx_mixed_radix.rs
@@ -5,7 +5,7 @@ use num_complex::Complex;
 use num_integer::div_ceil;
 
 use crate::array_utils;
-use crate::{Direction, FftNum, Fft, FftDirection, Length};
+use crate::{Direction, Fft, FftDirection, FftNum, Length};
 
 use super::{AvxNum, CommonSimdData};
 

--- a/src/avx/avx_mixed_radix.rs
+++ b/src/avx/avx_mixed_radix.rs
@@ -5,7 +5,7 @@ use num_complex::Complex;
 use num_integer::div_ceil;
 
 use crate::array_utils;
-use crate::{Direction, FFTnum, Fft, FftDirection, Length};
+use crate::{Direction, FftNum, Fft, FftDirection, Length};
 
 use super::{AvxNum, CommonSimdData};
 
@@ -381,7 +381,7 @@ pub struct MixedRadix2xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix2xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix2xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix2xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -409,7 +409,7 @@ pub struct MixedRadix3xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix3xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix3xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix3xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -438,7 +438,7 @@ pub struct MixedRadix4xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix4xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix4xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix4xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -467,7 +467,7 @@ pub struct MixedRadix5xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix5xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix5xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix5xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -505,7 +505,7 @@ pub struct MixedRadix6xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix6xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix6xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix6xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -534,7 +534,7 @@ pub struct MixedRadix7xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix7xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix7xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix7xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -574,7 +574,7 @@ pub struct MixedRadix8xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix8xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix8xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix8xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -606,7 +606,7 @@ pub struct MixedRadix9xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix9xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix9xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix9xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         let inverse = inner_fft.fft_direction();
@@ -659,7 +659,7 @@ pub struct MixedRadix11xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix11xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix11xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix11xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         Self {
@@ -704,7 +704,7 @@ pub struct MixedRadix12xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix12xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix12xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix12xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         let inverse = inner_fft.fft_direction();
@@ -745,7 +745,7 @@ pub struct MixedRadix16xnAvx<A: AvxNum, T> {
 }
 boilerplate_avx_fft_commondata!(MixedRadix16xnAvx);
 
-impl<A: AvxNum, T: FFTnum> MixedRadix16xnAvx<A, T> {
+impl<A: AvxNum, T: FftNum> MixedRadix16xnAvx<A, T> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
         let inverse = inner_fft.fft_direction();

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -10,7 +10,7 @@ use strength_reduce::StrengthReducedUsize;
 
 use crate::math_utils;
 use crate::{array_utils, FftDirection};
-use crate::{Direction, FFTnum, Fft, Length};
+use crate::{Direction, FftNum, Fft, Length};
 
 use super::avx_vector;
 use super::{
@@ -111,7 +111,7 @@ pub struct RadersAvx2<A: AvxNum, T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<A: AvxNum, T: FFTnum> RadersAvx2<A, T> {
+impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the FFT
     /// Returns Ok(instance) if this machine has the required instruction sets ("avx", "fma", and "avx2"), Err() if some instruction sets are missing
     ///

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -10,7 +10,7 @@ use strength_reduce::StrengthReducedUsize;
 
 use crate::math_utils;
 use crate::{array_utils, FftDirection};
-use crate::{Direction, FftNum, Fft, Length};
+use crate::{Direction, Fft, FftNum, Length};
 
 use super::avx_vector;
 use super::{

--- a/src/avx/avx_vector.rs
+++ b/src/avx/avx_vector.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::common::FFTnum;
+use crate::common::FftNum;
 use crate::{
     array_utils::{RawSlice, RawSliceMut},
     FftDirection,

--- a/src/avx/mod.rs
+++ b/src/avx/mod.rs
@@ -1,8 +1,8 @@
-use crate::{FFTnum, Fft, FftDirection};
+use crate::{FftNum, Fft, FftDirection};
 use std::arch::x86_64::{__m256, __m256d};
 use std::sync::Arc;
 
-pub trait AvxNum: FFTnum {
+pub trait AvxNum: FftNum {
     type VectorType: AvxVector256<ScalarType = Self>;
 }
 
@@ -29,7 +29,7 @@ struct CommonSimdData<T, V> {
 
 macro_rules! boilerplate_avx_fft {
     ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr) => {
-        impl<A: AvxNum, T: FFTnum> Fft<T> for $struct_name<A, T> {
+        impl<A: AvxNum, T: FftNum> Fft<T> for $struct_name<A, T> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -174,7 +174,7 @@ macro_rules! boilerplate_avx_fft {
 
 macro_rules! boilerplate_avx_fft_commondata {
     ($struct_name:ident) => {
-        impl<A: AvxNum, T: FFTnum> Fft<T> for $struct_name<A, T> {
+        impl<A: AvxNum, T: FftNum> Fft<T> for $struct_name<A, T> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],

--- a/src/avx/mod.rs
+++ b/src/avx/mod.rs
@@ -1,4 +1,4 @@
-use crate::{FftNum, Fft, FftDirection};
+use crate::{Fft, FftDirection, FftNum};
 use std::arch::x86_64::{__m256, __m256d};
 use std::sync::Arc;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,7 @@ use num_complex::Complex;
 use crate::FftDirection;
 
 /// Generic floating point number, implemented for f32 and f64
-pub trait FFTnum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {
+pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {
     // two related methodsfor generating twiddle factors. The first is a convenience wrapper around the second.
     fn generate_twiddle_factor(
         index: usize,
@@ -22,7 +22,7 @@ pub trait FFTnum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static 
     ) -> Complex<Self>;
 }
 
-impl<T> FFTnum for T
+impl<T> FftNum for T
 where
     T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static,
 {
@@ -46,7 +46,7 @@ where
     }
 }
 
-// impl FFTnum for f32 {
+// impl FftNum for f32 {
 // 	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, direction: FftDirection) -> Complex<Self> {
 // 		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
 // 		let angle = constant * index;
@@ -63,7 +63,7 @@ where
 // 	    }
 //     }
 // }
-// impl FFTnum for f64 {
+// impl FftNum for f64 {
 // 	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, direction: FftDirection) -> Complex<Self> {
 // 		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
 // 		let angle = constant * index;
@@ -83,7 +83,7 @@ where
 
 macro_rules! boilerplate_fft_oop {
     ($struct_name:ident, $len_fn:expr) => {
-        impl<T: FFTnum> Fft<T> for $struct_name<T> {
+        impl<T: FftNum> Fft<T> for $struct_name<T> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -230,7 +230,7 @@ macro_rules! boilerplate_fft_oop {
 
 macro_rules! boilerplate_fft {
     ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr) => {
-        impl<T: FFTnum> Fft<T> for $struct_name<T> {
+        impl<T: FftNum> Fft<T> for $struct_name<T> {
             fn process_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -358,13 +358,13 @@ macro_rules! boilerplate_fft {
                 $out_of_place_scratch_len_fn(self)
             }
         }
-        impl<T: FFTnum> Length for $struct_name<T> {
+        impl<T: FftNum> Length for $struct_name<T> {
             #[inline(always)]
             fn len(&self) -> usize {
                 $len_fn(self)
             }
         }
-        impl<T: FFTnum> Direction for $struct_name<T> {
+        impl<T: FftNum> Direction for $struct_name<T> {
             #[inline(always)]
             fn fft_direction(&self) -> FftDirection {
                 self.direction

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod twiddles;
 use num_complex::Complex;
 use num_traits::Zero;
 
-pub use crate::common::FFTnum;
+pub use crate::common::FftNum;
 pub use crate::plan::{FftPlanner, FftPlannerScalar};
 
 /// A trait that allows FFT algorithms to report their expected input/output size
@@ -114,7 +114,7 @@ pub trait Direction {
 ///
 /// Both methods may need to allocate additional scratch space. If you'd like re-use that allocation across multiple FFT computations, call
 /// `process_inplace_with_scratch` or `process_with_scratch`, respectively.
-pub trait Fft<T: FFTnum>: Length + Direction + Sync + Send {
+pub trait Fft<T: FftNum>: Length + Direction + Sync + Send {
     /// Computes a FFT.
     ///
     /// Convenience method that allocates the required scratch space and and calls `self.process_with_scratch`.
@@ -226,12 +226,12 @@ mod avx;
 #[cfg(not(target_arch = "x86_64"))]
 mod avx {
     pub mod avx_planner {
-        use crate::{FFTnum, Fft};
+        use crate::{FftNum, Fft};
         use std::sync::Arc;
-        pub struct FftPlannerAvx<T: FFTnum> {
+        pub struct FftPlannerAvx<T: FftNum> {
             _phantom: std::marker::PhantomData<T>,
         }
-        impl<T: FFTnum> FftPlannerAvx<T> {
+        impl<T: FftNum> FftPlannerAvx<T> {
             pub fn new(_direction: FftDirection) -> Result<Self, ()> {
                 Err(())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ mod avx;
 #[cfg(not(target_arch = "x86_64"))]
 mod avx {
     pub mod avx_planner {
-        use crate::{FftNum, Fft};
+        use crate::{Fft, FftNum};
         use std::sync::Arc;
         pub struct FftPlannerAvx<T: FftNum> {
             _phantom: std::marker::PhantomData<T>,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::{common::FFTnum, fft_cache::FftCache, FftDirection};
+use crate::{common::FftNum, fft_cache::FftCache, FftDirection};
 
 use crate::algorithm::butterflies::*;
 use crate::algorithm::*;
@@ -41,11 +41,11 @@ use crate::math_utils::{PrimeFactor, PrimeFactors};
 ///
 /// Each FFT instance owns [`Arc`s](std::sync::Arc) to its internal data, rather than borrowing it from the planner, so it's perfectly
 /// safe to drop the planner after creating Fft instances.
-pub enum FftPlanner<T: FFTnum> {
+pub enum FftPlanner<T: FftNum> {
     Scalar(FftPlannerScalar<T>),
     Avx(FftPlannerAvx<T>),
 }
-impl<T: FFTnum> FftPlanner<T> {
+impl<T: FftNum> FftPlanner<T> {
     /// Creates a new `FftPlanner` instance. It detects if AVX is supported on the current machine. If it is, it will plan AVX-accelerated FFTs.
     /// If AVX isn't supported, it will seamlessly fall back to planning non-SIMD FFTs.
     pub fn new() -> Self {
@@ -207,12 +207,12 @@ impl Recipe {
 ///
 /// Each FFT instance owns [`Arc`s](std::sync::Arc) to its internal data, rather than borrowing it from the planner, so it's perfectly
 /// safe to drop the planner after creating Fft instances.
-pub struct FftPlannerScalar<T: FFTnum> {
+pub struct FftPlannerScalar<T: FftNum> {
     algorithm_cache: FftCache<T>,
     recipe_cache: HashMap<usize, Rc<Recipe>>,
 }
 
-impl<T: FFTnum> FftPlannerScalar<T> {
+impl<T: FftNum> FftPlannerScalar<T> {
     /// Creates a new `FftPlannerScalar` instance.
     pub fn new() -> Self {
         Self {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -4,7 +4,7 @@ use num_traits::{Float, One, Zero};
 use rand::distributions::{uniform::SampleUniform, Distribution, Uniform};
 use rand::{rngs::StdRng, SeedableRng};
 
-use crate::{algorithm::DFT, FFTnum};
+use crate::{algorithm::DFT, FftNum};
 use crate::{Fft, FftDirection};
 
 /// The seed for the random number generator used to generate
@@ -14,7 +14,7 @@ const RNG_SEED: [u8; 32] = [
     1, 9, 1, 0, 1, 1, 4, 3, 1, 4, 9, 8, 4, 1, 4, 8, 2, 8, 1, 2, 2, 2, 6, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 ];
 
-pub fn random_signal<T: FFTnum + SampleUniform>(length: usize) -> Vec<Complex<T>> {
+pub fn random_signal<T: FftNum + SampleUniform>(length: usize) -> Vec<Complex<T>> {
     let mut sig = Vec::with_capacity(length);
     let normal_dist: Uniform<T> = Uniform::new(T::zero(), T::from_f32(10.0).unwrap());
     let mut rng: StdRng = SeedableRng::from_seed(RNG_SEED);
@@ -27,7 +27,7 @@ pub fn random_signal<T: FFTnum + SampleUniform>(length: usize) -> Vec<Complex<T>
     return sig;
 }
 
-pub fn compare_vectors<T: FFTnum + Float>(vec1: &[Complex<T>], vec2: &[Complex<T>]) -> bool {
+pub fn compare_vectors<T: FftNum + Float>(vec1: &[Complex<T>], vec2: &[Complex<T>]) -> bool {
     assert_eq!(vec1.len(), vec2.len());
     let mut error = T::zero();
     for (&a, &b) in vec1.iter().zip(vec2.iter()) {
@@ -37,7 +37,7 @@ pub fn compare_vectors<T: FFTnum + Float>(vec1: &[Complex<T>], vec2: &[Complex<T
 }
 
 #[allow(unused)]
-fn transppose_diagnostic<T: FFTnum + Float>(expected: &[Complex<T>], actual: &[Complex<T>]) {
+fn transppose_diagnostic<T: FftNum + Float>(expected: &[Complex<T>], actual: &[Complex<T>]) {
     for (i, (&e, &a)) in expected.iter().zip(actual.iter()).enumerate() {
         if (e - a).norm().to_f32().unwrap() > 0.01 {
             if let Some(found_index) = expected
@@ -52,7 +52,7 @@ fn transppose_diagnostic<T: FFTnum + Float>(expected: &[Complex<T>], actual: &[C
     }
 }
 
-pub fn check_fft_algorithm<T: FFTnum + Float + SampleUniform>(
+pub fn check_fft_algorithm<T: FftNum + Float + SampleUniform>(
     fft: &dyn Fft<T>,
     len: usize,
     direction: FftDirection,

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -1,7 +1,7 @@
-use crate::{common::FFTnum, FftDirection};
+use crate::{common::FftNum, FftDirection};
 use num_complex::Complex;
 
-pub fn generate_twiddle_factors<T: FFTnum>(
+pub fn generate_twiddle_factors<T: FftNum>(
     fft_len: usize,
     direction: FftDirection,
 ) -> Vec<Complex<T>> {
@@ -10,7 +10,7 @@ pub fn generate_twiddle_factors<T: FFTnum>(
         .collect()
 }
 
-pub fn rotate_90<T: FFTnum>(value: Complex<T>, direction: FftDirection) -> Complex<T> {
+pub fn rotate_90<T: FftNum>(value: Complex<T>, direction: FftDirection) -> Complex<T> {
     match direction {
         FftDirection::Forward => Complex {
             re: value.im,

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -10,7 +10,7 @@ use num_traits::Float;
 use rustfft::{
     algorithm::{BluesteinsAlgorithm, Radix4},
     num_complex::Complex,
-    FftNum, Fft, FftPlanner,
+    Fft, FftNum, FftPlanner,
 };
 use rustfft::{num_traits::Zero, FftDirection};
 

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -10,7 +10,7 @@ use num_traits::Float;
 use rustfft::{
     algorithm::{BluesteinsAlgorithm, Radix4},
     num_complex::Complex,
-    FFTnum, Fft, FftPlanner,
+    FftNum, Fft, FftPlanner,
 };
 use rustfft::{num_traits::Zero, FftDirection};
 
@@ -26,7 +26,7 @@ const RNG_SEED: [u8; 32] = [
 
 /// Returns true if the mean difference in the elements of the two vectors
 /// is small
-fn compare_vectors<T: rustfft::FFTnum + Float>(vec1: &[Complex<T>], vec2: &[Complex<T>]) -> bool {
+fn compare_vectors<T: rustfft::FftNum + Float>(vec1: &[Complex<T>], vec2: &[Complex<T>]) -> bool {
     assert_eq!(vec1.len(), vec2.len());
     let mut error = T::zero();
     for (&a, &b) in vec1.iter().zip(vec2.iter()) {
@@ -35,7 +35,7 @@ fn compare_vectors<T: rustfft::FFTnum + Float>(vec1: &[Complex<T>], vec2: &[Comp
     return (error / T::from_usize(vec1.len()).unwrap()) < T::from_f32(0.1).unwrap();
 }
 
-fn fft_matches_control<T: FFTnum + Float>(control: Arc<dyn Fft<T>>, input: &[Complex<T>]) -> bool {
+fn fft_matches_control<T: FftNum + Float>(control: Arc<dyn Fft<T>>, input: &[Complex<T>]) -> bool {
     let mut control_input = input.to_vec();
     let mut test_input = input.to_vec();
 
@@ -61,7 +61,7 @@ fn fft_matches_control<T: FFTnum + Float>(control: Arc<dyn Fft<T>>, input: &[Com
     return compare_vectors(&test_output, &control_output);
 }
 
-fn random_signal<T: FFTnum + SampleUniform>(length: usize) -> Vec<Complex<T>> {
+fn random_signal<T: FftNum + SampleUniform>(length: usize) -> Vec<Complex<T>> {
     let mut sig = Vec::with_capacity(length);
     let dist: Uniform<T> = Uniform::new(T::zero(), T::from_f64(10.0).unwrap());
     let mut rng: StdRng = SeedableRng::from_seed(RNG_SEED);
@@ -75,10 +75,10 @@ fn random_signal<T: FFTnum + SampleUniform>(length: usize) -> Vec<Complex<T>> {
 }
 
 // A cache that makes setup for integration tests faster
-struct ControlCache<T: FFTnum> {
+struct ControlCache<T: FftNum> {
     fft_cache: Vec<Arc<dyn Fft<T>>>,
 }
-impl<T: FFTnum> ControlCache<T> {
+impl<T: FftNum> ControlCache<T> {
     pub fn new(max_outer_len: usize, direction: FftDirection) -> Self {
         let max_inner_len = (max_outer_len * 2 - 1).checked_next_power_of_two().unwrap();
         let max_power = max_inner_len.trailing_zeros() as usize;


### PR DESCRIPTION
https://rust-lang.github.io/api-guidelines/naming.html

> In UpperCamelCase, acronyms and contractions of compound words count as one word: use Uuid rather than UUID
