### PR TITLE
Arm ci

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 name: CI
 

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -59,4 +59,33 @@ jobs:
         with:
           command: fmt
           args: -- --check
+
+  check_arm64:
+    name: Check and test Linux arm 64bit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          use-cross: true
+          args: --target aarch64-unknown-linux-gnu
+
+      - name: Run cargo test for arm
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          use-cross: true
+          args: --target aarch64-unknown-linux-gnu
         

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [push, pull_request]
 
 name: CI
 

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -88,4 +88,33 @@ jobs:
           command: test
           use-cross: true
           args: --target aarch64-unknown-linux-gnu
+
+  check_x86:
+    name: Check and test Linux x86 32bit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: i586-unknown-linux-gnu
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          use-cross: true
+          args: --target i586-unknown-linux-gnu
+
+      - name: Run cargo test for arm
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          use-cross: true
+          args: --target i586-unknown-linux-gnu
         

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           command: test
           use-cross: true
-          args: --target aarch64-unknown-linux-gnu
+          args: --release --target aarch64-unknown-linux-gnu
 
   check_x86:
     name: Check and test Linux x86 32bit
@@ -111,7 +111,7 @@ jobs:
           use-cross: true
           args: --target i586-unknown-linux-gnu
 
-      - name: Run cargo test for arm
+      - name: Run cargo test for i586
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -562,10 +562,10 @@ mod unit_tests {
     fn test_plan_scalar_mixedradix() {
         // Products of several different primes should become MixedRadix
         let mut planner = FftPlannerScalar::<f64>::new();
-        for pow2 in 2..6 {
-            for pow3 in 2..6 {
-                for pow5 in 2..6 {
-                    for pow7 in 2..6 {
+        for pow2 in 2..5 {
+            for pow3 in 2..5 {
+                for pow5 in 2..5 {
+                    for pow7 in 2..5 {
                         let len = 2usize.pow(pow2)
                             * 3usize.pow(pow3)
                             * 5usize.pow(pow5)


### PR DESCRIPTION
This adds a ci job to run check and test on aarch64. For simplicity it only runs on stable, should be fine since the nightly/beta/etc matrix is run in the other job on x86_64.
The test_planned_fft_forward_f32() etc test in accuracy.rs take a fairly long time to run in emulation, if this becomes a problem we can probably skip them for arm.