### PR TITLE
Removed twiddle factors from public API

### DIFF
--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::{common::FftNum, FftDirection};
+use crate::{FftDirection, common::FftNum, twiddles};
 
 use crate::{Direction, Fft, Length};
 
@@ -47,26 +47,11 @@ pub struct BluesteinsAlgorithm<T> {
 }
 
 impl<T: FftNum> BluesteinsAlgorithm<T> {
-    fn compute_bluesteins_twiddle(
-        index: usize,
-        size: usize,
-        direction: FftDirection,
-    ) -> Complex<T> {
-        let index_multiplier = core::f64::consts::PI / size as f64;
-
+    fn compute_bluesteins_twiddle(index: usize, len: usize, direction: FftDirection) -> Complex<T> {
         let index_float = index as f64;
         let index_squared = index_float * index_float;
 
-        let theta = index_squared * index_multiplier;
-        let result = Complex::new(
-            T::from_f64(theta.cos()).unwrap(),
-            T::from_f64(theta.sin()).unwrap(),
-        );
-
-        match direction {
-            FftDirection::Forward => result,
-            FftDirection::Inverse => result.conj(),
-        }
+        twiddles::compute_twiddle_floatindex(index_squared, len * 2, direction.reverse())
     }
 
     /// Creates a FFT instance which will process inputs/outputs of size `len`. `inner_fft.len()` must be >= `len * 2 - 1`

--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::{FftDirection, common::FftNum, twiddles};
+use crate::{common::FftNum, twiddles, FftDirection};
 
 use crate::{Direction, Fft, Length};
 

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -231,7 +231,7 @@ impl<T: FftNum> Butterfly3<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
-            twiddle: T::generate_twiddle_factor(1, 3, direction),
+            twiddle: twiddles::compute_twiddle(1, 3, direction),
             direction,
         }
     }
@@ -326,8 +326,8 @@ boilerplate_fft_butterfly!(Butterfly5, 5, |this: &Butterfly5<_>| this.direction)
 impl<T: FftNum> Butterfly5<T> {
     pub fn new(direction: FftDirection) -> Self {
         Self {
-            twiddle1: T::generate_twiddle_factor(1, 5, direction),
-            twiddle2: T::generate_twiddle_factor(2, 5, direction),
+            twiddle1: twiddles::compute_twiddle(1, 5, direction),
+            twiddle2: twiddles::compute_twiddle(2, 5, direction),
             direction,
         }
     }
@@ -540,9 +540,9 @@ boilerplate_fft_butterfly!(Butterfly7, 7, |this: &Butterfly7<_>| this.direction)
 impl<T: FftNum> Butterfly7<T> {
     pub fn new(direction: FftDirection) -> Self {
         Self {
-            twiddle1: T::generate_twiddle_factor(1, 7, direction),
-            twiddle2: T::generate_twiddle_factor(2, 7, direction),
-            twiddle3: T::generate_twiddle_factor(3, 7, direction),
+            twiddle1: twiddles::compute_twiddle(1, 7, direction),
+            twiddle2: twiddles::compute_twiddle(2, 7, direction),
+            twiddle3: twiddles::compute_twiddle(3, 7, direction),
             direction,
         }
     }
@@ -791,11 +791,11 @@ pub struct Butterfly11<T> {
 boilerplate_fft_butterfly!(Butterfly11, 11, |this: &Butterfly11<_>| this.direction);
 impl<T: FftNum> Butterfly11<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 11, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 11, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 11, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 11, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 11, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 11, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 11, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 11, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 11, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 11, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -1045,12 +1045,12 @@ pub struct Butterfly13<T> {
 boilerplate_fft_butterfly!(Butterfly13, 13, |this: &Butterfly13<_>| this.direction);
 impl<T: FftNum> Butterfly13<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 13, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 13, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 13, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 13, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 13, direction);
-        let twiddle6: Complex<T> = T::generate_twiddle_factor(6, 13, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 13, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 13, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 13, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 13, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 13, direction);
+        let twiddle6: Complex<T> = twiddles::compute_twiddle(6, 13, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -1368,9 +1368,9 @@ impl<T: FftNum> Butterfly16<T> {
     pub fn new(direction: FftDirection) -> Self {
         Self {
             butterfly8: Butterfly8::new(direction),
-            twiddle1: T::generate_twiddle_factor(1, 16, direction),
-            twiddle2: T::generate_twiddle_factor(2, 16, direction),
-            twiddle3: T::generate_twiddle_factor(3, 16, direction),
+            twiddle1: twiddles::compute_twiddle(1, 16, direction),
+            twiddle2: twiddles::compute_twiddle(2, 16, direction),
+            twiddle3: twiddles::compute_twiddle(3, 16, direction),
         }
     }
 
@@ -1459,14 +1459,14 @@ pub struct Butterfly17<T> {
 boilerplate_fft_butterfly!(Butterfly17, 17, |this: &Butterfly17<_>| this.direction);
 impl<T: FftNum> Butterfly17<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 17, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 17, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 17, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 17, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 17, direction);
-        let twiddle6: Complex<T> = T::generate_twiddle_factor(6, 17, direction);
-        let twiddle7: Complex<T> = T::generate_twiddle_factor(7, 17, direction);
-        let twiddle8: Complex<T> = T::generate_twiddle_factor(8, 17, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 17, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 17, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 17, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 17, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 17, direction);
+        let twiddle6: Complex<T> = twiddles::compute_twiddle(6, 17, direction);
+        let twiddle7: Complex<T> = twiddles::compute_twiddle(7, 17, direction);
+        let twiddle8: Complex<T> = twiddles::compute_twiddle(8, 17, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -1943,15 +1943,15 @@ pub struct Butterfly19<T> {
 boilerplate_fft_butterfly!(Butterfly19, 19, |this: &Butterfly19<_>| this.direction);
 impl<T: FftNum> Butterfly19<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 19, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 19, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 19, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 19, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 19, direction);
-        let twiddle6: Complex<T> = T::generate_twiddle_factor(6, 19, direction);
-        let twiddle7: Complex<T> = T::generate_twiddle_factor(7, 19, direction);
-        let twiddle8: Complex<T> = T::generate_twiddle_factor(8, 19, direction);
-        let twiddle9: Complex<T> = T::generate_twiddle_factor(9, 19, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 19, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 19, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 19, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 19, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 19, direction);
+        let twiddle6: Complex<T> = twiddles::compute_twiddle(6, 19, direction);
+        let twiddle7: Complex<T> = twiddles::compute_twiddle(7, 19, direction);
+        let twiddle8: Complex<T> = twiddles::compute_twiddle(8, 19, direction);
+        let twiddle9: Complex<T> = twiddles::compute_twiddle(9, 19, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -2522,17 +2522,17 @@ pub struct Butterfly23<T> {
 boilerplate_fft_butterfly!(Butterfly23, 23, |this: &Butterfly23<_>| this.direction);
 impl<T: FftNum> Butterfly23<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 23, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 23, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 23, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 23, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 23, direction);
-        let twiddle6: Complex<T> = T::generate_twiddle_factor(6, 23, direction);
-        let twiddle7: Complex<T> = T::generate_twiddle_factor(7, 23, direction);
-        let twiddle8: Complex<T> = T::generate_twiddle_factor(8, 23, direction);
-        let twiddle9: Complex<T> = T::generate_twiddle_factor(9, 23, direction);
-        let twiddle10: Complex<T> = T::generate_twiddle_factor(10, 23, direction);
-        let twiddle11: Complex<T> = T::generate_twiddle_factor(11, 23, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 23, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 23, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 23, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 23, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 23, direction);
+        let twiddle6: Complex<T> = twiddles::compute_twiddle(6, 23, direction);
+        let twiddle7: Complex<T> = twiddles::compute_twiddle(7, 23, direction);
+        let twiddle8: Complex<T> = twiddles::compute_twiddle(8, 23, direction);
+        let twiddle9: Complex<T> = twiddles::compute_twiddle(9, 23, direction);
+        let twiddle10: Complex<T> = twiddles::compute_twiddle(10, 23, direction);
+        let twiddle11: Complex<T> = twiddles::compute_twiddle(11, 23, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -3322,20 +3322,20 @@ pub struct Butterfly29<T> {
 boilerplate_fft_butterfly!(Butterfly29, 29, |this: &Butterfly29<_>| this.direction);
 impl<T: FftNum> Butterfly29<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 29, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 29, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 29, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 29, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 29, direction);
-        let twiddle6: Complex<T> = T::generate_twiddle_factor(6, 29, direction);
-        let twiddle7: Complex<T> = T::generate_twiddle_factor(7, 29, direction);
-        let twiddle8: Complex<T> = T::generate_twiddle_factor(8, 29, direction);
-        let twiddle9: Complex<T> = T::generate_twiddle_factor(9, 29, direction);
-        let twiddle10: Complex<T> = T::generate_twiddle_factor(10, 29, direction);
-        let twiddle11: Complex<T> = T::generate_twiddle_factor(11, 29, direction);
-        let twiddle12: Complex<T> = T::generate_twiddle_factor(12, 29, direction);
-        let twiddle13: Complex<T> = T::generate_twiddle_factor(13, 29, direction);
-        let twiddle14: Complex<T> = T::generate_twiddle_factor(14, 29, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 29, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 29, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 29, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 29, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 29, direction);
+        let twiddle6: Complex<T> = twiddles::compute_twiddle(6, 29, direction);
+        let twiddle7: Complex<T> = twiddles::compute_twiddle(7, 29, direction);
+        let twiddle8: Complex<T> = twiddles::compute_twiddle(8, 29, direction);
+        let twiddle9: Complex<T> = twiddles::compute_twiddle(9, 29, direction);
+        let twiddle10: Complex<T> = twiddles::compute_twiddle(10, 29, direction);
+        let twiddle11: Complex<T> = twiddles::compute_twiddle(11, 29, direction);
+        let twiddle12: Complex<T> = twiddles::compute_twiddle(12, 29, direction);
+        let twiddle13: Complex<T> = twiddles::compute_twiddle(13, 29, direction);
+        let twiddle14: Complex<T> = twiddles::compute_twiddle(14, 29, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -4497,21 +4497,21 @@ pub struct Butterfly31<T> {
 boilerplate_fft_butterfly!(Butterfly31, 31, |this: &Butterfly31<_>| this.direction);
 impl<T: FftNum> Butterfly31<T> {
     pub fn new(direction: FftDirection) -> Self {
-        let twiddle1: Complex<T> = T::generate_twiddle_factor(1, 31, direction);
-        let twiddle2: Complex<T> = T::generate_twiddle_factor(2, 31, direction);
-        let twiddle3: Complex<T> = T::generate_twiddle_factor(3, 31, direction);
-        let twiddle4: Complex<T> = T::generate_twiddle_factor(4, 31, direction);
-        let twiddle5: Complex<T> = T::generate_twiddle_factor(5, 31, direction);
-        let twiddle6: Complex<T> = T::generate_twiddle_factor(6, 31, direction);
-        let twiddle7: Complex<T> = T::generate_twiddle_factor(7, 31, direction);
-        let twiddle8: Complex<T> = T::generate_twiddle_factor(8, 31, direction);
-        let twiddle9: Complex<T> = T::generate_twiddle_factor(9, 31, direction);
-        let twiddle10: Complex<T> = T::generate_twiddle_factor(10, 31, direction);
-        let twiddle11: Complex<T> = T::generate_twiddle_factor(11, 31, direction);
-        let twiddle12: Complex<T> = T::generate_twiddle_factor(12, 31, direction);
-        let twiddle13: Complex<T> = T::generate_twiddle_factor(13, 31, direction);
-        let twiddle14: Complex<T> = T::generate_twiddle_factor(14, 31, direction);
-        let twiddle15: Complex<T> = T::generate_twiddle_factor(15, 31, direction);
+        let twiddle1: Complex<T> = twiddles::compute_twiddle(1, 31, direction);
+        let twiddle2: Complex<T> = twiddles::compute_twiddle(2, 31, direction);
+        let twiddle3: Complex<T> = twiddles::compute_twiddle(3, 31, direction);
+        let twiddle4: Complex<T> = twiddles::compute_twiddle(4, 31, direction);
+        let twiddle5: Complex<T> = twiddles::compute_twiddle(5, 31, direction);
+        let twiddle6: Complex<T> = twiddles::compute_twiddle(6, 31, direction);
+        let twiddle7: Complex<T> = twiddles::compute_twiddle(7, 31, direction);
+        let twiddle8: Complex<T> = twiddles::compute_twiddle(8, 31, direction);
+        let twiddle9: Complex<T> = twiddles::compute_twiddle(9, 31, direction);
+        let twiddle10: Complex<T> = twiddles::compute_twiddle(10, 31, direction);
+        let twiddle11: Complex<T> = twiddles::compute_twiddle(11, 31, direction);
+        let twiddle12: Complex<T> = twiddles::compute_twiddle(12, 31, direction);
+        let twiddle13: Complex<T> = twiddles::compute_twiddle(13, 31, direction);
+        let twiddle14: Complex<T> = twiddles::compute_twiddle(14, 31, direction);
+        let twiddle15: Complex<T> = twiddles::compute_twiddle(15, 31, direction);
         Self {
             twiddle1,
             twiddle2,
@@ -5806,13 +5806,13 @@ impl<T: FftNum> Butterfly32<T> {
             butterfly16: Butterfly16::new(direction),
             butterfly8: Butterfly8::new(direction),
             twiddles: [
-                T::generate_twiddle_factor(1, 32, direction),
-                T::generate_twiddle_factor(2, 32, direction),
-                T::generate_twiddle_factor(3, 32, direction),
-                T::generate_twiddle_factor(4, 32, direction),
-                T::generate_twiddle_factor(5, 32, direction),
-                T::generate_twiddle_factor(6, 32, direction),
-                T::generate_twiddle_factor(7, 32, direction),
+                twiddles::compute_twiddle(1, 32, direction),
+                twiddles::compute_twiddle(2, 32, direction),
+                twiddles::compute_twiddle(3, 32, direction),
+                twiddles::compute_twiddle(4, 32, direction),
+                twiddles::compute_twiddle(5, 32, direction),
+                twiddles::compute_twiddle(6, 32, direction),
+                twiddles::compute_twiddle(7, 32, direction),
             ],
         }
     }

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -31,8 +31,11 @@ pub struct DFT<T> {
 impl<T: FftNum> DFT<T> {
     /// Preallocates necessary arrays and precomputes necessary data to efficiently compute DFT
     pub fn new(len: usize, direction: FftDirection) -> Self {
+        let twiddles = (0..len)
+            .map(|i| twiddles::compute_twiddle(i, len, direction))
+            .collect();
         Self {
-            twiddles: twiddles::generate_twiddle_factors(len, direction),
+            twiddles,
             direction,
         }
     }

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use transpose;
 
-use crate::{FftDirection, common::FftNum, twiddles};
+use crate::{common::FftNum, twiddles, FftDirection};
 
 use crate::array_utils;
 use crate::{Direction, Fft, Length};

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use transpose;
 
-use crate::{common::FftNum, FftDirection};
+use crate::{FftDirection, common::FftNum, twiddles};
 
 use crate::array_utils;
 use crate::{Direction, Fft, Length};
@@ -67,7 +67,7 @@ impl<T: FftNum> MixedRadix<T> {
         let mut twiddles = Vec::with_capacity(len);
         for x in 0..width {
             for y in 0..height {
-                twiddles.push(T::generate_twiddle_factor(x * y, len, direction));
+                twiddles.push(twiddles::compute_twiddle(x * y, len, direction));
             }
         }
 
@@ -243,7 +243,7 @@ impl<T: FftNum> MixedRadixSmall<T> {
         let mut twiddles = Vec::with_capacity(len);
         for x in 0..width {
             for y in 0..height {
-                twiddles.push(T::generate_twiddle_factor(x * y, len, direction));
+                twiddles.push(twiddles::compute_twiddle(x * y, len, direction));
             }
         }
 

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
-use crate::{FftDirection, common::FftNum, twiddles};
+use crate::{common::FftNum, twiddles, FftDirection};
 
 use crate::math_utils;
 use crate::{Direction, Fft, Length};

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
-use crate::{common::FftNum, FftDirection};
+use crate::{FftDirection, common::FftNum, twiddles};
 
 use crate::math_utils;
 use crate::{Direction, Fft, Length};
@@ -89,7 +89,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
         let mut inner_fft_input = vec![Complex::zero(); inner_fft_len];
         let mut twiddle_input = 1;
         for input_cell in &mut inner_fft_input {
-            let twiddle = T::generate_twiddle_factor(twiddle_input, len, direction);
+            let twiddle = twiddles::compute_twiddle(twiddle_input, len, direction);
             *input_cell = twiddle * unity_scale;
 
             twiddle_input = (twiddle_input * primitive_root_inverse) % reduced_len;

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -3,11 +3,7 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::{
-    array_utils::{RawSlice, RawSliceMut},
-    common::FftNum,
-    FftDirection,
-};
+use crate::{FftDirection, array_utils::{RawSlice, RawSliceMut}, common::FftNum, twiddles};
 
 use crate::algorithm::butterflies::{Butterfly1, Butterfly16, Butterfly2, Butterfly4, Butterfly8};
 use crate::{Direction, Fft, Length};
@@ -73,7 +69,7 @@ impl<T: FftNum> Radix4<T> {
             for i in 0..num_rows {
                 for k in 1..4 {
                     let twiddle =
-                        T::generate_twiddle_factor(i * k * twiddle_stride, len, direction);
+                        twiddles::compute_twiddle(i * k * twiddle_stride, len, direction);
                     twiddle_factors.push(twiddle);
                 }
             }

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::{FftDirection, array_utils::{RawSlice, RawSliceMut}, common::FftNum, twiddles};
+use crate::{
+    array_utils::{RawSlice, RawSliceMut},
+    common::FftNum,
+    twiddles, FftDirection,
+};
 
 use crate::algorithm::butterflies::{Butterfly1, Butterfly16, Butterfly2, Butterfly4, Butterfly8};
 use crate::{Direction, Fft, Length};
@@ -68,8 +72,7 @@ impl<T: FftNum> Radix4<T> {
             let num_rows = len / (twiddle_stride * 4);
             for i in 0..num_rows {
                 for k in 1..4 {
-                    let twiddle =
-                        twiddles::compute_twiddle(i * k * twiddle_stride, len, direction);
+                    let twiddle = twiddles::compute_twiddle(i * k * twiddle_stride, len, direction);
                     twiddle_factors.push(twiddle);
                 }
             }

--- a/src/avx/avx32_butterflies.rs
+++ b/src/avx/avx32_butterflies.rs
@@ -774,7 +774,7 @@ boilerplate_fft_simd_butterfly!(Butterfly9Avx, 9);
 impl Butterfly9Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddles : [Complex<f32>; 4] = [
+        let twiddles: [Complex<f32>; 4] = [
             twiddles::compute_twiddle(1, 9, direction),
             twiddles::compute_twiddle(2, 9, direction),
             twiddles::compute_twiddle(2, 9, direction),
@@ -856,7 +856,10 @@ impl Butterfly12Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
         let twiddles = [
-            Complex { re: 1.0f32, im: 0.0 },
+            Complex {
+                re: 1.0f32,
+                im: 0.0,
+            },
             Complex { re: 1.0, im: 0.0 },
             twiddles::compute_twiddle(2, 12, direction),
             twiddles::compute_twiddle(4, 12, direction),

--- a/src/avx/avx32_butterflies.rs
+++ b/src/avx/avx32_butterflies.rs
@@ -4,7 +4,7 @@ use std::mem::MaybeUninit;
 
 use num_complex::Complex;
 
-use crate::common::FftNum;
+use crate::{common::FftNum, twiddles};
 
 use crate::{Direction, Fft, FftDirection, Length};
 
@@ -390,8 +390,8 @@ boilerplate_fft_simd_butterfly!(Butterfly5Avx, 5);
 impl Butterfly5Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddle1 = f32::generate_twiddle_factor(1, 5, direction);
-        let twiddle2 = f32::generate_twiddle_factor(2, 5, direction);
+        let twiddle1 = twiddles::compute_twiddle(1, 5, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 5, direction);
         Self {
             twiddles: [
                 _mm_set_ps(twiddle1.im, twiddle1.im, twiddle1.re, twiddle1.re),
@@ -459,9 +459,9 @@ boilerplate_fft_simd_butterfly!(Butterfly7Avx, 7);
 impl Butterfly7Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddle1 = f32::generate_twiddle_factor(1, 7, direction);
-        let twiddle2 = f32::generate_twiddle_factor(2, 7, direction);
-        let twiddle3 = f32::generate_twiddle_factor(3, 7, direction);
+        let twiddle1 = twiddles::compute_twiddle(1, 7, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 7, direction);
+        let twiddle3 = twiddles::compute_twiddle(3, 7, direction);
         Self {
             twiddles: [
                 _mm_set_ps(twiddle1.im, twiddle1.im, twiddle1.re, twiddle1.re),
@@ -559,11 +559,11 @@ boilerplate_fft_simd_butterfly!(Butterfly11Avx, 11);
 impl Butterfly11Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddle1 = f32::generate_twiddle_factor(1, 11, direction);
-        let twiddle2 = f32::generate_twiddle_factor(2, 11, direction);
-        let twiddle3 = f32::generate_twiddle_factor(3, 11, direction);
-        let twiddle4 = f32::generate_twiddle_factor(4, 11, direction);
-        let twiddle5 = f32::generate_twiddle_factor(5, 11, direction);
+        let twiddle1 = twiddles::compute_twiddle(1, 11, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 11, direction);
+        let twiddle3 = twiddles::compute_twiddle(3, 11, direction);
+        let twiddle4 = twiddles::compute_twiddle(4, 11, direction);
+        let twiddle5 = twiddles::compute_twiddle(5, 11, direction);
 
         let twiddles_lo = [
             _mm_set_ps(twiddle1.im, twiddle1.im, twiddle1.re, twiddle1.re),
@@ -774,11 +774,11 @@ boilerplate_fft_simd_butterfly!(Butterfly9Avx, 9);
 impl Butterfly9Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddles = [
-            f32::generate_twiddle_factor(1, 9, direction),
-            f32::generate_twiddle_factor(2, 9, direction),
-            f32::generate_twiddle_factor(2, 9, direction),
-            f32::generate_twiddle_factor(4, 9, direction),
+        let twiddles : [Complex<f32>; 4] = [
+            twiddles::compute_twiddle(1, 9, direction),
+            twiddles::compute_twiddle(2, 9, direction),
+            twiddles::compute_twiddle(2, 9, direction),
+            twiddles::compute_twiddle(4, 9, direction),
         ];
         Self {
             twiddles: twiddles.load_complex(0),
@@ -856,15 +856,15 @@ impl Butterfly12Avx<f32> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
         let twiddles = [
+            Complex { re: 1.0f32, im: 0.0 },
             Complex { re: 1.0, im: 0.0 },
-            Complex { re: 1.0, im: 0.0 },
-            f32::generate_twiddle_factor(2, 12, direction),
-            f32::generate_twiddle_factor(4, 12, direction),
+            twiddles::compute_twiddle(2, 12, direction),
+            twiddles::compute_twiddle(4, 12, direction),
             // note that these twiddles are deliberately in a weird order, see perform_fft_f32 for why
-            f32::generate_twiddle_factor(1, 12, direction),
-            f32::generate_twiddle_factor(2, 12, direction),
-            f32::generate_twiddle_factor(3, 12, direction),
-            f32::generate_twiddle_factor(6, 12, direction),
+            twiddles::compute_twiddle(1, 12, direction),
+            twiddles::compute_twiddle(2, 12, direction),
+            twiddles::compute_twiddle(3, 12, direction),
+            twiddles::compute_twiddle(6, 12, direction),
         ];
         Self {
             twiddles: [twiddles.load_complex(0), twiddles.load_complex(4)],

--- a/src/avx/avx64_butterflies.rs
+++ b/src/avx/avx64_butterflies.rs
@@ -4,7 +4,7 @@ use std::mem::MaybeUninit;
 
 use num_complex::Complex;
 
-use crate::common::FftNum;
+use crate::{common::FftNum, twiddles};
 
 use crate::{Direction, Fft, FftDirection, Length};
 
@@ -390,8 +390,8 @@ boilerplate_fft_simd_butterfly!(Butterfly5Avx64, 5);
 impl Butterfly5Avx64<f64> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddle1 = f64::generate_twiddle_factor(1, 5, direction);
-        let twiddle2 = f64::generate_twiddle_factor(2, 5, direction);
+        let twiddle1 = twiddles::compute_twiddle(1, 5, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 5, direction);
         Self {
             twiddles: [
                 _mm256_set_pd(twiddle1.im, twiddle1.im, twiddle1.re, twiddle1.re),
@@ -460,9 +460,9 @@ boilerplate_fft_simd_butterfly!(Butterfly7Avx64, 7);
 impl Butterfly7Avx64<f64> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddle1 = f64::generate_twiddle_factor(1, 7, direction);
-        let twiddle2 = f64::generate_twiddle_factor(2, 7, direction);
-        let twiddle3 = f64::generate_twiddle_factor(3, 7, direction);
+        let twiddle1 = twiddles::compute_twiddle(1, 7, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 7, direction);
+        let twiddle3 = twiddles::compute_twiddle(3, 7, direction);
         Self {
             twiddles: [
                 _mm256_set_pd(twiddle1.im, twiddle1.im, twiddle1.re, twiddle1.re),
@@ -555,11 +555,11 @@ boilerplate_fft_simd_butterfly!(Butterfly11Avx64, 11);
 impl Butterfly11Avx64<f64> {
     #[target_feature(enable = "avx")]
     unsafe fn new_with_avx(direction: FftDirection) -> Self {
-        let twiddle1 = f64::generate_twiddle_factor(1, 11, direction);
-        let twiddle2 = f64::generate_twiddle_factor(2, 11, direction);
-        let twiddle3 = f64::generate_twiddle_factor(3, 11, direction);
-        let twiddle4 = f64::generate_twiddle_factor(4, 11, direction);
-        let twiddle5 = f64::generate_twiddle_factor(5, 11, direction);
+        let twiddle1 = twiddles::compute_twiddle(1, 11, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 11, direction);
+        let twiddle3 = twiddles::compute_twiddle(3, 11, direction);
+        let twiddle4 = twiddles::compute_twiddle(4, 11, direction);
+        let twiddle5 = twiddles::compute_twiddle(5, 11, direction);
 
         let twiddles = [
             _mm256_set_pd(twiddle1.im, twiddle1.im, twiddle1.re, twiddle1.re),

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -5,7 +5,7 @@ use num_complex::Complex;
 use num_integer::div_ceil;
 use num_traits::Zero;
 
-use crate::{array_utils, FftDirection};
+use crate::{FftDirection, array_utils, twiddles};
 use crate::{Direction, Fft, FftNum, Length};
 
 use super::CommonSimdData;
@@ -36,7 +36,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
         let index_float = index as f64;
         let index_squared = index_float * index_float;
 
-        A::generate_twiddle_factor_floatindex(index_squared, len * 2, direction.reverse())
+        twiddles::compute_twiddle_floatindex(index_squared, len * 2, direction.reverse())
     }
 
     /// Pairwise multiply the complex numbers in `left` with the complex numbers in `right`.

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -5,7 +5,7 @@ use num_complex::Complex;
 use num_integer::div_ceil;
 use num_traits::Zero;
 
-use crate::{FftDirection, array_utils, twiddles};
+use crate::{array_utils, twiddles, FftDirection};
 use crate::{Direction, Fft, FftNum, Length};
 
 use super::CommonSimdData;

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -8,8 +8,8 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
-use crate::{math_utils, twiddles};
 use crate::{array_utils, FftDirection};
+use crate::{math_utils, twiddles};
 use crate::{Direction, Fft, FftNum, Length};
 
 use super::avx_vector;

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -8,7 +8,7 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
-use crate::math_utils;
+use crate::{math_utils, twiddles};
 use crate::{array_utils, FftDirection};
 use crate::{Direction, Fft, FftNum, Length};
 
@@ -164,7 +164,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
         let mut inner_fft_input = vec![Complex::zero(); inner_fft_len];
         let mut twiddle_input = 1;
         for input_cell in &mut inner_fft_input {
-            let twiddle = T::generate_twiddle_factor(twiddle_input, len, direction);
+            let twiddle = twiddles::compute_twiddle(twiddle_input, len, direction);
             *input_cell = twiddle * unity_scale;
 
             twiddle_input = (twiddle_input * primitive_root_inverse) % reduced_len;

--- a/src/avx/avx_vector.rs
+++ b/src/avx/avx_vector.rs
@@ -5,9 +5,8 @@ use num_complex::Complex;
 use num_traits::Zero;
 
 use crate::{
-    twiddles,
     array_utils::{RawSlice, RawSliceMut},
-    FftDirection,
+    twiddles, FftDirection,
 };
 
 use super::AvxNum;

--- a/src/avx/avx_vector.rs
+++ b/src/avx/avx_vector.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::common::FftNum;
 use crate::{
+    twiddles,
     array_utils::{RawSlice, RawSliceMut},
     FftDirection,
 };
@@ -909,9 +909,9 @@ impl AvxVector for __m256 {
         len: usize,
         direction: FftDirection,
     ) -> Self {
-        let mut twiddle_chunk = [Complex::zero(); Self::COMPLEX_PER_VECTOR];
+        let mut twiddle_chunk = [Complex::<f32>::zero(); Self::COMPLEX_PER_VECTOR];
         for i in 0..Self::COMPLEX_PER_VECTOR {
-            twiddle_chunk[i] = f32::generate_twiddle_factor(y * (x + i), len, direction);
+            twiddle_chunk[i] = twiddles::compute_twiddle(y * (x + i), len, direction);
         }
 
         twiddle_chunk.load_complex(0)
@@ -919,7 +919,7 @@ impl AvxVector for __m256 {
 
     #[inline(always)]
     unsafe fn broadcast_twiddle(index: usize, len: usize, direction: FftDirection) -> Self {
-        Self::broadcast_complex_elements(f32::generate_twiddle_factor(index, len, direction))
+        Self::broadcast_complex_elements(twiddles::compute_twiddle(index, len, direction))
     }
 
     #[inline(always)]
@@ -1293,16 +1293,16 @@ impl AvxVector for __m128 {
         len: usize,
         direction: FftDirection,
     ) -> Self {
-        let mut twiddle_chunk = [Complex::zero(); Self::COMPLEX_PER_VECTOR];
+        let mut twiddle_chunk = [Complex::<f32>::zero(); Self::COMPLEX_PER_VECTOR];
         for i in 0..Self::COMPLEX_PER_VECTOR {
-            twiddle_chunk[i] = f32::generate_twiddle_factor(y * (x + i), len, direction);
+            twiddle_chunk[i] = twiddles::compute_twiddle(y * (x + i), len, direction);
         }
 
         _mm_loadu_ps(twiddle_chunk.as_ptr() as *const f32)
     }
     #[inline(always)]
     unsafe fn broadcast_twiddle(index: usize, len: usize, direction: FftDirection) -> Self {
-        Self::broadcast_complex_elements(f32::generate_twiddle_factor(index, len, direction))
+        Self::broadcast_complex_elements(twiddles::compute_twiddle(index, len, direction))
     }
 
     #[inline(always)]
@@ -1558,16 +1558,16 @@ impl AvxVector for __m256d {
         len: usize,
         direction: FftDirection,
     ) -> Self {
-        let mut twiddle_chunk = [Complex::zero(); Self::COMPLEX_PER_VECTOR];
+        let mut twiddle_chunk = [Complex::<f64>::zero(); Self::COMPLEX_PER_VECTOR];
         for i in 0..Self::COMPLEX_PER_VECTOR {
-            twiddle_chunk[i] = f64::generate_twiddle_factor(y * (x + i), len, direction);
+            twiddle_chunk[i] = twiddles::compute_twiddle(y * (x + i), len, direction);
         }
 
         twiddle_chunk.load_complex(0)
     }
     #[inline(always)]
     unsafe fn broadcast_twiddle(index: usize, len: usize, direction: FftDirection) -> Self {
-        Self::broadcast_complex_elements(f64::generate_twiddle_factor(index, len, direction))
+        Self::broadcast_complex_elements(twiddles::compute_twiddle(index, len, direction))
     }
 
     #[inline(always)]
@@ -1879,16 +1879,16 @@ impl AvxVector for __m128d {
         len: usize,
         direction: FftDirection,
     ) -> Self {
-        let mut twiddle_chunk = [Complex::zero(); Self::COMPLEX_PER_VECTOR];
+        let mut twiddle_chunk = [Complex::<f64>::zero(); Self::COMPLEX_PER_VECTOR];
         for i in 0..Self::COMPLEX_PER_VECTOR {
-            twiddle_chunk[i] = f64::generate_twiddle_factor(y * (x + i), len, direction);
+            twiddle_chunk[i] = twiddles::compute_twiddle(y * (x + i), len, direction);
         }
 
         _mm_loadu_pd(twiddle_chunk.as_ptr() as *const f64)
     }
     #[inline(always)]
     unsafe fn broadcast_twiddle(index: usize, len: usize, direction: FftDirection) -> Self {
-        Self::broadcast_complex_elements(f64::generate_twiddle_factor(index, len, direction))
+        Self::broadcast_complex_elements(twiddles::compute_twiddle(index, len, direction))
     }
 
     #[inline(always)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,50 +1,10 @@
 use num_traits::{FromPrimitive, Signed};
 use std::fmt::Debug;
 
-use num_complex::Complex;
-
-use crate::FftDirection;
-
 /// Generic floating point number, implemented for f32 and f64
-pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {
-    // two related methodsfor generating twiddle factors. The first is a convenience wrapper around the second.
-    fn generate_twiddle_factor(
-        index: usize,
-        fft_len: usize,
-        direction: FftDirection,
-    ) -> Complex<Self> {
-        Self::generate_twiddle_factor_floatindex(index as f64, fft_len, direction)
-    }
-    fn generate_twiddle_factor_floatindex(
-        index: f64,
-        fft_len: usize,
-        direction: FftDirection,
-    ) -> Complex<Self>;
-}
+pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
 
-impl<T> FftNum for T
-where
-    T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static,
-{
-    fn generate_twiddle_factor_floatindex(
-        index: f64,
-        fft_len: usize,
-        direction: FftDirection,
-    ) -> Complex<Self> {
-        let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
-        let angle = constant * index;
-
-        let result = Complex {
-            re: Self::from_f64(angle.cos()).unwrap(),
-            im: Self::from_f64(angle.sin()).unwrap(),
-        };
-
-        match direction {
-            FftDirection::Forward => result,
-            FftDirection::Inverse => result.conj(),
-        }
-    }
-}
+impl<T> FftNum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
 
 // impl FftNum for f32 {
 // 	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, direction: FftDirection) -> Complex<Self> {

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -1,7 +1,11 @@
 use crate::{common::FftNum, FftDirection};
 use num_complex::Complex;
 
-pub fn compute_twiddle<T: FftNum>(index: usize, fft_len: usize, direction: FftDirection) -> Complex<T> {
+pub fn compute_twiddle<T: FftNum>(
+    index: usize,
+    fft_len: usize,
+    direction: FftDirection,
+) -> Complex<T> {
     let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
     let angle = constant * index as f64;
 
@@ -16,7 +20,11 @@ pub fn compute_twiddle<T: FftNum>(index: usize, fft_len: usize, direction: FftDi
     }
 }
 
-pub fn compute_twiddle_floatindex<T: FftNum>(index: f64, fft_len: usize, direction: FftDirection) -> Complex<T> {
+pub fn compute_twiddle_floatindex<T: FftNum>(
+    index: f64,
+    fft_len: usize,
+    direction: FftDirection,
+) -> Complex<T> {
     let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
     let angle = constant * index;
 

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -1,13 +1,34 @@
 use crate::{common::FftNum, FftDirection};
 use num_complex::Complex;
 
-pub fn generate_twiddle_factors<T: FftNum>(
-    fft_len: usize,
-    direction: FftDirection,
-) -> Vec<Complex<T>> {
-    (0..fft_len)
-        .map(|i| T::generate_twiddle_factor(i, fft_len, direction))
-        .collect()
+pub fn compute_twiddle<T: FftNum>(index: usize, fft_len: usize, direction: FftDirection) -> Complex<T> {
+    let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
+    let angle = constant * index as f64;
+
+    let result = Complex {
+        re: T::from_f64(angle.cos()).unwrap(),
+        im: T::from_f64(angle.sin()).unwrap(),
+    };
+
+    match direction {
+        FftDirection::Forward => result,
+        FftDirection::Inverse => result.conj(),
+    }
+}
+
+pub fn compute_twiddle_floatindex<T: FftNum>(index: f64, fft_len: usize, direction: FftDirection) -> Complex<T> {
+    let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
+    let angle = constant * index;
+
+    let result = Complex {
+        re: T::from_f64(angle.cos()).unwrap(),
+        im: T::from_f64(angle.sin()).unwrap(),
+    };
+
+    match direction {
+        FftDirection::Forward => result,
+        FftDirection::Inverse => result.conj(),
+    }
 }
 
 pub fn rotate_90<T: FftNum>(value: Complex<T>, direction: FftDirection) -> Complex<T> {
@@ -26,41 +47,28 @@ pub fn rotate_90<T: FftNum>(value: Complex<T>, direction: FftDirection) -> Compl
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::test_utils::compare_vectors;
-    use std::f32;
 
     #[test]
-    fn test_generate() {
-        //test the length-0 case
-        let zero_twiddles: Vec<Complex<f32>> = generate_twiddle_factors(0, FftDirection::Forward);
-        assert_eq!(0, zero_twiddles.len());
+    fn test_rotate() {
+        // Verify that the rotate90 function does the same thing as multiplying by twiddle(1,4), in the forward direction
+        let value = Complex { re: 9.1, im: 2.2 };
+        let rotated_forward = rotate_90(value, FftDirection::Forward);
+        let twiddled_forward = value * compute_twiddle(1, 4, FftDirection::Forward);
 
-        let constant = -2f32 * f32::consts::PI;
+        assert_eq!(value.re, -rotated_forward.im);
+        assert_eq!(value.im, rotated_forward.re);
 
-        for len in 1..10 {
-            let actual: Vec<Complex<f32>> = generate_twiddle_factors(len, FftDirection::Forward);
-            let expected: Vec<Complex<f32>> = (0..len)
-                .map(|i| Complex::from_polar(1f32, constant * i as f32 / len as f32))
-                .collect();
+        assert!(value.re + twiddled_forward.im < 0.0001);
+        assert!(value.im - rotated_forward.re < 0.0001);
 
-            assert!(compare_vectors(&actual, &expected), "len = {}", len)
-        }
+        // Verify that the rotate90 function does the same thing as multiplying by twiddle(1,4), in the inverse direction
+        let rotated_forward = rotate_90(value, FftDirection::Inverse);
+        let twiddled_forward = value * compute_twiddle(1, 4, FftDirection::Inverse);
 
-        //for each len, verify that each element in the inverse is the conjugate of the non-inverse
-        for len in 1..10 {
-            let twiddles: Vec<Complex<f32>> = generate_twiddle_factors(len, FftDirection::Forward);
-            let mut twiddles_inverse: Vec<Complex<f32>> =
-                generate_twiddle_factors(len, FftDirection::Inverse);
+        assert_eq!(value.re, rotated_forward.im);
+        assert_eq!(value.im, -rotated_forward.re);
 
-            for value in twiddles_inverse.iter_mut() {
-                *value = value.conj();
-            }
-
-            assert!(
-                compare_vectors(&twiddles, &twiddles_inverse),
-                "len = {}",
-                len
-            )
-        }
+        assert!(value.re - twiddled_forward.im < 0.0001);
+        assert!(value.im + rotated_forward.re < 0.0001);
     }
 }


### PR DESCRIPTION
Twiddles factors were added to FftNum so that we could use specialization when generating them.

Since we can't use specialization, there's no benefit in making it a part of the public API, and there's a high cost.