### PR TITLE
Reshuffled Fft trait methods to reduce binary size and user confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ let fft = planner.plan_fft_forward(1234);
 
 let mut buffer = vec![Complex{ re: 0.0, im: 0.0 }; 1234];
 
-fft.process_inplace(&mut buffer);
+fft.process(&mut buffer);
 ```
 
 ## Supported Rust Version

--- a/benches/compare_3n2m_strategies.rs
+++ b/benches/compare_3n2m_strategies.rs
@@ -500,7 +500,7 @@ fn bench_planned_fft_f32(b: &mut Bencher, len: usize) {
     let mut buffer = vec![Complex::zero(); fft.len()];
     let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
     b.iter(|| {
-        fft.process_inplace_with_scratch(&mut buffer, &mut scratch);
+        fft.process_with_scratch(&mut buffer, &mut scratch);
     });
 }
 
@@ -512,7 +512,7 @@ fn bench_planned_fft_f64(b: &mut Bencher, len: usize) {
     let mut buffer = vec![Complex::zero(); fft.len()];
     let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
     b.iter(|| {
-        fft.process_inplace_with_scratch(&mut buffer, &mut scratch);
+        fft.process_with_scratch(&mut buffer, &mut scratch);
     });
 }
 
@@ -525,7 +525,7 @@ fn bench_planned_bluesteins_f32(b: &mut Bencher, len: usize) {
 
     let mut buffer = vec![Complex::zero(); fft.len()];
     let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
-    b.iter(|| { fft.process_inplace_with_scratch(&mut buffer, &mut scratch); });
+    b.iter(|| { fft.process_with_scratch(&mut buffer, &mut scratch); });
 }
 
 // Computes the given FFT length using Rader's Algorithm, using the planner to plan the inner FFT
@@ -535,7 +535,7 @@ fn bench_planned_raders_f32(b: &mut Bencher, len: usize) {
 
     let mut buffer = vec![Complex::zero(); fft.len()];
     let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
-    b.iter(|| { fft.process_inplace_with_scratch(&mut buffer, &mut scratch); });
+    b.iter(|| { fft.process_with_scratch(&mut buffer, &mut scratch); });
 }
 
 // Computes the given FFT length using Bluestein's Algorithm, using the planner to plan the inner FFT
@@ -545,7 +545,7 @@ fn bench_planned_bluesteins_f64(b: &mut Bencher, len: usize) {
 
     let mut buffer = vec![Complex::zero(); fft.len()];
     let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
-    b.iter(|| { fft.process_inplace_with_scratch(&mut buffer, &mut scratch); });
+    b.iter(|| { fft.process_with_scratch(&mut buffer, &mut scratch); });
 }
 
 // Computes the given FFT length using Rader's Algorithm, using the planner to plan the inner FFT
@@ -555,7 +555,7 @@ fn bench_planned_raders_f64(b: &mut Bencher, len: usize) {
 
     let mut buffer = vec![Complex::zero(); fft.len()];
     let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
-    b.iter(|| { fft.process_inplace_with_scratch(&mut buffer, &mut scratch); });
+    b.iter(|| { fft.process_with_scratch(&mut buffer, &mut scratch); });
 }
 
 #[bench] fn comparef64_len0000023_11p01_bluesteins(b: &mut Bencher) { bench_planned_bluesteins_f64(b, 23); }

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -15,7 +15,7 @@ fn main() {
             let fft_copy = Arc::clone(&fft);
             thread::spawn(move || {
                 let mut buffer = vec![Complex32::new(0.0, 0.0); 100];
-                fft_copy.process_inplace(&mut buffer);
+                fft_copy.process(&mut buffer);
             })
         })
         .collect();

--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
+use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles, FftDirection};
 use crate::{Direction, Fft, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::array_utils;
 
 /// Implementation of Bluestein's Algorithm
 ///

--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -4,8 +4,9 @@ use num_complex::Complex;
 use num_traits::Zero;
 
 use crate::{common::FftNum, twiddles, FftDirection};
-
 use crate::{Direction, Fft, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::array_utils;
 
 /// Implementation of Bluestein's Algorithm
 ///
@@ -21,10 +22,8 @@ use crate::{Direction, Fft, Length};
 /// use rustfft::algorithm::BluesteinsAlgorithm;
 /// use rustfft::{Fft, FftPlanner};
 /// use rustfft::num_complex::Complex;
-/// use rustfft::num_traits::Zero;
 ///
-/// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1201];
-/// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1201];
+/// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1201];
 ///
 /// // We need to find an inner FFT whose size is greater than 1201*2 - 1.
 /// // The size 2401 (7^4) satisfies this requirement, while also being relatively fast.
@@ -32,7 +31,7 @@ use crate::{Direction, Fft, Length};
 /// let inner_fft = planner.plan_fft_forward(2401);
 ///
 /// let fft = BluesteinsAlgorithm::new(1201, inner_fft);
-/// fft.process(&mut input, &mut output);
+/// fft.process(&mut buffer);
 /// ~~~
 ///
 /// Bluesteins's Algorithm is relatively expensive compared to other FFT algorithms. Benchmarking shows that it is up to
@@ -82,7 +81,7 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
 
         //Compute the inner fft
         let mut inner_fft_scratch = vec![Complex::zero(); inner_fft.get_inplace_scratch_len()];
-        inner_fft.process_inplace_with_scratch(&mut inner_fft_input, &mut inner_fft_scratch);
+        inner_fft.process_with_scratch(&mut inner_fft_input, &mut inner_fft_scratch);
 
         // also compute some more mundane twiddle factors to start and end with
         let twiddles: Vec<_> = (0..len)
@@ -117,7 +116,7 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
 
         // run our inner forward FFT
         self.inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // Multiply our inner FFT output by our precomputed data. Then, conjugate the result to set up for an inverse FFT
         for (inner, multiplier) in inner_input.iter_mut().zip(self.inner_fft_multiplier.iter()) {
@@ -126,7 +125,7 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
 
         // inverse FFT. we're computing a forward but we're massaging it into an inverse by conjugating the inputs and outputs
         self.inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // copy our data back to the buffer, applying twiddle factors again as we go. Also conjugate inner_input to complete the inverse FFT
         for ((buffer_entry, inner_entry), twiddle) in input
@@ -160,7 +159,7 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
 
         // run our inner forward FFT
         self.inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // Multiply our inner FFT output by our precomputed data. Then, conjugate the result to set up for an inverse FFT
         for (inner, multiplier) in inner_input.iter_mut().zip(self.inner_fft_multiplier.iter()) {
@@ -169,7 +168,7 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
 
         // inverse FFT. we're computing a forward but we're massaging it into an inverse by conjugating the inputs and outputs
         self.inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // copy our data back to the buffer, applying twiddle factors again as we go. Also conjugate inner_input to complete the inverse FFT
         for ((buffer_entry, inner_entry), twiddle) in output

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -5,6 +5,8 @@ use crate::{common::FftNum, FftDirection};
 use crate::array_utils::{RawSlice, RawSliceMut};
 use crate::twiddles;
 use crate::{Direction, Fft, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::array_utils;
 
 #[allow(unused)]
 macro_rules! boilerplate_fft_butterfly {
@@ -16,94 +18,49 @@ macro_rules! boilerplate_fft_butterfly {
             }
         }
         impl<T: FftNum> Fft<T> for $struct_name<T> {
+            fn process_outofplace_with_scratch(
+                &self,
+                input: &mut [Complex<T>],
+                output: &mut [Complex<T>],
+                _scratch: &mut [Complex<T>],
+            ) {
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| {
+                    unsafe {
+                        self.perform_fft_contiguous(RawSlice::new(in_chunk), RawSliceMut::new(out_chunk))
+                    };
+                });
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_with_scratch(
                 &self,
-                input: &mut [Complex<T>],
-                output: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
-                assert_eq!(
-                    input.len(),
-                    self.len(),
-                    "Input is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    output.len(),
-                    self.len(),
-                    "Output is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    output.len()
-                );
-
-                unsafe {
-                    self.perform_fft_contiguous(RawSlice::new(input), RawSliceMut::new(output))
-                };
-            }
-            fn process_multi(
-                &self,
-                input: &mut [Complex<T>],
-                output: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
-                assert!(
-                    input.len() % self.len() == 0,
-                    "Output is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    input.len(),
-                    output.len(),
-                    "Output is the wrong length. input = {} output = {}",
-                    input.len(),
-                    output.len()
-                );
-
-                for (out_chunk, in_chunk) in output
-                    .chunks_exact_mut(self.len())
-                    .zip(input.chunks_exact(self.len()))
-                {
-                    unsafe {
-                        self.perform_fft_contiguous(
-                            RawSlice::new(in_chunk),
-                            RawSliceMut::new(out_chunk),
-                        )
-                    };
-                }
-            }
-            fn process_inplace_with_scratch(
-                &self,
                 buffer: &mut [Complex<T>],
                 _scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    buffer.len(),
-                    self.len(),
-                    "Buffer is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
-                unsafe { self.perform_fft_butterfly(buffer) };
-            }
-            fn process_inplace_multi(
-                &self,
-                buffer: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
-                assert_eq!(
-                    buffer.len() % self.len(),
-                    0,
-                    "Buffer is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
-                for chunk in buffer.chunks_exact_mut(self.len()) {
-                    unsafe { self.perform_fft_butterfly(chunk) };
+                if buffer.len() < self.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), 0, 0);
+                    return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
+
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| unsafe { self.perform_fft_butterfly(chunk) });
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), 0, 0);
+                }
+                
             }
             #[inline(always)]
             fn get_inplace_scratch_len(&self) -> usize {
@@ -143,7 +100,7 @@ impl<T: FftNum> Butterfly1<T> {
     }
 }
 impl<T: FftNum> Fft<T> for Butterfly1<T> {
-    fn process_with_scratch(
+    fn process_outofplace_with_scratch(
         &self,
         input: &mut [Complex<T>],
         output: &mut [Complex<T>],
@@ -152,23 +109,12 @@ impl<T: FftNum> Fft<T> for Butterfly1<T> {
         output.copy_from_slice(&input);
     }
 
-    fn process_inplace_with_scratch(
+    fn process_with_scratch(
         &self,
         _buffer: &mut [Complex<T>],
         _scratch: &mut [Complex<T>],
     ) {
     }
-
-    fn process_multi(
-        &self,
-        input: &mut [Complex<T>],
-        output: &mut [Complex<T>],
-        _scratch: &mut [Complex<T>],
-    ) {
-        output.copy_from_slice(&input);
-    }
-
-    fn process_inplace_multi(&self, _buffer: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {}
 
     fn get_inplace_scratch_len(&self) -> usize {
         0

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -1,10 +1,10 @@
 use num_complex::Complex;
 use num_traits::Zero;
 
+use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{twiddles, FftDirection};
 use crate::{Direction, Fft, FftNum, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::array_utils;
 
 /// Naive O(n^2 ) Discrete Fourier Transform implementation
 ///
@@ -99,13 +99,12 @@ mod unit_tests {
                 "DFT instance reported incorrect length"
             );
 
-            let input = random_signal(len * n);          
+            let input = random_signal(len * n);
             let mut expected_output = input.clone();
 
             // Compute the control data using our simplified DFT definition
-            for (input_chunk, output_chunk) in input
-                .chunks(len)
-                .zip(expected_output.chunks_mut(len))
+            for (input_chunk, output_chunk) in
+                input.chunks(len).zip(expected_output.chunks_mut(len))
             {
                 dft(input_chunk, output_chunk);
             }
@@ -126,23 +125,26 @@ mod unit_tests {
             // test process_with_scratch()
             {
                 let mut inplace_with_scratch_buffer = input.clone();
-                let mut inplace_scratch = vec![Zero::zero(); dft_instance.get_inplace_scratch_len()];
+                let mut inplace_scratch =
+                    vec![Zero::zero(); dft_instance.get_inplace_scratch_len()];
 
-                dft_instance.process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
+                dft_instance
+                    .process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
 
                 assert!(
                     compare_vectors(&expected_output, &inplace_with_scratch_buffer),
                     "process_inplace() failed, length = {}",
                     len
                 );
-    
+
                 // one more thing: make sure that the DFT algorithm even works with dirty scratch space
                 for item in inplace_scratch.iter_mut() {
                     *item = Complex::new(100.0, 100.0);
                 }
                 inplace_with_scratch_buffer.copy_from_slice(&input);
-                
-                dft_instance.process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
+
+                dft_instance
+                    .process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
 
                 assert!(
                     compare_vectors(&expected_output, &inplace_with_scratch_buffer),
@@ -156,7 +158,11 @@ mod unit_tests {
                 let mut outofplace_input = input.clone();
                 let mut outofplace_output = expected_output.clone();
 
-                dft_instance.process_outofplace_with_scratch(&mut outofplace_input, &mut outofplace_output, &mut []);
+                dft_instance.process_outofplace_with_scratch(
+                    &mut outofplace_input,
+                    &mut outofplace_output,
+                    &mut [],
+                );
 
                 assert!(
                     compare_vectors(&expected_output, &outofplace_output),
@@ -174,7 +180,11 @@ mod unit_tests {
 
         zero_dft.process(&mut zero_input);
         zero_dft.process_with_scratch(&mut zero_input, &mut zero_scratch);
-        zero_dft.process_outofplace_with_scratch(&mut zero_input, &mut zero_output, &mut zero_scratch);
+        zero_dft.process_outofplace_with_scratch(
+            &mut zero_input,
+            &mut zero_output,
+            &mut zero_scratch,
+        );
     }
 
     /// Returns true if our `dft` function calculates the given output from the
@@ -211,7 +221,8 @@ mod unit_tests {
             let mut inplace_with_scratch_buffer = input.to_vec();
             let mut inplace_scratch = vec![Zero::zero(); dft_instance.get_inplace_scratch_len()];
 
-            dft_instance.process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
+            dft_instance
+                .process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
 
             assert!(
                 compare_vectors(&expected_output, &inplace_with_scratch_buffer),
@@ -225,7 +236,8 @@ mod unit_tests {
             }
             inplace_with_scratch_buffer.copy_from_slice(&input);
 
-            dft_instance.process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
+            dft_instance
+                .process_with_scratch(&mut inplace_with_scratch_buffer, &mut inplace_scratch);
 
             assert!(
                 compare_vectors(&expected_output, &inplace_with_scratch_buffer),
@@ -239,7 +251,11 @@ mod unit_tests {
             let mut outofplace_input = input.to_vec();
             let mut outofplace_output = expected_output.to_vec();
 
-            dft_instance.process_outofplace_with_scratch(&mut outofplace_input, &mut outofplace_output, &mut []);
+            dft_instance.process_outofplace_with_scratch(
+                &mut outofplace_input,
+                &mut outofplace_output,
+                &mut [],
+            );
 
             assert!(
                 compare_vectors(&expected_output, &outofplace_output),

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -6,10 +6,10 @@ use num_integer::Integer;
 use strength_reduce::StrengthReducedUsize;
 use transpose;
 
+use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, FftDirection};
 use crate::{Direction, Fft, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::array_utils;
 
 /// Implementation of the [Good-Thomas Algorithm (AKA Prime Factor Algorithm)](https://en.wikipedia.org/wiki/Prime-factor_FFT_algorithm)
 ///
@@ -413,7 +413,8 @@ impl<T: FftNum> GoodThomasAlgorithmSmall<T> {
         unsafe { array_utils::transpose_small(self.width, self.height, scratch, buffer) };
 
         // run FFTs of size 'height'
-        self.height_size_fft.process_outofplace_with_scratch(buffer, scratch, &mut []);
+        self.height_size_fft
+            .process_outofplace_with_scratch(buffer, scratch, &mut []);
 
         // copy to the output, using our output redordeing mapping
         for (input_element, &output_index) in scratch.iter().zip(output_map.iter()) {

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 use num_complex::Complex;
 use transpose;
 
+use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles, FftDirection};
 use crate::{Direction, Fft, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::array_utils;
 
 /// Implementation of the Mixed-Radix FFT algorithm
 ///
@@ -273,7 +273,8 @@ impl<T: FftNum> MixedRadixSmall<T> {
         unsafe { array_utils::transpose_small(self.height, self.width, scratch, buffer) };
 
         // STEP 5: perform FFTs of size `width`
-        self.width_size_fft.process_outofplace_with_scratch(buffer, scratch, &mut []);
+        self.width_size_fft
+            .process_outofplace_with_scratch(buffer, scratch, &mut []);
 
         // STEP 6: transpose again
         unsafe { array_utils::transpose_small(self.width, self.height, scratch, buffer) };

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -5,9 +5,9 @@ use num_complex::Complex;
 use transpose;
 
 use crate::{common::FftNum, twiddles, FftDirection};
-
-use crate::array_utils;
 use crate::{Direction, Fft, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::array_utils;
 
 /// Implementation of the Mixed-Radix FFT algorithm
 ///
@@ -19,10 +19,8 @@ use crate::{Direction, Fft, Length};
 /// use rustfft::algorithm::MixedRadix;
 /// use rustfft::{Fft, FftPlanner};
 /// use rustfft::num_complex::Complex;
-/// use rustfft::num_traits::Zero;
 ///
-/// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1200];
-/// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1200];
+/// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1200];
 ///
 /// // we need to find an n1 and n2 such that n1 * n2 == 1200
 /// // n1 = 30 and n2 = 40 satisfies this
@@ -32,7 +30,7 @@ use crate::{Direction, Fft, Length};
 ///
 /// // the mixed radix FFT length will be inner_fft_n1.len() * inner_fft_n2.len() = 1200
 /// let fft = MixedRadix::new(inner_fft_n1, inner_fft_n2);
-/// fft.process(&mut input, &mut output);
+/// fft.process(&mut buffer);
 /// ~~~
 pub struct MixedRadix<T> {
     twiddles: Box<[Complex<T>]>,
@@ -119,7 +117,7 @@ impl<T: FftNum> MixedRadix<T> {
             &mut buffer[..]
         };
         self.height_size_fft
-            .process_inplace_multi(scratch, height_scratch);
+            .process_with_scratch(scratch, height_scratch);
 
         // STEP 3: Apply twiddle factors
         for (element, twiddle) in scratch.iter_mut().zip(self.twiddles.iter()) {
@@ -131,7 +129,7 @@ impl<T: FftNum> MixedRadix<T> {
 
         // STEP 5: perform FFTs of size `width`
         self.width_size_fft
-            .process_multi(buffer, scratch, inner_scratch);
+            .process_outofplace_with_scratch(buffer, scratch, inner_scratch);
 
         // STEP 6: transpose again
         transpose::transpose(scratch, buffer, self.width, self.height);
@@ -155,7 +153,7 @@ impl<T: FftNum> MixedRadix<T> {
             &mut input[..]
         };
         self.height_size_fft
-            .process_inplace_multi(output, height_scratch);
+            .process_with_scratch(output, height_scratch);
 
         // STEP 3: Apply twiddle factors
         for (element, twiddle) in output.iter_mut().zip(self.twiddles.iter()) {
@@ -172,7 +170,7 @@ impl<T: FftNum> MixedRadix<T> {
             &mut output[..]
         };
         self.width_size_fft
-            .process_inplace_multi(input, width_scratch);
+            .process_with_scratch(input, width_scratch);
 
         // STEP 6: transpose again
         transpose::transpose(input, output, self.width, self.height);
@@ -197,12 +195,10 @@ boilerplate_fft!(
 /// use rustfft::algorithm::butterflies::{Butterfly5, Butterfly8};
 /// use rustfft::{Fft, FftDirection};
 /// use rustfft::num_complex::Complex;
-/// use rustfft::num_traits::Zero;
 ///
 /// let len = 40;
 ///
-/// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); len];
-/// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); len];
+/// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; len];
 ///
 /// // we need to find an n1 and n2 such that n1 * n2 == 40
 /// // n1 = 5 and n2 = 8 satisfies this
@@ -211,7 +207,7 @@ boilerplate_fft!(
 ///
 /// // the mixed radix FFT length will be inner_fft_n1.len() * inner_fft_n2.len() = 40
 /// let fft = MixedRadixSmall::new(inner_fft_n1, inner_fft_n2);
-/// fft.process(&mut input, &mut output);
+/// fft.process(&mut buffer);
 /// ~~~
 pub struct MixedRadixSmall<T> {
     twiddles: Box<[Complex<T>]>,
@@ -266,7 +262,7 @@ impl<T: FftNum> MixedRadixSmall<T> {
         unsafe { array_utils::transpose_small(self.width, self.height, buffer, scratch) };
 
         // STEP 2: perform FFTs of size `height`
-        self.height_size_fft.process_inplace_multi(scratch, buffer);
+        self.height_size_fft.process_with_scratch(scratch, buffer);
 
         // STEP 3: Apply twiddle factors
         for (element, twiddle) in scratch.iter_mut().zip(self.twiddles.iter()) {
@@ -277,7 +273,7 @@ impl<T: FftNum> MixedRadixSmall<T> {
         unsafe { array_utils::transpose_small(self.height, self.width, scratch, buffer) };
 
         // STEP 5: perform FFTs of size `width`
-        self.width_size_fft.process_multi(buffer, scratch, &mut []);
+        self.width_size_fft.process_outofplace_with_scratch(buffer, scratch, &mut []);
 
         // STEP 6: transpose again
         unsafe { array_utils::transpose_small(self.width, self.height, scratch, buffer) };
@@ -294,7 +290,7 @@ impl<T: FftNum> MixedRadixSmall<T> {
         unsafe { array_utils::transpose_small(self.width, self.height, input, output) };
 
         // STEP 2: perform FFTs of size `height`
-        self.height_size_fft.process_inplace_multi(output, input);
+        self.height_size_fft.process_with_scratch(output, input);
 
         // STEP 3: Apply twiddle factors
         for (element, twiddle) in output.iter_mut().zip(self.twiddles.iter()) {
@@ -305,7 +301,7 @@ impl<T: FftNum> MixedRadixSmall<T> {
         unsafe { array_utils::transpose_small(self.height, self.width, output, input) };
 
         // STEP 5: perform FFTs of size `width`
-        self.width_size_fft.process_inplace_multi(input, output);
+        self.width_size_fft.process_with_scratch(input, output);
 
         // STEP 6: transpose again
         unsafe { array_utils::transpose_small(self.width, self.height, input, output) };

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -6,11 +6,11 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
-use crate::{common::FftNum, twiddles, FftDirection};
-use crate::math_utils;
-use crate::{Direction, Fft, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::math_utils;
+use crate::{common::FftNum, twiddles, FftDirection};
+use crate::{Direction, Fft, Length};
 
 /// Implementation of Rader's Algorithm
 ///
@@ -147,8 +147,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
         } else {
             &mut input[..]
         };
-        self.inner_fft
-            .process_with_scratch(output, inner_scratch);
+        self.inner_fft.process_with_scratch(output, inner_scratch);
 
         // multiply the inner result with our cached setup data
         // also conjugate every entry. this sets us up to do an inverse FFT
@@ -167,8 +166,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
         } else {
             &mut output[..]
         };
-        self.inner_fft
-            .process_with_scratch(input, inner_scratch);
+        self.inner_fft.process_with_scratch(input, inner_scratch);
 
         // copy the final values into the output, reordering as we go
         let mut output_index = 1;
@@ -200,8 +198,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
         } else {
             &mut buffer[..]
         };
-        self.inner_fft
-            .process_with_scratch(scratch, inner_scratch);
+        self.inner_fft.process_with_scratch(scratch, inner_scratch);
 
         // multiply the inner result with our cached setup data
         // also conjugate every entry. this sets us up to do an inverse FFT
@@ -211,8 +208,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
         }
 
         // execute the second FFT
-        self.inner_fft
-            .process_with_scratch(scratch, inner_scratch);
+        self.inner_fft.process_with_scratch(scratch, inner_scratch);
 
         // copy the final values into the output, reordering as we go
         let mut output_index = 1;

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -7,9 +7,10 @@ use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
 use crate::{common::FftNum, twiddles, FftDirection};
-
 use crate::math_utils;
 use crate::{Direction, Fft, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::array_utils;
 
 /// Implementation of Rader's Algorithm
 ///
@@ -24,17 +25,15 @@ use crate::{Direction, Fft, Length};
 /// use rustfft::algorithm::RadersAlgorithm;
 /// use rustfft::{Fft, FftPlanner};
 /// use rustfft::num_complex::Complex;
-/// use rustfft::num_traits::Zero;
 ///
-/// let mut input:  Vec<Complex<f32>> = vec![Zero::zero(); 1201];
-/// let mut output: Vec<Complex<f32>> = vec![Zero::zero(); 1201];
+/// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1201];
 ///
 /// // plan a FFT of size n - 1 = 1200
 /// let mut planner = FftPlanner::new();
 /// let inner_fft = planner.plan_fft_forward(1200);
 ///
 /// let fft = RadersAlgorithm::new(inner_fft);
-/// fft.process(&mut input, &mut output);
+/// fft.process(&mut buffer);
 /// ~~~
 ///
 /// Rader's Algorithm is relatively expensive compared to other FFT algorithms. Benchmarking shows that it is up to
@@ -104,7 +103,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
 
         //precompute a FFT of our reordered twiddle factors
         let mut inner_fft_scratch = vec![Zero::zero(); required_inner_scratch];
-        inner_fft.process_inplace_with_scratch(&mut inner_fft_input, &mut inner_fft_scratch);
+        inner_fft.process_with_scratch(&mut inner_fft_input, &mut inner_fft_scratch);
 
         Self {
             inner_fft,
@@ -149,7 +148,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
             &mut input[..]
         };
         self.inner_fft
-            .process_inplace_with_scratch(output, inner_scratch);
+            .process_with_scratch(output, inner_scratch);
 
         // multiply the inner result with our cached setup data
         // also conjugate every entry. this sets us up to do an inverse FFT
@@ -169,7 +168,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
             &mut output[..]
         };
         self.inner_fft
-            .process_inplace_with_scratch(input, inner_scratch);
+            .process_with_scratch(input, inner_scratch);
 
         // copy the final values into the output, reordering as we go
         let mut output_index = 1;
@@ -202,7 +201,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
             &mut buffer[..]
         };
         self.inner_fft
-            .process_inplace_with_scratch(scratch, inner_scratch);
+            .process_with_scratch(scratch, inner_scratch);
 
         // multiply the inner result with our cached setup data
         // also conjugate every entry. this sets us up to do an inverse FFT
@@ -213,7 +212,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
 
         // execute the second FFT
         self.inner_fft
-            .process_inplace_with_scratch(scratch, inner_scratch);
+            .process_with_scratch(scratch, inner_scratch);
 
         // copy the final values into the output, reordering as we go
         let mut output_index = 1;

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
+use crate::algorithm::butterflies::{Butterfly1, Butterfly16, Butterfly2, Butterfly4, Butterfly8};
+use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{
     array_utils::{RawSlice, RawSliceMut},
     common::FftNum,
     twiddles, FftDirection,
 };
-use crate::algorithm::butterflies::{Butterfly1, Butterfly16, Butterfly2, Butterfly4, Butterfly8};
 use crate::{Direction, Fft, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::array_utils;
 
 /// FFT algorithm optimized for power-of-two sizes
 ///

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -139,3 +139,57 @@ mod unit_tests {
         }
     }
 }
+
+// Loop over exact chunks of the provided buffer. Very similar in semantics to ChunksExactMut, but generates smaller code and requires no modulo operations
+// Returns Ok() if every element ended up in a chunk, Err() if there was a remainder
+pub fn iter_chunks<T>(mut buffer: &mut [T], chunk_size: usize, mut chunk_fn: impl FnMut(&mut [T])) -> Result<(), ()> {
+    // Loop over the buffer, splicing off chunk_size at a time, and calling chunk_fn on each
+    while buffer.len() >= chunk_size {
+        let (head, tail) = buffer.split_at_mut(chunk_size);
+        buffer = tail;
+
+        chunk_fn(head);
+    }
+
+    // We have a remainder if there's data still in the buffer -- in which case we want to indicate to the caller that there was an unwanted remainder
+    if buffer.len() == 0 {
+        Ok(())
+    }
+    else {
+        Err(())
+    }
+}
+
+// Loop over exact zipped chunks of the 2 provided buffers. Very similar in semantics to ChunksExactMut.zip(ChunksExactMut), but generates smaller code and requires no modulo operations
+// Returns Ok() if every element of both buffers ended up in a chunk, Err() if there was a remainder
+pub fn iter_chunks_zipped<T>(mut buffer1: &mut [T], mut buffer2: &mut [T], chunk_size: usize, mut chunk_fn: impl FnMut(&mut [T], &mut [T])) -> Result<(), ()> {
+    // If the two buffers aren't the same size, record the fact that they're different, then snip them to be the same size
+    let uneven = if buffer1.len() > buffer2.len() {
+        buffer1 = &mut buffer1[..buffer2.len()];
+        true
+    } else if buffer2.len() < buffer1.len() {
+        buffer2 = &mut buffer2[..buffer1.len()];
+        true
+    } else {
+        false
+    };
+
+    // Now that we know the two slices are the same length, loop over each one, splicing off chunk_size at a time, and calling chunk_fn on each
+    while buffer1.len() >= chunk_size && buffer2.len() >= chunk_size {
+        let (head1, tail1) = buffer1.split_at_mut(chunk_size);
+        buffer1 = tail1;
+
+        let (head2, tail2) = buffer2.split_at_mut(chunk_size);
+        buffer2 = tail2;
+
+        chunk_fn(head1, head2);
+    }
+
+    // We have a remainder if the 2 chunks were uneven to start with, or if there's still data in the buffers -- in which case we want to indicate to the caller that there was an unwanted remainder
+    if !uneven && buffer1.len() == 0 {
+        Ok(())
+    }
+    else {
+        Err(())
+    }
+}

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -142,7 +142,11 @@ mod unit_tests {
 
 // Loop over exact chunks of the provided buffer. Very similar in semantics to ChunksExactMut, but generates smaller code and requires no modulo operations
 // Returns Ok() if every element ended up in a chunk, Err() if there was a remainder
-pub fn iter_chunks<T>(mut buffer: &mut [T], chunk_size: usize, mut chunk_fn: impl FnMut(&mut [T])) -> Result<(), ()> {
+pub fn iter_chunks<T>(
+    mut buffer: &mut [T],
+    chunk_size: usize,
+    mut chunk_fn: impl FnMut(&mut [T]),
+) -> Result<(), ()> {
     // Loop over the buffer, splicing off chunk_size at a time, and calling chunk_fn on each
     while buffer.len() >= chunk_size {
         let (head, tail) = buffer.split_at_mut(chunk_size);
@@ -154,15 +158,19 @@ pub fn iter_chunks<T>(mut buffer: &mut [T], chunk_size: usize, mut chunk_fn: imp
     // We have a remainder if there's data still in the buffer -- in which case we want to indicate to the caller that there was an unwanted remainder
     if buffer.len() == 0 {
         Ok(())
-    }
-    else {
+    } else {
         Err(())
     }
 }
 
 // Loop over exact zipped chunks of the 2 provided buffers. Very similar in semantics to ChunksExactMut.zip(ChunksExactMut), but generates smaller code and requires no modulo operations
 // Returns Ok() if every element of both buffers ended up in a chunk, Err() if there was a remainder
-pub fn iter_chunks_zipped<T>(mut buffer1: &mut [T], mut buffer2: &mut [T], chunk_size: usize, mut chunk_fn: impl FnMut(&mut [T], &mut [T])) -> Result<(), ()> {
+pub fn iter_chunks_zipped<T>(
+    mut buffer1: &mut [T],
+    mut buffer2: &mut [T],
+    chunk_size: usize,
+    mut chunk_fn: impl FnMut(&mut [T], &mut [T]),
+) -> Result<(), ()> {
     // If the two buffers aren't the same size, record the fact that they're different, then snip them to be the same size
     let uneven = if buffer1.len() > buffer2.len() {
         buffer1 = &mut buffer1[..buffer2.len()];
@@ -188,8 +196,7 @@ pub fn iter_chunks_zipped<T>(mut buffer1: &mut [T], mut buffer2: &mut [T], chunk
     // We have a remainder if the 2 chunks were uneven to start with, or if there's still data in the buffers -- in which case we want to indicate to the caller that there was an unwanted remainder
     if !uneven && buffer1.len() == 0 {
         Ok(())
-    }
-    else {
+    } else {
         Err(())
     }
 }

--- a/src/avx/avx32_butterflies.rs
+++ b/src/avx/avx32_butterflies.rs
@@ -5,10 +5,9 @@ use std::mem::MaybeUninit;
 use num_complex::Complex;
 
 use crate::{common::FftNum, twiddles};
-
 use crate::{Direction, Fft, FftDirection, Length};
-
 use crate::array_utils;
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 
 use super::avx32_utils;
 use super::avx_vector;
@@ -37,106 +36,57 @@ macro_rules! boilerplate_fft_simd_butterfly {
         }
 
         impl<T: FftNum> Fft<T> for $struct_name<f32> {
-            fn process_with_scratch(
+            fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
                 output: &mut [Complex<T>],
                 _scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    input.len(),
-                    self.len(),
-                    "Input is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    output.len(),
-                    self.len(),
-                    "Output is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    output.len()
-                );
-
-                unsafe {
-                    // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
-                    let input_slice = RawSlice::<Complex<f32>>::new_transmuted(input);
-                    let output_slice = RawSliceMut::<Complex<f32>>::new_transmuted(output);
-                    self.perform_fft_f32(input_slice, output_slice);
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
-            }
-            fn process_multi(
-                &self,
-                input: &mut [Complex<T>],
-                output: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
-                assert!(
-                    input.len() % self.len() == 0,
-                    "Output is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    input.len(),
-                    output.len(),
-                    "Output is the wrong length. input = {} output = {}",
-                    input.len(),
-                    output.len()
-                );
 
-                for (in_chunk, out_chunk) in input
-                    .chunks_exact_mut(self.len())
-                    .zip(output.chunks_exact_mut(self.len()))
-                {
+                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| {
                     unsafe {
                         // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
                         let input_slice = RawSlice::<Complex<f32>>::new_transmuted(in_chunk);
                         let output_slice = RawSliceMut::<Complex<f32>>::new_transmuted(out_chunk);
                         self.perform_fft_f32(input_slice, output_slice);
                     }
+                });
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
-            fn process_inplace_with_scratch(
+            fn process_with_scratch(
                 &self,
                 buffer: &mut [Complex<T>],
                 _scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    buffer.len(),
-                    self.len(),
-                    "Buffer is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
-                unsafe {
-                    // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
-                    let input_slice = RawSlice::<Complex<f32>>::new_transmuted(buffer);
-                    let output_slice = RawSliceMut::<Complex<f32>>::new_transmuted(buffer);
-                    self.perform_fft_f32(input_slice, output_slice);
+                if buffer.len() < self.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), 0, 0);
+                    return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
-            }
-            fn process_inplace_multi(
-                &self,
-                buffer: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
-                assert_eq!(
-                    buffer.len() % self.len(),
-                    0,
-                    "Buffer is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
 
-                for chunk in buffer.chunks_exact_mut(self.len()) {
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
                     unsafe {
                         // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
                         let input_slice = RawSlice::<Complex<f32>>::new_transmuted(chunk);
                         let output_slice = RawSliceMut::<Complex<f32>>::new_transmuted(chunk);
                         self.perform_fft_f32(input_slice, output_slice);
                     }
+                });
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), 0, 0);
                 }
             }
             #[inline(always)]
@@ -213,112 +163,56 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             }
         }
         impl<T: FftNum> Fft<T> for $struct_name<f32> {
-            fn process_with_scratch(
+            fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
                 output: &mut [Complex<T>],
                 _scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    input.len(),
-                    self.len(),
-                    "Input is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    output.len(),
-                    self.len(),
-                    "Output is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    output.len()
-                );
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
 
                 // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
                 let transmuted_input: &mut [Complex<f32>] =
                     unsafe { array_utils::workaround_transmute_mut(input) };
                 let transmuted_output: &mut [Complex<f32>] =
                     unsafe { array_utils::workaround_transmute_mut(output) };
+                let result = array_utils::iter_chunks_zipped(transmuted_input, transmuted_output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk));
 
-                self.perform_fft_out_of_place(transmuted_input, transmuted_output);
-            }
-            fn process_multi(
-                &self,
-                input: &mut [Complex<T>],
-                output: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
-                assert!(
-                    input.len() % self.len() == 0,
-                    "Output is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    input.len(),
-                    output.len(),
-                    "Output is the wrong length. input = {} output = {}",
-                    input.len(),
-                    output.len()
-                );
-
-                // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
-                let transmuted_input: &mut [Complex<f32>] =
-                    unsafe { array_utils::workaround_transmute_mut(input) };
-                let transmuted_output: &mut [Complex<f32>] =
-                    unsafe { array_utils::workaround_transmute_mut(output) };
-
-                for (in_chunk, out_chunk) in transmuted_input
-                    .chunks_exact_mut(self.len())
-                    .zip(transmuted_output.chunks_exact_mut(self.len()))
-                {
-                    self.perform_fft_out_of_place(in_chunk, out_chunk);
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
-            fn process_inplace_with_scratch(
+            fn process_with_scratch(
                 &self,
                 buffer: &mut [Complex<T>],
                 scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    buffer.len(),
-                    self.len(),
-                    "Buffer is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
+                let required_scratch = self.len();
+                if scratch.len() < required_scratch || buffer.len() < self.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), self.len(), scratch.len());
+                    return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
+                }
 
-                assert!(scratch.len() >= $len);
-                let scratch = &mut scratch[..$len];
+                let scratch = &mut scratch[..required_scratch];
 
                 // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
                 let transmuted_buffer: &mut [Complex<f32>] =
                     unsafe { array_utils::workaround_transmute_mut(buffer) };
                 let transmuted_scratch: &mut [Complex<f32>] =
                     unsafe { array_utils::workaround_transmute_mut(scratch) };
+                let result = array_utils::iter_chunks(transmuted_buffer, self.len(), |chunk| self.perform_fft_inplace(chunk, transmuted_scratch));
 
-                self.perform_fft_inplace(transmuted_buffer, transmuted_scratch);
-            }
-            fn process_inplace_multi(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
-                assert_eq!(
-                    buffer.len() % self.len(),
-                    0,
-                    "Buffer is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
-                assert!(scratch.len() >= $len);
-                let scratch = &mut scratch[..$len];
-
-                // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
-                let transmuted_buffer: &mut [Complex<f32>] =
-                    unsafe { array_utils::workaround_transmute_mut(buffer) };
-                let transmuted_scratch: &mut [Complex<f32>] =
-                    unsafe { array_utils::workaround_transmute_mut(scratch) };
-
-                for chunk in transmuted_buffer.chunks_exact_mut(self.len()) {
-                    self.perform_fft_inplace(chunk, transmuted_scratch);
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), self.len(), scratch.len());
                 }
             }
             #[inline(always)]

--- a/src/avx/avx64_butterflies.rs
+++ b/src/avx/avx64_butterflies.rs
@@ -4,10 +4,10 @@ use std::mem::MaybeUninit;
 
 use num_complex::Complex;
 
-use crate::{common::FftNum, twiddles};
-use crate::{Direction, Fft, FftDirection, Length};
 use crate::array_utils;
 use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::{common::FftNum, twiddles};
+use crate::{Direction, Fft, FftDirection, Length};
 
 use super::avx64_utils;
 use super::avx_vector;
@@ -46,14 +46,20 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
 
-                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| {
-                    unsafe {
-                        // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
-                        let input_slice = RawSlice::<Complex<f64>>::new_transmuted(in_chunk);
-                        let output_slice = RawSliceMut::<Complex<f64>>::new_transmuted(out_chunk);
-                        self.perform_fft_f64(input_slice, output_slice);
-                    }
-                });
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        unsafe {
+                            // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
+                            let input_slice = RawSlice::<Complex<f64>>::new_transmuted(in_chunk);
+                            let output_slice =
+                                RawSliceMut::<Complex<f64>>::new_transmuted(out_chunk);
+                            self.perform_fft_f64(input_slice, output_slice);
+                        }
+                    },
+                );
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
@@ -61,11 +67,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
-            fn process_with_scratch(
-                &self,
-                buffer: &mut [Complex<T>],
-                _scratch: &mut [Complex<T>],
-            ) {
+            fn process_with_scratch(&self, buffer: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {
                 if buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
                     fft_error_inplace(self.len(), buffer.len(), 0, 0);
@@ -180,7 +182,12 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     unsafe { array_utils::workaround_transmute_mut(input) };
                 let transmuted_output: &mut [Complex<f64>] =
                     unsafe { array_utils::workaround_transmute_mut(output) };
-                let result = array_utils::iter_chunks_zipped(transmuted_input, transmuted_output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk));
+                let result = array_utils::iter_chunks_zipped(
+                    transmuted_input,
+                    transmuted_output,
+                    self.len(),
+                    |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk),
+                );
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
@@ -188,11 +195,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
-            fn process_with_scratch(
-                &self,
-                buffer: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
+            fn process_with_scratch(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
                 let required_scratch = self.len();
                 if scratch.len() < required_scratch || buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
@@ -207,7 +210,9 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     unsafe { array_utils::workaround_transmute_mut(buffer) };
                 let transmuted_scratch: &mut [Complex<f64>] =
                     unsafe { array_utils::workaround_transmute_mut(scratch) };
-                let result = array_utils::iter_chunks(transmuted_buffer, self.len(), |chunk| self.perform_fft_inplace(chunk, transmuted_scratch));
+                let result = array_utils::iter_chunks(transmuted_buffer, self.len(), |chunk| {
+                    self.perform_fft_inplace(chunk, transmuted_scratch)
+                });
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -5,9 +5,9 @@ use num_complex::Complex;
 use num_integer::div_ceil;
 use num_traits::Zero;
 
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{array_utils, twiddles, FftDirection};
 use crate::{Direction, Fft, FftNum, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
 
 use super::CommonSimdData;
 use super::{

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -7,6 +7,7 @@ use num_traits::Zero;
 
 use crate::{array_utils, twiddles, FftDirection};
 use crate::{Direction, Fft, FftNum, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 
 use super::CommonSimdData;
 use super::{
@@ -106,7 +107,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
             let transmuted_input: &mut [Complex<T>] =
                 array_utils::workaround_transmute_mut(&mut inner_fft_input);
 
-            inner_fft.process_inplace_with_scratch(transmuted_input, &mut inner_fft_scratch);
+            inner_fft.process_with_scratch(transmuted_input, &mut inner_fft_scratch);
         }
 
         // When computing the FFT, we'll want this array to be pre-conjugated, so conjugate it now
@@ -280,7 +281,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
         // run our inner forward FFT
         self.common_data
             .inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // Multiply our inner FFT output by our precomputed data. Then, conjugate the result to set up for an inverse FFT.
         // We can conjugate the result of multiplication by conjugating both inputs. We pre-conjugated the multiplier array,
@@ -299,7 +300,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
         // inverse FFT. we're computing a forward but we're massaging it into an inverse by conjugating the inputs and outputs
         self.common_data
             .inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // finalize the result
         unsafe {
@@ -335,7 +336,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
         // run our inner forward FFT
         self.common_data
             .inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // Multiply our inner FFT output by our precomputed data. Then, conjugate the result to set up for an inverse FFT.
         // We can conjugate the result of multiplication by conjugating both inputs. We pre-conjugated the multiplier array,
@@ -354,7 +355,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
         // inverse FFT. we're computing a forward but we're massaging it into an inverse by conjugating the inputs and outputs
         self.common_data
             .inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // finalize the result
         unsafe {

--- a/src/avx/avx_mixed_radix.rs
+++ b/src/avx/avx_mixed_radix.rs
@@ -5,8 +5,8 @@ use num_complex::Complex;
 use num_integer::div_ceil;
 
 use crate::array_utils;
-use crate::{Direction, Fft, FftDirection, FftNum, Length};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::{Direction, Fft, FftDirection, FftNum, Length};
 
 use super::{AvxNum, CommonSimdData};
 
@@ -50,9 +50,11 @@ macro_rules! boilerplate_mixedradix {
 
             // process the row FFTs
             let (scratch, inner_scratch) = scratch.split_at_mut(self.len());
-            self.common_data
-                .inner_fft
-                .process_outofplace_with_scratch(buffer, scratch, inner_scratch);
+            self.common_data.inner_fft.process_outofplace_with_scratch(
+                buffer,
+                scratch,
+                inner_scratch,
+            );
 
             // Transpose
             // Safety: self.transpose() requres the "avx" instruction set, and we return Err() in our constructor if the instructions aren't available

--- a/src/avx/avx_mixed_radix.rs
+++ b/src/avx/avx_mixed_radix.rs
@@ -6,6 +6,7 @@ use num_integer::div_ceil;
 
 use crate::array_utils;
 use crate::{Direction, Fft, FftDirection, FftNum, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 
 use super::{AvxNum, CommonSimdData};
 
@@ -51,7 +52,7 @@ macro_rules! boilerplate_mixedradix {
             let (scratch, inner_scratch) = scratch.split_at_mut(self.len());
             self.common_data
                 .inner_fft
-                .process_multi(buffer, scratch, inner_scratch);
+                .process_outofplace_with_scratch(buffer, scratch, inner_scratch);
 
             // Transpose
             // Safety: self.transpose() requres the "avx" instruction set, and we return Err() in our constructor if the instructions aren't available
@@ -91,7 +92,7 @@ macro_rules! boilerplate_mixedradix {
             };
             self.common_data
                 .inner_fft
-                .process_inplace_multi(input, inner_scratch);
+                .process_with_scratch(input, inner_scratch);
 
             // Transpose
             // Safety: self.transpose() requres the "avx" instruction set, and we return Err() in our constructor if the instructions aren't available

--- a/src/avx/avx_planner.rs
+++ b/src/avx/avx_planner.rs
@@ -95,7 +95,7 @@ impl MixedRadixPlan {
 ///     let fft = planner.plan_fft_forward(1234);
 ///
 ///     let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1234];
-///     fft.process_inplace(&mut buffer);
+///     fft.process(&mut buffer);
 ///
 ///     // The FFT instance returned by the planner has the type `Arc<dyn Fft<T>>`,
 ///     // where T is the numeric type, ie f32 or f64, so it's cheap to clone
@@ -875,10 +875,8 @@ impl<A: AvxNum, T: FftNum> AvxPlannerInternal<A, T> {
                 // try to construct our AVX2 rader's algorithm. If that fails (probably because the machine we're running on doesn't have AVX2), fall back to scalar
                 let raders_instance =
                     if let Ok(raders_avx) = RadersAvx2::<A, T>::new(Arc::clone(&inner_fft)) {
-                        dbg!("constructing avx2 raders");
                         wrap_fft(raders_avx)
                     } else {
-                        dbg!("constructing scalar raders");
                         wrap_fft(RadersAlgorithm::new(inner_fft))
                     };
 

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -11,6 +11,7 @@ use strength_reduce::StrengthReducedUsize;
 use crate::{array_utils, FftDirection};
 use crate::{math_utils, twiddles};
 use crate::{Direction, Fft, FftNum, Length};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 
 use super::avx_vector;
 use super::{
@@ -179,7 +180,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
 
         //precompute a FFT of our reordered twiddle factors
         let mut inner_fft_scratch = vec![Zero::zero(); required_inner_scratch];
-        inner_fft.process_inplace_with_scratch(&mut inner_fft_input, &mut inner_fft_scratch);
+        inner_fft.process_with_scratch(&mut inner_fft_input, &mut inner_fft_scratch);
 
         // When computing the FFT, we'll want this array to be pre-conjugated, so conjugate it. at the same time, convert it to vectors for convenient use later.
         let conjugation_mask =
@@ -400,7 +401,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
             &mut inner_input[..]
         };
         self.inner_fft
-            .process_inplace_with_scratch(inner_output, inner_scratch);
+            .process_with_scratch(inner_output, inner_scratch);
 
         // multiply the inner result with our cached setup data
         // also conjugate every entry. this sets us up to do an inverse FFT
@@ -425,7 +426,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
             &mut inner_output[..]
         };
         self.inner_fft
-            .process_inplace_with_scratch(inner_input, inner_scratch);
+            .process_with_scratch(inner_input, inner_scratch);
 
         // copy the final values into the output, reordering as we go
         unsafe {
@@ -457,7 +458,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
             &mut buffer[..]
         };
         self.inner_fft
-            .process_inplace_with_scratch(truncated_scratch, inner_scratch);
+            .process_with_scratch(truncated_scratch, inner_scratch);
 
         // multiply the inner result with our cached setup data
         // also conjugate every entry. this sets us up to do an inverse FFT
@@ -471,7 +472,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
 
         // execute the second FFT
         self.inner_fft
-            .process_inplace_with_scratch(truncated_scratch, inner_scratch);
+            .process_with_scratch(truncated_scratch, inner_scratch);
 
         // copy the final values into the output, reordering as we go
         unsafe {

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -8,10 +8,10 @@ use num_traits::Zero;
 use primal_check::miller_rabin;
 use strength_reduce::StrengthReducedUsize;
 
+use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{array_utils, FftDirection};
 use crate::{math_utils, twiddles};
 use crate::{Direction, Fft, FftNum, Length};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
 
 use super::avx_vector;
 use super::{

--- a/src/avx/mod.rs
+++ b/src/avx/mod.rs
@@ -37,40 +37,70 @@ macro_rules! boilerplate_avx_fft {
                 scratch: &mut [Complex<T>],
             ) {
                 let required_scratch = self.get_out_of_place_scratch_len();
-                if scratch.len() < required_scratch || input.len() < self.len() || output.len() != input.len() {
+                if scratch.len() < required_scratch
+                    || input.len() < self.len()
+                    || output.len() != input.len()
+                {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_out_of_place_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk, scratch));
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        self.perform_fft_out_of_place(in_chunk, out_chunk, scratch)
+                    },
+                );
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len())
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_out_of_place_scratch_len(),
+                        scratch.len(),
+                    )
                 }
             }
-            fn process_with_scratch(
-                &self,
-                buffer: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
+            fn process_with_scratch(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
                 let required_scratch = self.get_inplace_scratch_len();
                 if scratch.len() < required_scratch || buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| self.perform_fft_inplace(chunk, scratch));
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                    self.perform_fft_inplace(chunk, scratch)
+                });
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len())
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    )
                 }
             }
             #[inline(always)]
@@ -111,26 +141,44 @@ macro_rules! boilerplate_avx_fft_commondata {
                 }
 
                 let required_scratch = self.get_out_of_place_scratch_len();
-                if scratch.len() < required_scratch || input.len() < self.len() || output.len() != input.len() {
+                if scratch.len() < required_scratch
+                    || input.len() < self.len()
+                    || output.len() != input.len()
+                {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_out_of_place_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk, scratch));
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        self.perform_fft_out_of_place(in_chunk, out_chunk, scratch)
+                    },
+                );
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_out_of_place_scratch_len(),
+                        scratch.len(),
+                    );
                 }
             }
-            fn process_with_scratch(
-                &self,
-                buffer: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
+            fn process_with_scratch(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
                 if self.len() == 0 {
                     return;
                 }
@@ -138,17 +186,29 @@ macro_rules! boilerplate_avx_fft_commondata {
                 let required_scratch = self.get_inplace_scratch_len();
                 if scratch.len() < required_scratch || buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| self.perform_fft_inplace(chunk, scratch));
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                    self.perform_fft_inplace(chunk, scratch)
+                });
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                 }
             }
             #[inline(always)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,21 +10,64 @@ impl<T> FftNum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debu
 // Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods
 #[cold]
 #[inline(never)]
-pub fn fft_error_inplace(expected_len: usize, actual_len: usize, expected_scratch: usize, actual_scratch: usize) {
-    assert!(actual_len >= expected_len, "Provided FFT buffer was too small. Expected len = {}, got len = {}", expected_len, actual_len);
-    assert_eq!(actual_len % expected_len, 0, "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}", expected_len, actual_len);
-    assert!(actual_scratch >= expected_scratch, "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}", expected_scratch, actual_scratch);
+pub fn fft_error_inplace(
+    expected_len: usize,
+    actual_len: usize,
+    expected_scratch: usize,
+    actual_scratch: usize,
+) {
+    assert!(
+        actual_len >= expected_len,
+        "Provided FFT buffer was too small. Expected len = {}, got len = {}",
+        expected_len,
+        actual_len
+    );
+    assert_eq!(
+        actual_len % expected_len,
+        0,
+        "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}",
+        expected_len,
+        actual_len
+    );
+    assert!(
+        actual_scratch >= expected_scratch,
+        "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}",
+        expected_scratch,
+        actual_scratch
+    );
 }
 
 // Prints an error raised by an in-place FFT algorithm's `process_inplace` method
 // Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods
 #[cold]
 #[inline(never)]
-pub fn fft_error_outofplace(expected_len: usize, actual_input: usize, actual_output: usize, expected_scratch: usize, actual_scratch: usize) {
+pub fn fft_error_outofplace(
+    expected_len: usize,
+    actual_input: usize,
+    actual_output: usize,
+    expected_scratch: usize,
+    actual_scratch: usize,
+) {
     assert_eq!(actual_input, actual_output, "Provided FFT input buffer and output buffer must have the same length. Got input.len() = {}, output.len() = {}", actual_input, actual_output);
-    assert!(actual_input >= expected_len, "Provided FFT buffer was too small. Expected len = {}, got len = {}", expected_len, actual_input);
-    assert_eq!(actual_input % expected_len, 0, "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}", expected_len, actual_input);
-    assert!(actual_scratch >= expected_scratch, "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}", expected_scratch, actual_scratch);
+    assert!(
+        actual_input >= expected_len,
+        "Provided FFT buffer was too small. Expected len = {}, got len = {}",
+        expected_len,
+        actual_input
+    );
+    assert_eq!(
+        actual_input % expected_len,
+        0,
+        "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}",
+        expected_len,
+        actual_input
+    );
+    assert!(
+        actual_scratch >= expected_scratch,
+        "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}",
+        expected_scratch,
+        actual_scratch
+    );
 }
 
 macro_rules! boilerplate_fft_oop {
@@ -39,14 +82,21 @@ macro_rules! boilerplate_fft_oop {
                 if self.len() == 0 {
                     return;
                 }
-                
+
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
                     fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                     return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
 
-                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk, &mut []));
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        self.perform_fft_out_of_place(in_chunk, out_chunk, &mut [])
+                    },
+                );
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
@@ -54,19 +104,20 @@ macro_rules! boilerplate_fft_oop {
                     fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
-            fn process_with_scratch(
-                &self,
-                buffer: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
+            fn process_with_scratch(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
                 if self.len() == 0 {
                     return;
                 }
-                
+
                 let required_scratch = self.get_inplace_scratch_len();
                 if scratch.len() < required_scratch || buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
 
@@ -79,7 +130,12 @@ macro_rules! boilerplate_fft_oop {
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                 }
             }
             #[inline(always)]
@@ -120,26 +176,44 @@ macro_rules! boilerplate_fft {
                 }
 
                 let required_scratch = self.get_out_of_place_scratch_len();
-                if scratch.len() < required_scratch || input.len() < self.len() || output.len() != input.len() {
+                if scratch.len() < required_scratch
+                    || input.len() < self.len()
+                    || output.len() != input.len()
+                {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_out_of_place_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk, scratch));
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        self.perform_fft_out_of_place(in_chunk, out_chunk, scratch)
+                    },
+                );
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_out_of_place_scratch_len(),
+                        scratch.len(),
+                    );
                 }
             }
-            fn process_with_scratch(
-                &self,
-                buffer: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
+            fn process_with_scratch(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
                 if self.len() == 0 {
                     return;
                 }
@@ -147,17 +221,29 @@ macro_rules! boilerplate_fft {
                 let required_scratch = self.get_inplace_scratch_len();
                 if scratch.len() < required_scratch || buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                     return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| self.perform_fft_inplace(chunk, scratch));
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                    self.perform_fft_inplace(chunk, scratch)
+                });
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    fft_error_inplace(
+                        self.len(),
+                        buffer.len(),
+                        self.get_inplace_scratch_len(),
+                        scratch.len(),
+                    );
                 }
             }
             #[inline(always)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,162 +6,80 @@ pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static 
 
 impl<T> FftNum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
 
-// impl FftNum for f32 {
-// 	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, direction: FftDirection) -> Complex<Self> {
-// 		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
-// 		let angle = constant * index;
+// Prints an error raised by an in-place FFT algorithm's `process_inplace` method
+// Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods
+#[cold]
+#[inline(never)]
+pub fn fft_error_inplace(expected_len: usize, actual_len: usize, expected_scratch: usize, actual_scratch: usize) {
+    assert!(actual_len >= expected_len, "Provided FFT buffer was too small. Expected len = {}, got len = {}", expected_len, actual_len);
+    assert_eq!(actual_len % expected_len, 0, "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}", expected_len, actual_len);
+    assert!(actual_scratch >= expected_scratch, "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}", expected_scratch, actual_scratch);
+}
 
-// 	    let result = Complex {
-// 	    	re: angle.cos() as f32,
-// 	    	im: angle.sin() as f32,
-// 	    };
-
-// 	    if inverse {
-// 	    	result.conj()
-// 	    } else {
-// 	    	result
-// 	    }
-//     }
-// }
-// impl FftNum for f64 {
-// 	fn generate_twiddle_factor_floatindex(index: f64, fft_len: usize, direction: FftDirection) -> Complex<Self> {
-// 		let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
-// 		let angle = constant * index;
-
-// 	    let result = Complex {
-// 	    	re: angle.cos(),
-// 	    	im: angle.sin(),
-// 	    };
-
-// 	    if inverse {
-// 	    	result.conj()
-// 	    } else {
-// 	    	result
-// 	    }
-//     }
-// }
+// Prints an error raised by an in-place FFT algorithm's `process_inplace` method
+// Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods
+#[cold]
+#[inline(never)]
+pub fn fft_error_outofplace(expected_len: usize, actual_input: usize, actual_output: usize, expected_scratch: usize, actual_scratch: usize) {
+    assert_eq!(actual_input, actual_output, "Provided FFT input buffer and output buffer must have the same length. Got input.len() = {}, output.len() = {}", actual_input, actual_output);
+    assert!(actual_input >= expected_len, "Provided FFT buffer was too small. Expected len = {}, got len = {}", expected_len, actual_input);
+    assert_eq!(actual_input % expected_len, 0, "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}", expected_len, actual_input);
+    assert!(actual_scratch >= expected_scratch, "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}", expected_scratch, actual_scratch);
+}
 
 macro_rules! boilerplate_fft_oop {
     ($struct_name:ident, $len_fn:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {
-            fn process_with_scratch(
+            fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
                 output: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
+                _scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    input.len(),
-                    self.len(),
-                    "Input is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    output.len(),
-                    self.len(),
-                    "Output is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    output.len()
-                );
+                if self.len() == 0 {
+                    return;
+                }
+                
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
 
-                let required_scratch = self.get_out_of_place_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
+                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk, &mut []));
 
-                let scratch = &mut scratch[..required_scratch];
-
-                self.perform_fft_out_of_place(input, output, scratch);
-            }
-            fn process_multi(
-                &self,
-                input: &mut [Complex<T>],
-                output: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
-                assert!(
-                    input.len() % self.len() == 0,
-                    "Output is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    input.len(),
-                    output.len(),
-                    "Output is the wrong length. input = {} output = {}",
-                    input.len(),
-                    output.len()
-                );
-
-                let required_scratch = self.get_out_of_place_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
-
-                let scratch = &mut scratch[..required_scratch];
-
-                for (in_chunk, out_chunk) in input
-                    .chunks_exact_mut(self.len())
-                    .zip(output.chunks_exact_mut(self.len()))
-                {
-                    self.perform_fft_out_of_place(in_chunk, out_chunk, scratch);
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
-            fn process_inplace_with_scratch(
+            fn process_with_scratch(
                 &self,
                 buffer: &mut [Complex<T>],
                 scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    buffer.len(),
-                    self.len(),
-                    "Buffer is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
+                if self.len() == 0 {
+                    return;
+                }
+                
                 let required_scratch = self.get_inplace_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
+                if scratch.len() < required_scratch || buffer.len() < self.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
+                }
 
                 let scratch = &mut scratch[..required_scratch];
-
-                self.perform_fft_out_of_place(buffer, scratch, &mut []);
-                buffer.copy_from_slice(scratch);
-            }
-            fn process_inplace_multi(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
-                assert_eq!(
-                    buffer.len() % self.len(),
-                    0,
-                    "Buffer is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
-                let required_scratch = self.get_inplace_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
-
-                let scratch = &mut scratch[..required_scratch];
-
-                for chunk in buffer.chunks_exact_mut(self.len()) {
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
                     self.perform_fft_out_of_place(chunk, scratch, &mut []);
                     chunk.copy_from_slice(scratch);
+                });
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
                 }
             }
             #[inline(always)]
@@ -191,122 +109,55 @@ macro_rules! boilerplate_fft_oop {
 macro_rules! boilerplate_fft {
     ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {
-            fn process_with_scratch(
+            fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
                 output: &mut [Complex<T>],
                 scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    input.len(),
-                    self.len(),
-                    "Input is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    output.len(),
-                    self.len(),
-                    "Output is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    output.len()
-                );
+                if self.len() == 0 {
+                    return;
+                }
 
                 let required_scratch = self.get_out_of_place_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
+                if scratch.len() < required_scratch || input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
 
                 let scratch = &mut scratch[..required_scratch];
+                let result = array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| self.perform_fft_out_of_place(in_chunk, out_chunk, scratch));
 
-                self.perform_fft_out_of_place(input, output, scratch);
-            }
-            fn process_multi(
-                &self,
-                input: &mut [Complex<T>],
-                output: &mut [Complex<T>],
-                scratch: &mut [Complex<T>],
-            ) {
-                assert!(
-                    input.len() % self.len() == 0,
-                    "Output is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    input.len()
-                );
-                assert_eq!(
-                    input.len(),
-                    output.len(),
-                    "Output is the wrong length. input = {} output = {}",
-                    input.len(),
-                    output.len()
-                );
-
-                let required_scratch = self.get_out_of_place_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
-
-                let scratch = &mut scratch[..required_scratch];
-
-                for (in_chunk, out_chunk) in input
-                    .chunks_exact_mut(self.len())
-                    .zip(output.chunks_exact_mut(self.len()))
-                {
-                    self.perform_fft_out_of_place(in_chunk, out_chunk, scratch);
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), self.get_out_of_place_scratch_len(), scratch.len());
                 }
             }
-            fn process_inplace_with_scratch(
+            fn process_with_scratch(
                 &self,
                 buffer: &mut [Complex<T>],
                 scratch: &mut [Complex<T>],
             ) {
-                assert_eq!(
-                    buffer.len(),
-                    self.len(),
-                    "Buffer is the wrong length. Expected {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
+                if self.len() == 0 {
+                    return;
+                }
 
                 let required_scratch = self.get_inplace_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
+                if scratch.len() < required_scratch || buffer.len() < self.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
+                    return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
+                }
 
                 let scratch = &mut scratch[..required_scratch];
+                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| self.perform_fft_inplace(chunk, scratch));
 
-                self.perform_fft_inplace(buffer, scratch);
-            }
-            fn process_inplace_multi(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
-                assert_eq!(
-                    buffer.len() % self.len(),
-                    0,
-                    "Buffer is the wrong length. Expected multiple of {}, got {}",
-                    self.len(),
-                    buffer.len()
-                );
-
-                let required_scratch = self.get_inplace_scratch_len();
-                assert!(
-                    scratch.len() >= required_scratch,
-                    "Scratch is the wrong length. Expected {} or greater, got {}",
-                    required_scratch,
-                    scratch.len()
-                );
-
-                let scratch = &mut scratch[..required_scratch];
-
-                for chunk in buffer.chunks_exact_mut(self.len()) {
-                    self.perform_fft_inplace(chunk, scratch);
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_inplace(self.len(), buffer.len(), self.get_inplace_scratch_len(), scratch.len());
                 }
             }
             #[inline(always)]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -33,7 +33,7 @@ enum ChosenFftPlanner<T: FftNum> {
 /// let fft = planner.plan_fft_forward(1234);
 ///
 /// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1234];
-/// fft.process_inplace(&mut buffer);
+/// fft.process(&mut buffer);
 ///
 /// // The FFT instance returned by the planner has the type `Arc<dyn Fft<T>>`,
 /// // where T is the numeric type, ie f32 or f64, so it's cheap to clone
@@ -204,7 +204,7 @@ impl Recipe {
 /// let fft = planner.plan_fft_forward(1234);
 ///
 /// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1234];
-/// fft.process_inplace(&mut buffer);
+/// fft.process(&mut buffer);
 ///
 /// // The FFT instance returned by the planner has the type `Arc<dyn Fft<T>>`,
 /// // where T is the numeric type, ie f32 or f64, so it's cheap to clone

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -82,7 +82,7 @@ pub fn check_fft_algorithm<T: FftNum + Float + SampleUniform>(
     let mut expected_output = reference_input.clone();
     let mut dft_scratch = vec![Zero::zero(); dft.get_inplace_scratch_len()];
     dft.process_with_scratch(&mut expected_output, &mut dft_scratch);
-    
+
     // test process()
     {
         let mut buffer = reference_input.clone();
@@ -119,7 +119,7 @@ pub fn check_fft_algorithm<T: FftNum + Float + SampleUniform>(
             buffer.copy_from_slice(&reference_input);
 
             fft.process_with_scratch(&mut buffer, &mut scratch);
-            
+
             assert!(compare_vectors(&expected_output, &buffer), "process_with_scratch() failed the 'dirty scratch' test, length = {}, direction = {}", len, direction);
         }
     }
@@ -147,7 +147,7 @@ pub fn check_fft_algorithm<T: FftNum + Float + SampleUniform>(
             input.copy_from_slice(&reference_input);
 
             fft.process_outofplace_with_scratch(&mut input, &mut output, &mut scratch);
-            
+
             assert!(
                 compare_vectors(&expected_output, &output),
                 "process_outofplace_with_scratch() failed the 'dirty scratch' test, length = {}, direction = {}",

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -52,7 +52,10 @@ fn fft_matches_control<T: FftNum + Float>(control: Arc<dyn Fft<T>>, input: &[Com
         "FFTplanner created FFT of wrong direction"
     );
 
-    let scratch_max = std::cmp::max(control.get_inplace_scratch_len(), fft.get_inplace_scratch_len());
+    let scratch_max = std::cmp::max(
+        control.get_inplace_scratch_len(),
+        fft.get_inplace_scratch_len(),
+    );
     let mut scratch = vec![Zero::zero(); scratch_max];
 
     control.process_with_scratch(&mut control_input, &mut scratch);


### PR DESCRIPTION
This refactor has several benefits:
* Through my experience working with the updated Fft trait methods, I've concluded that the inplace API is significantly more ergonomic than the out-of-place version - to the point that I think most users will never touch it. If that's the case, then we should make the inplace API require less typing than an API that users will never use. I kept the out-of-place API around, because it's useful internally, but it's been renamed.
* The Fft trait used to have 6 different FFT computation methods that all did different things. now it has only 3. This will make RustFFT's public API easier to understand.
* The reduced number of Fft trait methods significantly reduces binary size
    * On top of that, I optimized the implementations of the remaining methods to have much smaller compiled code size
    * Overall, the bench_rustfft binary drops in size from 1723kb to 1452kb as a result of this PR, which seems like a pretty massive win.
* Reduced API surface means there's less to test