### PR TITLE
Implement real FFT

### DIFF
--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -3,19 +3,27 @@
 use std::sync::Arc;
 use std::thread;
 
-use rustfft::num_complex::Complex32;
 use rustfft::FftPlanner;
+use rustfft::FftRealToComplex;
+use rustfft::{algorithm::real_to_complex::RealToComplexEven, num_complex::Complex32};
 
 fn main() {
     let mut planner = FftPlanner::new();
     let fft = planner.plan_fft_forward(100);
-
+    let fft2 = Arc::new(RealToComplexEven::new(Arc::clone(&fft)));
     let threads: Vec<thread::JoinHandle<_>> = (0..2)
         .map(|_| {
             let fft_copy = Arc::clone(&fft);
+            let fft2_copy = Arc::clone(&fft2);
             thread::spawn(move || {
                 let mut buffer = vec![Complex32::new(0.0, 0.0); 100];
                 fft_copy.process(&mut buffer);
+
+                let mut input = vec![0.0; 100];
+                let mut output = vec![Complex32::new(0.0, 0.0); 51];
+                let mut scratch = vec![0.0; fft2_copy.get_scratch_len()];
+
+                fft2_copy.process(&mut input, &mut output, &mut scratch);
             })
         })
         .collect();

--- a/src/algorithm/dht.rs
+++ b/src/algorithm/dht.rs
@@ -1,0 +1,516 @@
+use array_utils::into_real_mut;
+use num_complex::Complex;
+use num_traits::Zero;
+
+use crate::{FftDirection, array_utils};
+
+fn w(index: usize, len: usize, direction: FftDirection) -> Complex<f32> {
+    let constant = -2f32 * std::f32::consts::PI / len as f32;
+    let angle = index as f32 * constant;
+    let twiddle = Complex::from_polar(1f32, angle);
+
+    match direction {
+        FftDirection::Forward => twiddle,
+        FftDirection::Inverse => twiddle.conj(),
+    }
+}
+
+#[allow(unused)]
+fn compute_dft_twiddle_inverse(index: usize, len: usize) -> Complex<f32> {
+    let constant = 2f32 * std::f32::consts::PI / len as f32;
+    let angle = index as f32 * constant;
+    let twiddle = Complex::from_polar(1f32, angle);
+
+    twiddle
+}
+
+fn cas(index: usize, len: usize) -> f32 {
+    let constant = 2f32 * std::f32::consts::PI / len as f32;
+    let angle = index as f32 * constant;
+    angle.cos() + angle.sin()
+}
+
+#[allow(unused)]
+fn compute_dft(buffer: &mut [Complex<f32>]) {
+    let mut scratch = buffer.to_vec();
+
+    for (k, spec_bin) in buffer.iter_mut().enumerate() {
+        let mut sum = Zero::zero();
+        for (i, &x) in scratch.iter().enumerate() {
+            let twiddle = w(i*k, scratch.len(), FftDirection::Forward);
+
+            sum = sum + twiddle * x;
+        }
+        *spec_bin = sum;
+    }
+}
+
+#[allow(unused)]
+fn compute_r2c(input: &[f32], output: &mut [Complex<f32>]) {
+    assert_eq!(output.len(), input.len() / 2 + 1);
+
+    for (k, spec_bin) in output.iter_mut().enumerate() {
+        let mut sum = Zero::zero();
+        for (i, &x) in input.iter().enumerate() {
+            let twiddle = w(i*k, input.len(), FftDirection::Forward);
+
+            sum = sum + twiddle * x;
+        }
+        *spec_bin = sum;
+    }
+}
+#[allow(unused)]
+fn compute_c2r(input: &mut [Complex<f32>], output: &mut [f32]) {
+    assert_eq!(input.len(), output.len() / 2 + 1);
+    let len = output.len();
+
+    let mut full_input = vec![Zero::zero(); len];
+    (&mut full_input[..input.len()]).copy_from_slice(input);
+
+    let unfilled_slots = full_input.len() - input.len();
+    for (i, e) in input.iter().enumerate().skip(1).take(unfilled_slots) {
+        full_input[len - i] = e.conj();
+    }
+
+    for (k, spec_bin) in output.iter_mut().enumerate() {
+        let mut sum = 0.0;
+        for (i, &x) in full_input.iter().enumerate() {
+            let twiddle = w(i*k, len, FftDirection::Forward);
+
+            sum = sum + (twiddle * x).re;
+        }
+        *spec_bin = sum;
+    }
+}
+fn compute_dht(buffer: &mut [f32]) {
+    let scratch = buffer.to_vec();
+
+    for (n, output_cell) in buffer.iter_mut().enumerate() {
+        let mut output_value = 0.0;
+        for (k, input_cell) in scratch.iter().enumerate() {
+            let twiddle = cas(n*k, scratch.len());
+            
+            output_value += *input_cell * twiddle;
+        }
+        *output_cell = output_value;
+    }
+}
+
+// Computes a DFT of real-only input by converting the problem to a DHT
+#[allow(unused)]
+fn compute_r2c_via_dht(input: &mut [f32], output: &mut [Complex<f32>]) {
+    assert_eq!(output.len(), input.len() / 2 + 1);
+
+    compute_dht(input);
+
+    output[0] = Complex::from(input[0]);
+
+    for (k, output_cell) in output.iter_mut().enumerate().skip(1) {
+        *output_cell = Complex {
+            re: (input[input.len() - k] + input[k]) * 0.5,
+            im: (input[input.len() - k] - input[k]) * 0.5,
+        }
+    }
+}
+
+// Computes a DFT of real-only input by converting the problem to a DHT
+#[allow(unused)]
+fn compute_c2r_via_dht(input: &[Complex<f32>], output: &mut [f32]) {
+    assert_eq!(input.len(), output.len() / 2 + 1);
+
+    output[0] = input[0].re;
+
+    for (k, input_cell) in input.iter().enumerate().skip(1) {
+        output[k]               = (input_cell.re + input_cell.im);
+        output[output.len() - k] = (input_cell.re - input_cell.im);
+    }
+
+    compute_dht(output);
+}
+
+// Computes a DHT by converting the problem to a R2C
+#[allow(unused)]
+fn compute_dht_via_r2c(buffer: &mut [f32]) {
+    let mut scratch = vec![Complex::zero(); buffer.len() / 2 + 1];
+
+    compute_r2c(buffer, &mut scratch);
+
+    buffer[0] = scratch[0].re;
+
+    for (k, scratch_cell) in scratch.iter().enumerate().skip(1) {
+        buffer[k]                   = (scratch_cell.re - scratch_cell.im);
+        buffer[buffer.len() - k]    = (scratch_cell.re + scratch_cell.im);
+    }
+}
+
+// Computes a DHT by converting the problem to a R2C
+#[allow(unused)]
+fn compute_dht_via_c2r(buffer: &mut [f32]) {
+    let mut scratch = vec![Complex::zero(); buffer.len() / 2 + 1];
+
+    scratch[0] = Complex::from(buffer[0]);
+
+    for (k, scratch_cell) in scratch.iter_mut().enumerate().skip(1) {
+        *scratch_cell = Complex {
+            re: (buffer[k] + buffer[buffer.len() - k]) * 0.5,
+            im: (buffer[k] - buffer[buffer.len() - k]) * 0.5,
+        }
+    }
+    
+    compute_c2r(&mut scratch, buffer);
+}
+
+#[allow(unused)]
+fn subtract_mod(a: usize, b: usize, m: usize) -> usize {
+    let a_wrap = a % m;
+    let b_wrap = b % m;
+    let result = if a_wrap >= b_wrap {
+        a_wrap - b_wrap
+    } else {
+        m - (b_wrap - a_wrap)
+    };
+    assert_eq!((b + result) % m, a);
+    result
+}
+
+
+// Computes a DHT via the six-step mixed-radix algorithm
+#[allow(unused)]
+fn compute_dht_mixedradix(buffer: &mut [f32], width: usize, height: usize) {
+    let len = buffer.len();
+    let mut scratch = vec![0.0; len];
+    
+    assert_eq!(len, width * height);
+
+    // Step 1: Transpose the width x height array to height x width
+    transpose::transpose(buffer, &mut scratch, width, height);
+
+    // Step 2: Compute DHTs of size `height` down the rows of our transposed array
+    for chunk in scratch.chunks_exact_mut(height) {
+        compute_dht(chunk);
+    }
+
+    // Step 3: Apply twiddle factors
+    for k in 0..height {
+        // we need -k % height, but k is unsigned, so do it without actual negatives
+        let k_rev = subtract_mod(0, k, height);
+        for i in 0..width {
+            // -i % radix, but i is unsigned, so do it without actual negatives
+            let i_bot = subtract_mod(0, i, width);
+            let top_twiddle = compute_dft_twiddle_inverse(i * k, len);
+            let bot_twiddle = compute_dft_twiddle_inverse(i_bot * k, len);
+            let rev_twiddle = compute_dft_twiddle_inverse(i * k_rev, len);
+            let bot_rev_twiddle = compute_dft_twiddle_inverse(i_bot * k_rev, len);
+
+            // Instead of just multiplying a single input vlaue with a single complex number like we do in the DFT,
+            // we need to combine 4 numbers, determined by mirroring the input number across the horizontal and vertical axes of the array
+            let top_fwd = scratch[i*height + k];
+            let top_rev = scratch[i*height + k_rev];
+            let bot_fwd = scratch[i_bot*height + k];
+            let bot_rev = scratch[i_bot*height + k_rev];
+
+            // Since we're overwriting data that our mirrored input values will need whenthey compute their own twiddles,
+            // we currently can't apply twiddles inplace. An obvious optimization here is to compute all 4 values at once and write them all out at once.
+            // That would cut down on the number of flops by 75%, and would let us do this inplace
+            buffer[i*height + k] = 0.5 * (
+                  top_fwd * top_twiddle.re
+                - top_fwd * top_twiddle.im
+                + top_rev * top_twiddle.re
+                + top_rev * top_twiddle.im
+                + bot_fwd * bot_twiddle.re
+                + bot_fwd * bot_twiddle.im
+                - bot_rev * bot_twiddle.re
+                + bot_rev * bot_twiddle.im
+            );
+        }
+    }
+
+    // Step 4: Transpose the height x width array back to width x height
+    transpose::transpose(&buffer, &mut scratch, height, width);
+
+    // Step 5: Compute DHTs of size `width` down the rows of the array
+    for chunk in scratch.chunks_exact_mut(width) {
+        compute_dht(chunk);
+    }
+
+    // Step 6: Transpose the width x height array to height x width one lst time
+    transpose::transpose(&scratch, buffer, width, height);
+}
+
+#[allow(unused)]
+fn compute_r2c_mixedradix(input: &mut [f32], output: &mut [Complex<f32>], radix: usize) {
+    assert_eq!(output.len(), input.len() / 2 + 1);
+
+    let width = radix;
+    assert!(input.len() % width == 0);
+    let height = input.len() / width;
+    let complex_height = height / 2 + 1;
+
+    let mut complex_scratch = vec![Complex::zero(); complex_height * width];
+    let mut complex_scratch2 = vec![Complex::zero(); complex_height * width];
+
+    let temp_transpose = &mut into_real_mut(output)[..input.len()];
+    transpose::transpose(&input, temp_transpose, width, height);
+
+    for (i, (in_chunk, out_chunk)) in temp_transpose.chunks_exact_mut(height).zip(complex_scratch.chunks_exact_mut(complex_height)).enumerate() {
+        compute_r2c(in_chunk, out_chunk);
+
+        for k in 0..out_chunk.len() {
+            out_chunk[k] = out_chunk[k] * w(i*k, input.len(), FftDirection::Forward);
+        }
+    }
+
+    transpose::transpose(&complex_scratch, &mut complex_scratch2, complex_height, width);
+    for chunk in complex_scratch2.chunks_exact_mut(width) {
+        compute_dft(chunk);
+    }
+
+    let mut indexes = vec![0; output.len()];
+    dbg!(complex_scratch2.len());
+
+    // step 6: transpose. Slightly different than the normal transpose, since we have to work around the fact that some of the data is missing
+    for i in 0..output.len() {
+        let x = i % height;
+        let y = i / height;
+
+        let scratch_index = x * width + y;
+        if let Some(element) = complex_scratch2.get(scratch_index) {
+            output[i] = *element;
+            indexes[i] = scratch_index as isize;
+        } else {
+            let reverse_scratch_index = (height - x) * width + (width - y - 1);
+            output[i] = complex_scratch2[reverse_scratch_index].conj();
+            indexes[i] = -(reverse_scratch_index as isize);
+        }
+    }
+
+    for chunk in indexes.chunks(radix) {
+        for index in chunk.iter() {
+            print!("{:>5}", index);
+        }
+        println!();
+    }
+}
+
+
+
+
+
+
+#[cfg(test)]
+mod unit_tests {
+    use num_complex::Complex;
+    use num_traits::Zero;
+
+    use super::*;
+
+    use crate::{Fft, test_utils::{compare_real_vectors, random_signal}};
+
+    use crate::{FftDirection, algorithm::Dft, test_utils::{compare_vectors, random_real_signal}};
+
+    #[test]
+    fn test_r2c() {
+        for len in 1..10 {
+            let control = Dft::new(len, FftDirection::Forward);
+            let real_input = random_real_signal(len);
+            let mut control_input: Vec<Complex<f32>> = real_input.iter().map(Complex::from).collect();
+
+            let mut real_output = vec![Zero::zero(); len/2 + 1];
+
+            control.process(&mut control_input);
+            compute_r2c(&real_input, &mut real_output);
+
+            assert!(compare_vectors(&control_input[..len/2 + 1], &real_output));
+        }
+    }
+
+    #[test]
+    fn test_c2r() {
+        for len in 1..10 {
+            let control = Dft::new(len, FftDirection::Forward);
+
+            let mut real_input = random_signal(len/2 + 1);
+            real_input[0].im = 0.0;
+            real_input.last_mut().unwrap().im = 0.0;
+            let mut complex_input = real_input.clone();
+
+            if len%2 == 0 {
+                for i in (1..len/2).rev() {
+                    complex_input.push(complex_input[i].conj());
+                }
+            } else {
+                for i in (1..len/2+1).rev() {
+                    complex_input.push(complex_input[i].conj());
+                }
+            }
+
+            control.process(&mut complex_input);
+
+            let mut real_output = vec![0.0; len];
+            compute_c2r(&mut real_input, &mut real_output);
+
+            let real_output: Vec<_> = real_output.iter().map(Complex::from).collect();
+            if len > 0 {
+                assert!(compare_vectors(&complex_input, &real_output));
+            }
+        }
+    }
+
+    #[test]
+    fn test_r2c_via_dht() {
+        for len in 1..10 {
+            let control = Dft::new(len, FftDirection::Forward);
+            let mut real_input = random_real_signal(len);
+            let mut control_input: Vec<Complex<f32>> = real_input.iter().map(Complex::from).collect();
+
+            let mut real_output = vec![Zero::zero(); len/2 + 1];
+
+            control.process(&mut control_input);
+            compute_r2c_via_dht(&mut real_input, &mut real_output);
+
+            assert!(compare_vectors(&control_input[..len/2 + 1], &real_output));
+        }
+    }
+
+    #[test]
+    fn test_c2r_via_dht() {
+        for len in 1..10 {
+            let control = Dft::new(len, FftDirection::Forward);
+
+            let mut real_input = random_signal(len/2 + 1);
+            real_input[0].im = 0.0;
+            real_input.last_mut().unwrap().im = 0.0;
+            let mut complex_input = real_input.clone();
+
+            if len%2 == 0 {
+                for i in (1..len/2).rev() {
+                    complex_input.push(complex_input[i].conj());
+                }
+            } else {
+                for i in (1..len/2+1).rev() {
+                    complex_input.push(complex_input[i].conj());
+                }
+            }
+
+            control.process(&mut complex_input);
+
+            let mut real_output = vec![0.0; len];
+            compute_c2r_via_dht(&real_input, &mut real_output);
+
+            let real_output: Vec<_> = real_output.iter().map(Complex::from).collect();
+            if len > 0 {
+
+                assert!(compare_vectors(&complex_input, &real_output));
+            }
+        }
+    }
+
+    #[test]
+    fn test_dht_via_r2c() {
+        for len in 1..10 {
+            let mut real_buffer = random_real_signal(len);
+            let mut control_buffer = real_buffer.clone();
+
+            compute_dht(&mut control_buffer);
+            compute_dht_via_r2c(&mut real_buffer);
+
+            assert!(compare_real_vectors(&control_buffer, &real_buffer));
+        }
+    }
+
+    #[test]
+    fn test_dht_via_c2r() {
+        for len in 5..10 {
+            let mut real_buffer = random_real_signal(len);
+            let mut control_buffer = real_buffer.clone();
+
+            compute_dht(&mut control_buffer);
+            compute_dht_via_c2r(&mut real_buffer);
+
+            assert!(compare_real_vectors(&control_buffer, &real_buffer));
+        }
+    }
+
+    #[test]
+    fn test_dht_mixedradix() {
+        for width in 3..4 {
+            for height in 5..6 {
+                let len = height * width;
+                let mut real_buffer = random_real_signal(len);
+                let mut control_buffer = real_buffer.clone();
+
+                compute_dht(&mut control_buffer);
+                compute_dht_mixedradix(&mut real_buffer, width, height);
+
+                assert!(compare_real_vectors(&control_buffer, &real_buffer), "width = {}, height = {}", width, height);
+            }
+        }
+    }
+
+    #[test]
+    fn test_r2c_radix3() {
+        for radix in 3..4 {
+            for height in 10..11 {
+                let len = height * radix;
+                let control = Dft::new(len, FftDirection::Forward);
+                let mut real_input = random_real_signal(len);
+                let mut control_input: Vec<Complex<f32>> = real_input.iter().map(Complex::from).collect();
+
+                let mut real_output = vec![Zero::zero(); len/2 + 1];
+
+                control.process(&mut control_input);
+                compute_r2c_mixedradix(&mut real_input, &mut real_output, radix);
+
+                assert!(compare_vectors(&control_input[..len/2 + 1], &real_output));
+            }
+        }
+    }
+
+
+    fn compute_dht_splitradix(buffer: &mut [f32]) {
+        let scratch = buffer.to_vec();
+        let len = buffer.len();
+        let half_len = len / 2;
+        let quarter_len = len / 4;
+        assert_eq!(len % 4, 0);
+    
+        for (k, output_cell) in buffer.iter_mut().enumerate() {
+            let mut output_value = 0.0;
+            for n in 0..half_len {
+                let twiddle = cas(k*2*n, scratch.len());
+                let input_value = scratch[2*n];
+                
+                output_value += input_value * twiddle;
+            }
+
+            for n in 0..quarter_len {
+                let twiddle = cas(k*(4*n+1), scratch.len());
+                let input_value = scratch[4*n + 1];
+                
+                output_value += input_value * twiddle;
+            }
+
+            for n in 0..quarter_len {
+                let twiddle = cas(k*(4*n+3), scratch.len());
+                let input_value = scratch[4*n + 3];
+                
+                output_value += input_value * twiddle;
+            }
+            *output_cell = output_value;
+        }
+    }
+
+    #[test]
+    fn test_dht_splitradix() {
+        for height in 1..6 {
+            let len = height * 4;
+            let mut real_buffer = random_real_signal(len);
+            let mut control_buffer = real_buffer.clone();
+
+            compute_dht(&mut control_buffer);
+            compute_dht_splitradix(&mut real_buffer);
+
+            assert!(compare_real_vectors(&control_buffer, &real_buffer), "height = {}", height);
+        }
+    }
+}

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -16,3 +16,5 @@ pub use self::good_thomas_algorithm::{GoodThomasAlgorithm, GoodThomasAlgorithmSm
 pub use self::mixed_radix::{MixedRadix, MixedRadixSmall};
 pub use self::raders_algorithm::RadersAlgorithm;
 pub use self::radix4::Radix4;
+
+mod dht;

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -5,6 +5,8 @@ mod mixed_radix;
 mod raders_algorithm;
 mod radix4;
 
+pub mod real_to_complex;
+
 /// Hardcoded size-specfic FFT algorithms
 pub mod butterflies;
 

--- a/src/algorithm/real_to_complex.rs
+++ b/src/algorithm/real_to_complex.rs
@@ -1,0 +1,384 @@
+use std::sync::Arc;
+
+use num_complex::Complex;
+
+use crate::{twiddles, Fft, FftComplexToReal, FftDirection, FftNum, FftRealToComplex, Length};
+
+pub fn into_complex_mut<T>(buffer: &mut [T]) -> &mut [Complex<T>] {
+    let complex_len = buffer.len() / 2;
+    let ptr = buffer.as_mut_ptr() as *mut Complex<T>;
+    unsafe { std::slice::from_raw_parts_mut(ptr, complex_len) }
+}
+pub fn into_real_mut<T>(buffer: &mut [Complex<T>]) -> &mut [T] {
+    let real_len = buffer.len() * 2;
+    let ptr = buffer.as_mut_ptr() as *mut T;
+    unsafe { std::slice::from_raw_parts_mut(ptr, real_len) }
+}
+
+fn zip3<A, B, C>(a: A, b: B, c: C) -> impl Iterator<Item = (A::Item, B::Item, C::Item)>
+where
+    A: IntoIterator,
+    B: IntoIterator,
+    C: IntoIterator,
+{
+    a.into_iter()
+        .zip(b.into_iter().zip(c))
+        .map(|(x, (y, z))| (x, y, z))
+}
+
+/// Processes FFTs with real-only inputs. Restricted to even input sizes.
+pub struct RealToComplexEven<T> {
+    inner_fft: Arc<dyn Fft<T>>,
+    twiddles: Box<[Complex<T>]>,
+
+    len: usize,
+    required_scratch: usize,
+    direction: FftDirection,
+}
+impl<T: FftNum> RealToComplexEven<T> {
+    /// Creates a FFT instance which will process forward FFTs with real-only inputs of size `inner_fft.len() * 2`
+    #[allow(unused)]
+    pub fn new(inner_fft: Arc<dyn Fft<T>>) -> Self {
+        let inner_fft_len = inner_fft.len();
+        let len = inner_fft_len * 2;
+        let direction = inner_fft.fft_direction();
+
+        // Compute our twiddle factors. We only need half as many twiddle factors as our FFT length,
+        // and keep in mind that we're baking a multiply by half into the twiddles
+        let twiddle_count = if inner_fft_len % 2 == 0 {
+            inner_fft_len / 2
+        } else {
+            inner_fft_len / 2 + 1
+        };
+        let half = T::from_f32(0.5).unwrap();
+        let twiddles: Box<[Complex<T>]> = (1..twiddle_count)
+            .map(|i| twiddles::compute_twiddle(i, len, direction) * half)
+            .collect();
+
+        Self {
+            required_scratch: 2 * inner_fft.get_outofplace_scratch_len(),
+
+            inner_fft,
+            twiddles: twiddles,
+
+            len,
+            direction,
+        }
+    }
+}
+impl<T: FftNum> FftRealToComplex<T> for RealToComplexEven<T> {
+    #[inline(never)]
+    fn process(&self, input: &mut [T], output: &mut [Complex<T>], scratch: &mut [T]) {
+        if self.len() == 0 {
+            return;
+        }
+
+        let half = T::from_f32(0.5).unwrap();
+
+        // The simplest part of the process is computing the inner FFT. Just transmute the input and forward it to the FFT
+        {
+            let inner_fft_len = self.len() / 2;
+
+            let input_complex = into_complex_mut(input);
+            let chopped_output = &mut output[..inner_fft_len];
+            let scratch_complex = into_complex_mut(scratch);
+
+            self.inner_fft.process_outofplace_with_scratch(
+                input_complex,
+                chopped_output,
+                scratch_complex,
+            );
+        }
+
+        // Next step is to apply twiddle factors to our output array, in-place.
+        // The process works by loading 2 elements from opposite ends of the array,
+        // combining them, and writing them back where we found them.
+        // To support reading/writing from opposite ends of the array simultaneously, split the output array in half
+        let (mut output_left, mut output_right) = output.split_at_mut(output.len() / 2);
+
+        // The first and last element don't require any twiddle factors, so skip that work
+        match (output_left.first_mut(), output_right.last_mut()) {
+            (Some(first_element), Some(last_element)) => {
+                // The first and last elements are just a sum and difference of the first value's real and imaginary values
+                let first_value = *first_element;
+                *first_element = Complex {
+                    re: first_value.re + first_value.im,
+                    im: T::zero(),
+                };
+                *last_element = Complex {
+                    re: first_value.re - first_value.im,
+                    im: T::zero(),
+                };
+
+                // Chop the first and last element off of our slices so that the loop below doesn't have to deal with them
+                output_left = &mut output_left[1..];
+                let right_len = output_right.len();
+                output_right = &mut output_right[..right_len - 1];
+            }
+            _ => {
+                return;
+            }
+        }
+
+        // Loop over the remaining elements and apply twiddle factors on them
+        for (twiddle, out, out_rev) in zip3(
+            self.twiddles.iter(),
+            output_left.iter_mut(),
+            output_right.iter_mut().rev(),
+        ) {
+            let sum = *out + *out_rev;
+            let diff = *out - *out_rev;
+
+            // Apply twiddle factors. Theoretically we'd have to load 2 separate twiddle factors here, one for the beginning
+            // and one for the end. But the twiddle factor for the end is jsut the twiddle for the beginning, with the
+            // real part negated. Since it's the same twiddle, we can factor out a ton of math ops and cut the number of
+            // multiplications in half
+            let twiddled_re_sum = sum * twiddle.re;
+            let twiddled_im_sum = sum * twiddle.im;
+            let twiddled_re_diff = diff * twiddle.re;
+            let twiddled_im_diff = diff * twiddle.im;
+            let half_sum_re = half * sum.re;
+            let half_diff_im = half * diff.im;
+
+            let output_twiddled_real = twiddled_re_sum.im + twiddled_im_diff.re;
+            let output_twiddled_im = twiddled_im_sum.im - twiddled_re_diff.re;
+
+            // We finally have all the data we need to write the transformed data back out where we found it
+            *out = Complex {
+                re: half_sum_re + output_twiddled_real,
+                im: half_diff_im + output_twiddled_im,
+            };
+
+            *out_rev = Complex {
+                re: half_sum_re - output_twiddled_real,
+                im: output_twiddled_im - half_diff_im,
+            };
+        }
+
+        // If the output len is odd, the loop above can't postprocess the centermost element, so handle that separately
+        if self.direction == FftDirection::Forward && output.len() % 2 == 1 {
+            if let Some(center_element) = output.get_mut(output.len() / 2) {
+                center_element.im = -center_element.im;
+            }
+        }
+    }
+
+    fn get_scratch_len(&self) -> usize {
+        self.required_scratch
+    }
+}
+impl<T> Length for RealToComplexEven<T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+/// Processes FFTs with real-only outputs. Restricted to even input sizes.
+pub struct ComplexToRealEven<T> {
+    inner_fft: Arc<dyn Fft<T>>,
+    twiddles: Box<[Complex<T>]>,
+
+    len: usize,
+    required_scratch: usize,
+    direction: FftDirection,
+}
+impl<T: FftNum> ComplexToRealEven<T> {
+    /// Creates a FFT instance which will process FFTs of size `inner_fft.len() * 2`, with real-only outputs
+    #[allow(unused)]
+    pub fn new(inner_fft: Arc<dyn Fft<T>>) -> Self {
+        let inner_fft_len = inner_fft.len();
+        let len = inner_fft_len * 2;
+        let direction = inner_fft.fft_direction();
+
+        // Compute our twiddle factors. We only need half as many twiddle factors as our FFT length,
+        // and keep in mind that we're baking a multiply by half into the twiddles
+        let twiddle_count = inner_fft_len;
+        let twiddles: Box<[Complex<T>]> = (0..twiddle_count)
+            .map(|i| twiddles::compute_twiddle(i, len, direction))
+            .collect();
+
+        Self {
+            required_scratch: 2 * inner_fft.get_outofplace_scratch_len(),
+
+            inner_fft,
+            twiddles: twiddles,
+
+            len,
+            direction,
+        }
+    }
+}
+impl<T: FftNum> FftComplexToReal<T> for ComplexToRealEven<T> {
+    #[inline(never)]
+    fn process(&self, input: &mut [Complex<T>], output: &mut [T], scratch: &mut [T]) {
+        if self.len() == 0 {
+            return;
+        }
+
+        let inner_fft_len = self.len() / 2;
+        assert_eq!(input.len(), self.len() / 2 + 1);
+        assert_eq!(output.len(), self.len());
+        assert!(scratch.len() >= self.get_scratch_len());
+
+        // We have to preprocess the input in-place before we send it to the FFT.
+        // The first and centermost values have to be preprocessed separately from the rest, so do that now
+        {
+            let last_value = input[input.len() - 1];
+            let first_value = input[0];
+            let first_sum = first_value + last_value;
+            let first_diff = first_value - last_value;
+
+            input[0] = Complex {
+                re: first_sum.re - first_sum.im,
+                im: first_diff.re - first_diff.im,
+            };
+        }
+
+        // now, in a loop, preprocess the rest of the elements 2 at a time
+        let chopped_input = &mut input[1..inner_fft_len];
+        let (input_left, input_right) = chopped_input.split_at_mut(chopped_input.len() / 2);
+
+        for (twiddle, fft_input, fft_input_rev) in zip3(
+            (&self.twiddles[1..]).iter(),
+            input_left.iter_mut(),
+            input_right.iter_mut().rev(),
+        ) {
+            let sum = *fft_input + *fft_input_rev;
+            let diff = *fft_input - *fft_input_rev;
+
+            // Apply twiddle factors. Theoretically we'd have to load 2 separate twiddle factors here, one for the beginning
+            // and one for the end. But the twiddle factor for the end is jsut the twiddle for the beginning, with the
+            // real part negated. Since it's the same twiddle, we can factor out a ton of math ops and cut the number of
+            // multiplications in half
+            let twiddled_re_sum = sum * twiddle.re;
+            let twiddled_im_sum = sum * twiddle.im;
+            let twiddled_re_diff = diff * twiddle.re;
+            let twiddled_im_diff = diff * twiddle.im;
+
+            // We finally have all the data we need to write our preprocessed data back where we got it from
+            *fft_input = Complex {
+                re: sum.re - twiddled_re_sum.im - twiddled_im_diff.re,
+                im: diff.im + twiddled_re_diff.re - twiddled_im_sum.im,
+            };
+
+            *fft_input_rev = Complex {
+                re: sum.re + twiddled_re_sum.im + twiddled_im_diff.re,
+                im: twiddled_re_diff.re - twiddled_im_sum.im - diff.im,
+            }
+        }
+
+        // If the output len is odd, the loop above can't preprocess the centermost element, so handle that separately
+        if input.len() % 2 == 1 {
+            let center_element = input[input.len() / 2];
+            let doubled = center_element + center_element;
+            input[input.len() / 2] = match self.direction {
+                FftDirection::Forward => doubled,
+                FftDirection::Inverse => doubled.conj(),
+            };
+        }
+
+        // The only theing left to do is compute the FFT.
+        // The data is in `input`, and we want it in `output`, so do an out of place transform to get it there
+        let complex_output = into_complex_mut(output);
+        let complex_scratch = into_complex_mut(scratch);
+        self.inner_fft.process_outofplace_with_scratch(
+            &mut input[..inner_fft_len],
+            complex_output,
+            complex_scratch,
+        );
+    }
+
+    fn get_scratch_len(&self) -> usize {
+        self.required_scratch
+    }
+}
+impl<T> Length for ComplexToRealEven<T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::{
+        algorithm::Dft,
+        test_utils::{compare_vectors, random_real_signal, random_signal},
+        FftDirection,
+    };
+    use num_traits::Zero;
+
+    #[test]
+    fn test_r2c_even() {
+        for inner_len in 0..10 {
+            test_r2c_even_with_inner(inner_len, FftDirection::Forward);
+
+            // Note: Even though R2C is usually used with a forward FFT, it was pretty trivial to make it support inverse FFTs.
+            // If there's a compelling performance reason to drop inverse support, go ahead.
+            test_r2c_even_with_inner(inner_len, FftDirection::Inverse);
+        }
+    }
+
+    fn test_r2c_even_with_inner(inner_len: usize, direction: FftDirection) {
+        let inner_fft: Arc<Dft<f32>> = Arc::new(Dft::new(inner_len, direction));
+        let fft = RealToComplexEven::new(inner_fft);
+
+        let control = Dft::new(inner_len * 2, direction);
+
+        let mut real_input = random_real_signal(control.len());
+        let mut complex_input: Vec<Complex<f32>> = real_input.iter().map(Complex::from).collect();
+
+        control.process(&mut complex_input);
+
+        let mut real_output = vec![Complex::zero(); inner_len + 1];
+        let mut scratch = vec![0.0; fft.get_scratch_len()];
+        fft.process(&mut real_input, &mut real_output, &mut scratch);
+
+        if inner_len > 0 {
+            assert!(
+                compare_vectors(&complex_input[..inner_len + 1], &real_output),
+                "process() failed, len = {}, direction = {}",
+                inner_len * 2,
+                direction,
+            );
+        }
+    }
+
+    #[test]
+    fn test_c2r_even() {
+        for inner_len in 0..10 {
+            // Note: Even though C2R is usually used with an inverse FFT, it was pretty trivial to make it support forward FFTs.
+            // If there's a compelling performance reason to drop forward support, go ahead.
+            test_c2r_even_with_inner(inner_len, FftDirection::Forward);
+
+            test_c2r_even_with_inner(inner_len, FftDirection::Inverse);
+        }
+    }
+
+    fn test_c2r_even_with_inner(inner_len: usize, direction: FftDirection) {
+        let inner_fft: Arc<Dft<f32>> = Arc::new(Dft::new(inner_len, direction));
+        let fft = ComplexToRealEven::new(inner_fft);
+
+        let control = Dft::new(inner_len * 2, direction);
+
+        let mut real_input = random_signal(inner_len + 1);
+        real_input[0].im = 0.0;
+        real_input.last_mut().unwrap().im = 0.0;
+        let mut complex_input = real_input.clone();
+
+        for i in (1..complex_input.len() - 1).rev() {
+            complex_input.push(complex_input[i].conj());
+        }
+
+        control.process(&mut complex_input);
+
+        let mut real_output = vec![0.0; inner_len * 2];
+        let mut scratch = vec![0.0; fft.get_scratch_len()];
+        fft.process(&mut real_input, &mut real_output, &mut scratch);
+
+        let real_output: Vec<_> = real_output.iter().map(Complex::from).collect();
+        if inner_len > 0 {
+            assert!(compare_vectors(&complex_input, &real_output));
+        }
+    }
+}

--- a/src/algorithm/real_to_complex.rs
+++ b/src/algorithm/real_to_complex.rs
@@ -255,15 +255,18 @@ impl<T: FftNum> FftComplexToReal<T> for ComplexToRealEven<T> {
             let twiddled_re_diff = diff * twiddle.re;
             let twiddled_im_diff = diff * twiddle.im;
 
+            let output_twiddled_real = twiddled_re_sum.im + twiddled_im_diff.re;
+            let output_twiddled_im = twiddled_im_sum.im - twiddled_re_diff.re;
+
             // We finally have all the data we need to write our preprocessed data back where we got it from
             *fft_input = Complex {
-                re: sum.re - twiddled_re_sum.im - twiddled_im_diff.re,
-                im: diff.im + twiddled_re_diff.re - twiddled_im_sum.im,
+                re: sum.re - output_twiddled_real,
+                im: diff.im - output_twiddled_im,
             };
 
             *fft_input_rev = Complex {
-                re: sum.re + twiddled_re_sum.im + twiddled_im_diff.re,
-                im: twiddled_re_diff.re - twiddled_im_sum.im - diff.im,
+                re: sum.re + output_twiddled_real,
+                im: -output_twiddled_im - diff.im,
             }
         }
 

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -225,3 +225,31 @@ pub fn iter_chunks_zipped<T>(
         Err(())
     }
 }
+
+// Loop over exact zipped chunks of the 2 provided buffers. Very similar in semantics to ChunksExactMut.zip(ChunksExactMut), but generates smaller code and requires no modulo operations
+// Returns Ok() if every element of both buffers ended up in a chunk, Err() if there was a remainder
+pub fn iter_chunks_zipped_r2c<T, U>(
+    mut buffer1: &mut [T],
+    chunk_size_1: usize,
+    mut buffer2: &mut [U],
+    chunk_size_2: usize,
+    mut chunk_fn: impl FnMut(&mut [T], &mut [U]),
+) -> Result<(), ()> {
+    while buffer1.len() >= chunk_size_1 && buffer2.len() >= chunk_size_2 {
+        let (head1, tail1) = buffer1.split_at_mut(chunk_size_1);
+        buffer1 = tail1;
+
+        let (head2, tail2) = buffer2.split_at_mut(chunk_size_2);
+        buffer2 = tail2;
+
+        chunk_fn(head1, head2);
+    }
+
+    // We have a remainder if there's still data in either of the buffers -- in which case we want to indicate to the caller that there was an unwanted remainder
+    if buffer1.len() == 0 && buffer2.len() == 0 {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -1,3 +1,5 @@
+use num_complex::Complex;
+
 /// Given an array of size width * height, representing a flattened 2D array,
 /// transpose the rows and columns of that 2D array into the output
 /// benchmarking shows that loop tiling isn't effective for small arrays (in the range of 50x50 or smaller)
@@ -23,6 +25,29 @@ pub unsafe fn workaround_transmute_mut<T, U>(slice: &mut [T]) -> &mut [U] {
     let ptr = slice.as_mut_ptr() as *mut U;
     let len = slice.len();
     std::slice::from_raw_parts_mut(ptr, len)
+}
+
+pub fn into_complex_mut<T>(buffer: &mut [T]) -> &mut [Complex<T>] {
+    let complex_len = buffer.len() / 2;
+    let ptr = buffer.as_mut_ptr() as *mut Complex<T>;
+    unsafe { std::slice::from_raw_parts_mut(ptr, complex_len) }
+}
+#[allow(unused)]
+pub fn into_real_mut<T>(buffer: &mut [Complex<T>]) -> &mut [T] {
+    let real_len = buffer.len() * 2;
+    let ptr = buffer.as_mut_ptr() as *mut T;
+    unsafe { std::slice::from_raw_parts_mut(ptr, real_len) }
+}
+
+pub fn zip3<A, B, C>(a: A, b: B, c: C) -> impl Iterator<Item = (A::Item, B::Item, C::Item)>
+where
+    A: IntoIterator,
+    B: IntoIterator,
+    C: IntoIterator,
+{
+    a.into_iter()
+        .zip(b.into_iter().zip(c))
+        .map(|(x, (y, z))| (x, y, z))
 }
 
 #[derive(Copy, Clone)]

--- a/src/avx/avx_planner.rs
+++ b/src/avx/avx_planner.rs
@@ -3,12 +3,15 @@ use std::{any::TypeId, cmp::min};
 
 use primal_check::miller_rabin;
 
-use crate::fft_cache::{FftCache, ComplexToRealCache, RealToComplexCache};
-use crate::{FftComplexToReal, FftRealToComplex, algorithm::{real_to_complex::{ComplexToRealEven, RealToComplexEven}}};
+use crate::algorithm::{butterflies::*, Dft, RadersAlgorithm};
 use crate::common::FftNum;
+use crate::fft_cache::{ComplexToRealCache, FftCache, RealToComplexCache};
 use crate::math_utils::PartialFactors;
 use crate::Fft;
-use crate::algorithm::{butterflies::*, Dft, RadersAlgorithm};
+use crate::{
+    algorithm::real_to_complex::{ComplexToRealEven, RealToComplexEven},
+    FftComplexToReal, FftRealToComplex,
+};
 
 use super::*;
 
@@ -204,14 +207,17 @@ impl<T: FftNum> FftPlannerAvx<T> {
                 fft
             } else {
                 let inner_fft = self.plan_fft_forward(len);
-                let fft = Arc::new(RealToComplexEven::new(inner_fft)) as Arc<dyn FftRealToComplex<T>>;
+                let fft =
+                    Arc::new(RealToComplexEven::new(inner_fft)) as Arc<dyn FftRealToComplex<T>>;
 
                 self.r2c_cache.insert(&fft);
 
                 fft
             }
         } else {
-            unimplemented!("Complex-to-real FFTs with off length aren't supported yet, but will be soon.");
+            unimplemented!(
+                "Complex-to-real FFTs with off length aren't supported yet, but will be soon."
+            );
         }
     }
 
@@ -230,14 +236,17 @@ impl<T: FftNum> FftPlannerAvx<T> {
                 fft
             } else {
                 let inner_fft = self.plan_fft_forward(len);
-                let fft = Arc::new(ComplexToRealEven::new(inner_fft)) as Arc<dyn FftComplexToReal<T>>;
+                let fft =
+                    Arc::new(ComplexToRealEven::new(inner_fft)) as Arc<dyn FftComplexToReal<T>>;
 
                 self.c2r_cache.insert(&fft);
 
                 fft
             }
         } else {
-            unimplemented!("Complex-to-real FFTs with off length aren't supported yet, but will be soon.");
+            unimplemented!(
+                "Complex-to-real FFTs with off length aren't supported yet, but will be soon."
+            );
         }
     }
 

--- a/src/avx/avx_real_to_complex.rs
+++ b/src/avx/avx_real_to_complex.rs
@@ -1,0 +1,301 @@
+use std::{any::TypeId, sync::Arc};
+
+use num_complex::Complex;
+use num_integer::div_ceil;
+
+use crate::array_utils::{into_complex_mut, workaround_transmute_mut};
+use crate::{Fft, FftDirection, FftNum, FftRealToComplex, Length};
+
+use super::{
+    avx_vector::{AvxArray, AvxArrayMut, AvxVector, AvxVector256},
+    AvxNum,
+};
+
+/// Processes FFTs with real-only inputs. Restricted to even input sizes.
+pub struct RealToComplexEvenAvx<A: AvxNum, T> {
+    inner_fft: Arc<dyn Fft<T>>,
+    twiddles: Box<[A::VectorType]>,
+
+    len: usize,
+    required_scratch: usize,
+    direction: FftDirection,
+}
+impl<A: AvxNum, T: FftNum> RealToComplexEvenAvx<A, T> {
+    /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the FFT
+    /// Returns Ok() if this machine has the required instruction sets, Err() if some instruction sets are missing
+    #[allow(unused)]
+    #[inline]
+    pub fn new(inner_fft: Arc<dyn Fft<T>>) -> Result<Self, ()> {
+        // Internal sanity check: Make sure that A == T.
+        // This struct has two generic parameters A and T, but they must always be the same, and are only kept separate to help work around the lack of specialization.
+        // It would be cool if we could do this as a static_assert instead
+        let id_a = TypeId::of::<A>();
+        let id_t = TypeId::of::<T>();
+        assert_eq!(id_a, id_t);
+
+        let has_avx = is_x86_feature_detected!("avx");
+        let has_fma = is_x86_feature_detected!("fma");
+        if has_avx && has_fma {
+            // Safety: new_with_avx requires the "avx" feature set. Since we know it's present, we're safe
+            Ok(unsafe { Self::new_with_avx(inner_fft) })
+        } else {
+            Err(())
+        }
+    }
+
+    /// Creates a FFT instance which will process forward FFTs with real-only inputs of size `inner_fft.len() * 2`
+    #[target_feature(enable = "avx")]
+    unsafe fn new_with_avx(inner_fft: Arc<dyn Fft<T>>) -> Self {
+        let inner_fft_len = inner_fft.len();
+        let inner_buffer_len = inner_fft_len + 1;
+        let len = inner_fft_len * 2;
+        let direction = inner_fft.fft_direction();
+
+        // Compute our twiddle factors. We only need half as many twiddle factors as our FFT length,
+        // and keep in mind that we're baking a multiply by half into the twiddles
+        let first_twiddle = if (inner_buffer_len / 2) % 2 == 0 {
+            0
+        } else {
+            1
+        };
+
+        let twiddle_count = if inner_fft_len % 2 == 0 {
+            inner_fft_len / 2 - first_twiddle
+        } else {
+            inner_fft_len / 2 + 1 - first_twiddle
+        };
+
+        let full_twiddle_chunks = div_ceil(twiddle_count, A::VectorType::COMPLEX_PER_VECTOR);
+
+        let twiddles: Box<[A::VectorType]> = (0..full_twiddle_chunks)
+            .map(|i| first_twiddle + i * A::VectorType::COMPLEX_PER_VECTOR)
+            .map(|twiddle_base_index| {
+                let twiddle_chunk = A::VectorType::make_mixedradix_twiddle_chunk(
+                    twiddle_base_index,
+                    1,
+                    len,
+                    direction,
+                );
+                AvxVector::mul(twiddle_chunk, AvxVector::half())
+            })
+            .collect();
+
+        Self {
+            required_scratch: 2 * inner_fft.get_outofplace_scratch_len(),
+
+            inner_fft,
+            twiddles: twiddles,
+
+            len,
+            direction,
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn postprocess_chunk<V: AvxVector>(val_fwd: V, val_rev: V, twiddle: V) -> (V, V) {
+        let val_rev = AvxVector::reverse_complex_elements(val_rev);
+
+        let sum = AvxVector::add(val_fwd, val_rev);
+        let diff = AvxVector::sub(val_fwd, val_rev);
+
+        let (twiddle_re, twiddle_im) = AvxVector::duplicate_complex_components(twiddle);
+        let twiddle_re = twiddle_re.conj();
+
+        // This is unusual - we want to swap the imaginaries in 'sum' with the imaginaries in 'diff'
+        // 'sumdiff' will contain (sum.re, diff.im), and 'diffsum' will contain (diff.re, sum.im)
+        let sumdiff_blended = AvxVector::blend_real_imaginary(sum, diff);
+        let diffsum_blended = AvxVector::blend_real_imaginary(diff, sum);
+        let diffsum_swapped = AvxVector::swap_complex_components(diffsum_blended);
+
+        // Apply twiddle factors. Theoretically we'd have to load 2 separate twiddle factors here, one for the beginning
+        // and one for the end. But the twiddle factor for the end is jsut the twiddle for the beginning, with the
+        // real part negated. Since it's the same twiddle, we can factor out a ton of math ops and cut the number of
+        // multiplications in half
+        let twiddled_diffsum_blended = AvxVector::mul(diffsum_blended, twiddle_im);
+        let twiddled_diffsum_swapped = AvxVector::mul(diffsum_swapped, twiddle_re);
+        let half_sumdiff = AvxVector::mul(sumdiff_blended, AvxVector::half());
+
+        let twiddled_output = AvxVector::add(twiddled_diffsum_blended, twiddled_diffsum_swapped);
+
+        let out_fwd = AvxVector::add(half_sumdiff, twiddled_output);
+        let out_rev = AvxVector::sub(half_sumdiff, twiddled_output).conj();
+        let out_rev = AvxVector::reverse_complex_elements(out_rev);
+
+        (out_fwd, out_rev)
+    }
+
+    #[target_feature(enable = "avx", enable = "fma")]
+    unsafe fn postprocess_output(&self, buffer: &mut [Complex<A>]) {
+        // Next step is to apply twiddle factors to our output array, in-place.
+        // The process works by loading 2 elements from opposite ends of the array,
+        // combining them, and writing them back where we found them.
+        // To support reading/writing from opposite ends of the array simultaneously, split the output array in half
+        let (mut output_left, mut output_right) = buffer.split_at_mut(buffer.len() / 2);
+
+        let special_first_element = output_left.len() % 2 == 1;
+
+        // The first and last element don't require any twiddle factors, so skip that work
+        match (output_left.first_mut(), output_right.last_mut()) {
+            (Some(first_element), Some(last_element)) => {
+                if special_first_element {
+                    // The first and last elements are just a sum and difference of the first value's real and imaginary values
+                    let first_value = *first_element;
+                    *first_element = Complex {
+                        re: first_value.re + first_value.im,
+                        im: A::zero(),
+                    };
+                    *last_element = Complex {
+                        re: first_value.re - first_value.im,
+                        im: A::zero(),
+                    };
+
+                    // Chop the first and last element off of our slices so that the loop below doesn't have to deal with them
+                    output_left = &mut output_left[1..];
+                    let right_len = output_right.len();
+                    output_right = &mut output_right[..right_len - 1];
+                } else {
+                    // Copy the first element to the last element to prepare for the main postprocessing loop below
+                    *last_element = *first_element;
+                }
+            }
+            _ => {
+                return;
+            }
+        }
+
+        let chunk_count = output_left.len() / A::VectorType::COMPLEX_PER_VECTOR;
+        let remainder_count = output_left.len() % A::VectorType::COMPLEX_PER_VECTOR;
+
+        // Loop over the remaining elements and apply twiddle factors on them.
+        // This algorithm is ripped directly from the scalar version of the same struct. Thankfully it maps very cleanly.
+        for (i, twiddle) in (&self.twiddles[..chunk_count]).iter().enumerate() {
+            // We need to load a bunch of elements from the beginning of the array, and a bunch from the end.
+            // In the scalar version, we load the ones fro mthe end in reverse order, so we have to reverse them here
+            let val_rev = output_right
+                .load_complex(output_right.len() - (i + 1) * A::VectorType::COMPLEX_PER_VECTOR);
+            let val_fwd = output_left.load_complex(i * A::VectorType::COMPLEX_PER_VECTOR);
+
+            let (out_fwd, out_rev) = Self::postprocess_chunk(val_fwd, val_rev, *twiddle);
+
+            output_left.store_complex(out_fwd, i * A::VectorType::COMPLEX_PER_VECTOR);
+            output_right.store_complex(
+                out_rev,
+                output_right.len() - (i + 1) * A::VectorType::COMPLEX_PER_VECTOR,
+            );
+        }
+
+        // Our tricks with the first/last element up above meant that we will never have to deal with remainders of 1 or 3. But we may have to deal with a remainder of 2.
+        if remainder_count == 2 {
+            // We need to load a bunch of elements from the beginning of the array, and a bunch from the end.
+            // In the scalar version, we load the ones fro mthe end in reverse order, so we have to reverse them here
+            let val_rev = output_right.load_partial2_complex(
+                output_right.len() - chunk_count * A::VectorType::COMPLEX_PER_VECTOR - 2,
+            );
+            let val_fwd = output_left.load_partial2_complex(output_left.len() - 2);
+            let twiddle = self.twiddles.last().unwrap().lo();
+
+            let (out_fwd, out_rev) = Self::postprocess_chunk(val_fwd, val_rev, twiddle);
+
+            output_left.store_partial2_complex(out_fwd, output_left.len() - 2);
+            output_right.store_partial2_complex(
+                out_rev,
+                output_right.len() - chunk_count * A::VectorType::COMPLEX_PER_VECTOR - 2,
+            );
+        }
+
+        // If the output len is odd, the loop above can't postprocess the centermost element, so handle that separately
+        if self.direction == FftDirection::Forward && buffer.len() % 2 == 1 {
+            if let Some(center_element) = buffer.get_mut(buffer.len() / 2) {
+                center_element.im = -center_element.im;
+            }
+        }
+    }
+}
+impl<A: AvxNum, T: FftNum> FftRealToComplex<T> for RealToComplexEvenAvx<A, T> {
+    fn process(&self, input: &mut [T], output: &mut [Complex<T>], scratch: &mut [T]) {
+        if self.len() == 0 {
+            return;
+        }
+
+        // The simplest part of the process is computing the inner FFT. Just transmute the input and forward it to the FFT
+        {
+            let inner_fft_len = self.len() / 2;
+
+            let input_complex = into_complex_mut(input);
+            let chopped_output = &mut output[..inner_fft_len];
+            let scratch_complex = into_complex_mut(scratch);
+
+            self.inner_fft.process_outofplace_with_scratch(
+                input_complex,
+                chopped_output,
+                scratch_complex,
+            );
+        }
+
+        let output_avx: &mut [Complex<A>] = unsafe { workaround_transmute_mut(output) };
+
+        unsafe { self.postprocess_output(output_avx) };
+    }
+
+    fn get_scratch_len(&self) -> usize {
+        self.required_scratch
+    }
+}
+impl<A: AvxNum, T: FftNum> Length for RealToComplexEvenAvx<A, T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::{
+        algorithm::Dft,
+        test_utils::{compare_vectors, random_real_signal},
+        FftDirection,
+    };
+    use num_traits::{Float, Zero};
+    use rand::distributions::uniform::SampleUniform;
+
+    #[test]
+    fn test_r2c_even_avx() {
+        for inner_len in 0..10 {
+            test_r2c_even_with_inner::<f32>(inner_len, FftDirection::Forward);
+            test_r2c_even_with_inner::<f64>(inner_len, FftDirection::Forward);
+
+            // Note: Even though R2C is usually used with a forward FFT, it was pretty trivial to make it support inverse FFTs.
+            // If there's a compelling performance reason to drop inverse support, go ahead.
+            test_r2c_even_with_inner::<f32>(inner_len, FftDirection::Inverse);
+            test_r2c_even_with_inner::<f64>(inner_len, FftDirection::Inverse);
+        }
+    }
+
+    fn test_r2c_even_with_inner<A: AvxNum + SampleUniform + Float>(
+        inner_len: usize,
+        direction: FftDirection,
+    ) {
+        let inner_fft: Arc<Dft<A>> = Arc::new(Dft::new(inner_len, direction));
+        let fft = RealToComplexEvenAvx::<A, A>::new(inner_fft).unwrap();
+
+        let control = Dft::new(inner_len * 2, direction);
+
+        let mut real_input = random_real_signal(control.len());
+        let mut complex_input: Vec<Complex<A>> = real_input.iter().map(Complex::from).collect();
+
+        control.process(&mut complex_input);
+
+        let mut real_output = vec![Complex::zero(); inner_len + 1];
+        let mut scratch = vec![A::zero(); fft.get_scratch_len()];
+        fft.process(&mut real_input, &mut real_output, &mut scratch);
+
+        if inner_len > 0 {
+            assert!(
+                compare_vectors(&complex_input[..inner_len + 1], &real_output),
+                "process() failed, len = {}, direction = {}",
+                inner_len * 2,
+                direction,
+            );
+        }
+    }
+}

--- a/src/avx/mod.rs
+++ b/src/avx/mod.rs
@@ -247,6 +247,7 @@ mod avx64_utils;
 mod avx_bluesteins;
 mod avx_mixed_radix;
 mod avx_raders;
+mod avx_real_to_complex;
 
 pub mod avx_planner;
 
@@ -272,3 +273,5 @@ pub use self::avx_mixed_radix::{
 };
 pub use self::avx_raders::RadersAvx2;
 use self::avx_vector::AvxVector256;
+
+pub use self::avx_real_to_complex::RealToComplexEvenAvx;

--- a/src/common.rs
+++ b/src/common.rs
@@ -70,6 +70,41 @@ pub fn fft_error_outofplace(
     );
 }
 
+// Prints an error raised by an in-place FFT algorithm's `process_inplace` method
+// Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods
+#[cold]
+#[inline(never)]
+pub fn r2c_error_outofplace(
+    expected_len: usize,
+    actual_input: usize,
+    actual_output: usize,
+    expected_scratch: usize,
+    actual_scratch: usize,
+) {
+    assert!(
+        actual_input >= expected_len,
+        "Provided FFT input was too small. Expected len = {}, got len = {}",
+        expected_len,
+        actual_input
+    );
+    assert_eq!(
+        actual_input % expected_len,
+        0,
+        "Input FFT buffer must be a multiple of FFT length. Expected multiple of {}, got len = {}",
+        expected_len,
+        actual_input
+    );
+    let multiplier = actual_input / expected_len;
+    let single_output = expected_len / 2 + 1;
+    assert_eq!(actual_output, multiplier * single_output);
+    assert!(
+        actual_scratch >= expected_scratch,
+        "Not enough scratch space was provided. Expected scratch len >= {}, got scratch len = {}",
+        expected_scratch,
+        actual_scratch
+    );
+}
+
 macro_rules! boilerplate_fft_oop {
     ($struct_name:ident, $len_fn:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {

--- a/src/fft_cache.rs
+++ b/src/fft_cache.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{Fft, FftDirection};
+use crate::{Fft, FftComplexToReal, FftDirection, FftRealToComplex};
 
 pub(crate) struct FftCache<T> {
     forward_cache: HashMap<usize, Arc<dyn Fft<T>>>,
@@ -37,3 +37,50 @@ impl<T> FftCache<T> {
         };
     }
 }
+
+pub(crate) struct RealToComplexCache<T> {
+    cache: HashMap<usize, Arc<dyn FftRealToComplex<T>>>,
+}
+impl<T> RealToComplexCache<T> {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+    #[allow(unused)]
+    pub fn contains_fft(&self, len: usize) -> bool {
+        self.cache.contains_key(&len)
+    }
+    pub fn get(&self, len: usize) -> Option<Arc<dyn FftRealToComplex<T>>> {
+        self.cache.get(&len).map(Arc::clone)
+    }
+    pub fn insert(&mut self, fft: &Arc<dyn FftRealToComplex<T>>) {
+        let cloned = Arc::clone(fft);
+        let len = cloned.len();
+        self.cache.insert(len, cloned);
+    }
+}
+
+pub(crate) struct ComplexToRealCache<T> {
+    cache: HashMap<usize, Arc<dyn FftComplexToReal<T>>>,
+}
+impl<T> ComplexToRealCache<T> {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+    #[allow(unused)]
+    pub fn contains_fft(&self, len: usize) -> bool {
+        self.cache.contains_key(&len)
+    }
+    pub fn get(&self, len: usize) -> Option<Arc<dyn FftComplexToReal<T>>> {
+        self.cache.get(&len).map(Arc::clone)
+    }
+    pub fn insert(&mut self, fft: &Arc<dyn FftComplexToReal<T>>) {
+        let cloned = Arc::clone(fft);
+        let len = cloned.len();
+        self.cache.insert(len, cloned);
+    }
+}
+

--- a/src/fft_cache.rs
+++ b/src/fft_cache.rs
@@ -83,4 +83,3 @@ impl<T> ComplexToRealCache<T> {
         self.cache.insert(len, cloned);
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ mod fft_cache;
 mod math_utils;
 mod plan;
 mod twiddles;
+pub mod r2c;
 
 use num_complex::Complex;
 use num_traits::Zero;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,18 @@ pub trait Fft<T: FftNum>: Length + Direction + Sync + Send {
     fn get_outofplace_scratch_len(&self) -> usize;
 }
 
+// A FFT with real-only inputs
+pub trait FftRealToComplex<T: FftNum>: Length + Sync + Send {
+    fn process(&self, input: &mut [T], output: &mut [Complex<T>], scratch: &mut [T]);
+    fn get_scratch_len(&self) -> usize;
+}
+
+// A FFT with real-only outputs
+pub trait FftComplexToReal<T: FftNum>: Length + Sync + Send {
+    fn process(&self, input: &mut [Complex<T>], output: &mut [T], scratch: &mut [T]);
+    fn get_scratch_len(&self) -> usize;
+}
+
 // Algorithms implemented to use AVX instructions. Only compiled on x86_64, and only compiled if the "avx" feature flag is set.
 #[cfg(all(target_arch = "x86_64", feature = "avx"))]
 mod avx;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -4,7 +4,12 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::{FftComplexToReal, FftDirection, FftRealToComplex, algorithm::real_to_complex::RealToComplexEven, common::FftNum, fft_cache::{ComplexToRealCache, FftCache, RealToComplexCache}};
+use crate::{
+    algorithm::real_to_complex::RealToComplexEven,
+    common::FftNum,
+    fft_cache::{ComplexToRealCache, FftCache, RealToComplexCache},
+    FftComplexToReal, FftDirection, FftRealToComplex,
+};
 
 use crate::algorithm::butterflies::*;
 use crate::algorithm::*;
@@ -313,14 +318,17 @@ impl<T: FftNum> FftPlannerScalar<T> {
                 fft
             } else {
                 let inner_fft = self.plan_fft_forward(len);
-                let fft = Arc::new(RealToComplexEven::new(inner_fft)) as Arc<dyn FftRealToComplex<T>>;
+                let fft =
+                    Arc::new(RealToComplexEven::new(inner_fft)) as Arc<dyn FftRealToComplex<T>>;
 
                 self.r2c_cache.insert(&fft);
 
                 fft
             }
         } else {
-            unimplemented!("Complex-to-real FFTs with off length aren't supported yet, but will be soon.");
+            unimplemented!(
+                "Complex-to-real FFTs with off length aren't supported yet, but will be soon."
+            );
         }
     }
 
@@ -339,14 +347,17 @@ impl<T: FftNum> FftPlannerScalar<T> {
                 fft
             } else {
                 let inner_fft = self.plan_fft_forward(len);
-                let fft = Arc::new(ComplexToRealEven::new(inner_fft)) as Arc<dyn FftComplexToReal<T>>;
+                let fft =
+                    Arc::new(ComplexToRealEven::new(inner_fft)) as Arc<dyn FftComplexToReal<T>>;
 
                 self.c2r_cache.insert(&fft);
 
                 fft
             }
         } else {
-            unimplemented!("Complex-to-real FFTs with off length aren't supported yet, but will be soon.");
+            unimplemented!(
+                "Complex-to-real FFTs with off length aren't supported yet, but will be soon."
+            );
         }
     }
 

--- a/src/r2c/mixed_radix_r2c.rs
+++ b/src/r2c/mixed_radix_r2c.rs
@@ -1,0 +1,382 @@
+use std::sync::Arc;
+
+use num_complex::Complex;
+use num_traits::Zero;
+
+use crate::{Fft, FftDirection, FftNum, FftRealToComplex, Length, array_utils::{self, into_complex_mut, into_real_mut}, common::r2c_error_outofplace, twiddles};
+
+
+
+pub struct MixedRadixR2C<T> {
+    inner_r2c: Arc<dyn FftRealToComplex<T>>,
+    inner_r2c_len: usize,
+    inner_r2c_complex_len: usize,
+
+    inner_fft: Arc<dyn Fft<T>>,
+    inner_fft_len: usize,
+
+    len: usize,
+
+    twiddles: Box<[Complex<T>]>,
+}
+impl<T: FftNum> MixedRadixR2C<T> {
+    pub fn new(inner_r2c: Arc<dyn FftRealToComplex<T>>, inner_fft: Arc<dyn Fft<T>>) -> Self {
+        let inner_fft_len = inner_fft.len();
+        let inner_r2c_len = inner_r2c.len();
+
+        let direction = inner_fft.fft_direction();
+
+        let inner_r2c_complex_len = inner_r2c_len / 2 + 1;
+
+        let len = inner_fft_len * inner_r2c_len;
+
+        let mut twiddles = Vec::with_capacity(inner_r2c_complex_len * inner_fft_len);
+
+        for k in 0..inner_fft_len {
+            for i in 0..inner_r2c_complex_len {
+                twiddles.push(twiddles::compute_twiddle(i*k, len, direction))
+            }
+        }
+        Self {
+            len: inner_r2c_len * inner_fft_len,
+
+            inner_r2c_len,
+            inner_r2c_complex_len,
+            inner_r2c,
+
+            inner_fft_len,
+            inner_fft,
+
+            twiddles: twiddles.into_boxed_slice(),
+
+        }
+    }
+    #[inline(never)]
+    fn perform_r2c(&self, input: &[T], output: &mut [Complex<T>], scratch: &mut [T]) {
+        let (scratch1, scratch2) = into_complex_mut(scratch).split_at_mut(self.inner_fft_len * self.inner_r2c_complex_len);
+
+        // Step 1: Transpose. The output is guaranteed to be big enough to hold the input, so it's a great place to transpose. Alternatively we could transpose into scratch1.
+        let temp_transpose = &mut into_real_mut(output)[..input.len()];
+        
+        transpose::transpose(&input, temp_transpose, self.inner_fft_len, self.inner_r2c_len);
+
+        // Step 2: Compute the inner R2C FFTs
+        self.inner_r2c.process(temp_transpose, scratch1, &mut []);
+
+        // Step 3: Apply twiddle factors
+        for (element, twiddle) in scratch1.iter_mut().zip(self.twiddles.iter()) {
+            *element = *element * *twiddle;
+        }
+
+        // Step 4: Transpose
+        transpose::transpose(&scratch1, scratch2, self.inner_r2c_complex_len, self.inner_fft_len);
+
+        // Step 5: Compute the inner full-complex FFT of size width. Even though we're computing full-complex FFTs,
+        // we're still only doing half the work, because we only need to compute half of them! The other half, per the definition of the R2C, will contain transposed redundant data
+        self.inner_fft.process_with_scratch(scratch2, scratch1);
+
+        // step 6: transpose. Slightly different than the normal transpose, since we have to work around the fact that some of the data is missing
+        self.transpose_r2c_final_small(scratch2, output);
+    }
+
+    #[allow(unused)]
+    #[inline(never)]
+    fn transpose_r2c_final_small(&self, source: &[Complex<T>], destination: &mut [Complex<T>]) {
+        let forward_column_count = self.inner_r2c_complex_len;
+        let reverse_column_count = self.inner_r2c_len - self.inner_r2c_complex_len;
+
+        let column_stride = self.inner_fft_len;
+
+        let mut indexes_gather = vec![0; destination.len()];
+        let mut indexes_scatter = vec![0; source.len()];
+
+        // The easy part: the forward data is just a standard transpose
+        let mut chunks_iter = destination.chunks_exact_mut(self.inner_r2c_len);
+        for (y, chunk) in chunks_iter.by_ref().enumerate() {
+            for (x, destination_element) in (&mut chunk[..forward_column_count]).iter_mut().enumerate() {
+                *destination_element = source[x * column_stride + y];
+                indexes_gather[y * self.inner_r2c_len + x] = (x * column_stride + y) as isize;
+                indexes_scatter[x * column_stride + y] = (y * self.inner_r2c_len + x) as isize;
+            }
+        }
+        // We'll have one remainder row at the end of the short section that can be processed entirely with the forward logic
+        for (x, destination_element) in chunks_iter.into_remainder().iter_mut().enumerate() {
+            *destination_element = source[x * column_stride + column_stride / 2];
+            indexes_gather[column_stride / 2 * self.inner_r2c_len + x] = (x * column_stride + column_stride / 2) as isize;
+            indexes_scatter[x * column_stride + column_stride / 2] = (column_stride / 2 * self.inner_r2c_len + x) as isize;
+        }
+
+        // the hard part: the "reverse data", where we have to pull data from a weird part of the array and conjugate it
+        // we're making up for the fact that we're trying to pull data from a part of the array that we didn't compute
+        // Because we're computing a R2C, all of that missing data is available in another spot, conjugated
+        if reverse_column_count > 0 {
+            let reverse_base = self.len() - 1 + column_stride;
+            for (y, chunk) in destination.chunks_exact_mut(self.inner_r2c_len).enumerate() {
+                for (x, destination_element) in (forward_column_count..).zip((&mut chunk[forward_column_count..]).iter_mut()) {
+                    *destination_element = source[reverse_base - x * column_stride - y].conj();
+                    indexes_gather[y * self.inner_r2c_len + x] = -((reverse_base - x * column_stride - y) as isize);
+                    indexes_scatter[reverse_base - x * column_stride - y] = -((y * self.inner_r2c_len + x) as isize);
+                }
+            }
+        }
+
+        println!();
+        println!("len={}, r2c len={}, r2c complex len={}, fft len={}", self.len, self.inner_r2c_len, self.inner_r2c_complex_len, self.inner_fft_len);
+        println!("Gather indexes: ");
+        for chunk in indexes_gather.chunks(self.inner_r2c_len) {
+            for e in chunk.iter() {
+                print!("{:>4}", e);
+            }
+            println!();
+        }
+
+        println!("Scatter indexes: ");
+        for chunk in indexes_scatter.chunks(self.inner_fft_len) {
+            for e in chunk.iter() {
+                print!("{:>4}", e);
+            }
+            println!();
+        }
+    }
+
+    #[allow(unused)]
+    #[inline(never)]
+    fn transpose_r2c_final(&self, source: &[Complex<T>], destination: &mut [Complex<T>]) {
+        let forward_column_count = self.inner_r2c_complex_len;
+        let reverse_column_count = self.inner_r2c_len - self.inner_r2c_complex_len;
+        let bare_columns = forward_column_count - reverse_column_count;
+        
+        let column_stride = self.inner_fft_len;
+        let rev_offset = if bare_columns % 2 == 1 { 0 } else { column_stride };
+
+        // we will have a small remainder chunk at the end that will need special handling - slice it off now
+        let remainder_len = destination.len() % self.inner_r2c_len;
+        let (destination, destination_remainder) = destination.split_at_mut(destination.len() - remainder_len);
+        let tile_count = destination.len() / (self.inner_r2c_len * TILE_SIZE);
+
+        // The easy part: the forward data is just a standard transpose
+        // we're going to iterate over multiple rows at once in order to implement "loop tiling", which is a cache-friendliness improvement to transposing
+        // Intentionally use chunks_mut() instead of chunks_exact_mut() so that we get the final 
+        const TILE_SIZE : usize = 8;
+        let mut tiles_iter = destination.chunks_exact_mut(self.inner_r2c_len * TILE_SIZE);
+        for (tile_index, tile) in tiles_iter.by_ref().enumerate() {
+            for x in 0..forward_column_count {
+                for y in 0..TILE_SIZE {
+                    unsafe { *tile.get_unchecked_mut(x + y * self.inner_r2c_len) = source[x * column_stride + tile_index * TILE_SIZE + y] };
+                }
+            }
+        }
+
+        // The last section of loop tiling - not big enough for an entire tile
+        let final_tile = tiles_iter.into_remainder();
+        for x in 0..forward_column_count {
+            for (y, chunk) in final_tile.chunks_exact_mut(self.inner_r2c_len).enumerate() {
+                chunk[x] = source[x * column_stride + tile_count + y];
+            }
+        }
+
+        // We'll have one remainder row at the end of the short section that can be processed entirely with the forward logic
+        for (x, destination_element) in destination_remainder.iter_mut().enumerate() {
+            *destination_element = source[x * column_stride + column_stride / 2];
+        }
+
+        // the hard part: the "reverse data", where we have to pull data from a weird part of the array and conjugate it
+        // we're making up for the fact that we're trying to pull data from a part of the array that we didn't compute
+        // Because we're computing a R2C, all of that missing data is available in another spot, conjugated
+        if reverse_column_count > 0 {
+            let reverse_base = self.len() - 1 + column_stride;
+            for (y, chunk) in destination.chunks_exact_mut(self.inner_r2c_len).enumerate() {
+                for (x, destination_element) in (forward_column_count..).zip((&mut chunk[forward_column_count..]).iter_mut()) {
+                    *destination_element = source[reverse_base - x * column_stride - y].conj();
+                }
+            }
+        }
+    }
+}
+impl<T: FftNum> FftRealToComplex<T> for MixedRadixR2C<T> {
+    fn process(&self, input: &mut [T], output: &mut [Complex<T>], scratch: &mut [T]) {
+        if self.len() == 0 {
+            return;
+        }
+
+        let output_blocksize = self.len() / 2 + 1;
+
+        let required_scratch = self.get_scratch_len();
+        if scratch.len() < required_scratch
+            || input.len() < self.len()
+            || output.len() < output_blocksize
+        {
+            // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+            r2c_error_outofplace(
+                self.len(),
+                input.len(),
+                output.len(),
+                self.get_scratch_len(),
+                scratch.len(),
+            );
+            return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+        }
+
+        let scratch = &mut scratch[..required_scratch];
+        let result = array_utils::iter_chunks_zipped_r2c(
+            input,
+            self.len(),
+            output,
+            output_blocksize,
+            |in_chunk, out_chunk| {
+                self.perform_r2c(in_chunk, out_chunk, scratch)
+            },
+        );
+
+        if result.is_err() {
+            // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+            // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+            r2c_error_outofplace(
+                self.len(),
+                input.len(),
+                output.len(),
+                self.get_scratch_len(),
+                scratch.len(),
+            );
+        }
+    }
+
+    fn get_scratch_len(&self) -> usize {
+        4 * self.inner_fft_len * self.inner_r2c_complex_len
+    }
+}
+impl<T> Length for MixedRadixR2C<T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+pub struct DftR2C<T> {
+    twiddles: Box<[Complex<T>]>,
+}
+impl<T: FftNum> DftR2C<T> {
+    pub fn new(len: usize, direction: FftDirection) -> Self {
+        Self {
+            twiddles: (0..len).map(|i| twiddles::compute_twiddle(i, len, direction)).collect()
+        }
+    }
+
+    fn perform_r2c(&self, input: &mut [T], output: &mut [Complex<T>], _: &mut [T]) {
+        assert_eq!(input.len(), self.len());
+        for i in 0..output.len() {
+            let mut output_value = Zero::zero();
+            for k in 0..input.len() {
+                output_value = output_value + self.twiddles[(i*k)%self.len()] * input[k];
+            }
+            output[i] = output_value;
+        }
+    }
+}
+impl<T: FftNum> FftRealToComplex<T> for DftR2C<T> {
+    fn process(&self, input: &mut [T], output: &mut [Complex<T>], scratch: &mut [T]) {
+        if self.len() == 0 {
+            return;
+        }
+
+        let output_blocksize = self.len() / 2 + 1;
+
+        let required_scratch = self.get_scratch_len();
+        if scratch.len() < required_scratch
+            || input.len() < self.len()
+            || output.len() < output_blocksize
+        {
+            // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+            r2c_error_outofplace(
+                self.len(),
+                input.len(),
+                output.len(),
+                self.get_scratch_len(),
+                scratch.len(),
+            );
+            return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+        }
+
+        let scratch = &mut scratch[..required_scratch];
+        let result = array_utils::iter_chunks_zipped_r2c(
+            input,
+            self.len(),
+            output,
+            output_blocksize,
+            |in_chunk, out_chunk| {
+                self.perform_r2c(in_chunk, out_chunk, scratch)
+            },
+        );
+
+        if result.is_err() {
+            // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+            // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+            r2c_error_outofplace(
+                self.len(),
+                input.len(),
+                output.len(),
+                self.get_scratch_len(),
+                scratch.len(),
+            );
+        }
+    }
+
+    fn get_scratch_len(&self) -> usize {
+        0
+    }
+}
+impl<T> Length for DftR2C<T> {
+    fn len(&self) -> usize {
+        self.twiddles.len()
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::{
+        algorithm::Dft,
+        test_utils::{compare_vectors, random_real_signal},
+        FftDirection,
+    };
+    use num_traits::Zero;
+
+    #[test]
+    fn test_r2c_mixedradix_scalar() {
+        for width in 1..10 {
+            for height in 1..10 {
+                test_r2c_mixedradix(width, height, FftDirection::Forward);
+
+                // Note: Even though R2C is usually used with a forward FFT, it was pretty trivial to make it support inverse FFTs.
+                // If there's a compelling performance reason to drop inverse support, go ahead.
+                //test_r2c_even_with_inner(inner_len, FftDirection::Inverse);
+            }
+        }
+    }
+
+    fn test_r2c_mixedradix(width: usize, height: usize, direction: FftDirection) {
+        let inner_r2c: Arc<DftR2C<f64>> = Arc::new(DftR2C::new(height, direction));
+        let inner_fft: Arc<Dft<f64>> = Arc::new(Dft::new(width, direction));
+        let fft = MixedRadixR2C::new(inner_r2c, inner_fft);
+
+        let control = DftR2C::new(width * height, direction);
+
+        let mut real_input = random_real_signal(control.len());
+        let mut control_input = random_real_signal(control.len());
+
+        let mut real_output = vec![Complex::zero(); control.len()/2 + 1];
+        let mut control_output = vec![Complex::zero(); control.len()/2 + 1];
+
+        control.process(&mut control_input, &mut control_output, &mut []);
+
+        let mut scratch = vec![0.0; fft.get_scratch_len()];
+        fft.process(&mut real_input, &mut real_output, &mut scratch);
+
+        assert!(
+            compare_vectors(&real_output, &control_output),
+            "process() failed, inner_fft_len = {}, inner_r2c_len = {}, direction = {}",
+            width, height,
+            direction,
+        );
+    }
+
+}

--- a/src/r2c/mod.rs
+++ b/src/r2c/mod.rs
@@ -1,0 +1,4 @@
+mod mixed_radix_r2c;
+
+pub use self::mixed_radix_r2c::DftR2C;
+pub use self::mixed_radix_r2c::MixedRadixR2C;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -46,6 +46,15 @@ pub fn compare_vectors<T: FftNum + Float>(vec1: &[Complex<T>], vec2: &[Complex<T
     return (error.to_f64().unwrap() / vec1.len() as f64) < 0.1f64;
 }
 
+pub fn compare_real_vectors<T: FftNum + Float>(vec1: &[T], vec2: &[T]) -> bool {
+    assert_eq!(vec1.len(), vec2.len());
+    let mut error = T::zero();
+    for (&a, &b) in vec1.iter().zip(vec2.iter()) {
+        error = error + (a - b).abs();
+    }
+    return (error.to_f64().unwrap() / vec1.len() as f64) < 0.1f64;
+}
+
 #[allow(unused)]
 fn transppose_diagnostic<T: FftNum + Float>(expected: &[Complex<T>], actual: &[Complex<T>]) {
     for (i, (&e, &a)) in expected.iter().zip(actual.iter()).enumerate() {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -14,6 +14,16 @@ const RNG_SEED: [u8; 32] = [
     1, 9, 1, 0, 1, 1, 4, 3, 1, 4, 9, 8, 4, 1, 4, 8, 2, 8, 1, 2, 2, 2, 6, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 ];
 
+pub fn random_real_signal<T: FftNum + SampleUniform>(length: usize) -> Vec<T> {
+    let mut sig = Vec::with_capacity(length);
+    let normal_dist: Uniform<T> = Uniform::new(T::zero(), T::from_f32(10.0).unwrap());
+    let mut rng: StdRng = SeedableRng::from_seed(RNG_SEED);
+    for _ in 0..length {
+        sig.push(normal_dist.sample(&mut rng));
+    }
+    return sig;
+}
+
 pub fn random_signal<T: FftNum + SampleUniform>(length: usize) -> Vec<Complex<T>> {
     let mut sig = Vec::with_capacity(length);
     let normal_dist: Uniform<T> = Uniform::new(T::zero(), T::from_f32(10.0).unwrap());


### PR DESCRIPTION
This isn't ready to merge yet, but it's in a previewable state.

I used the RealFFT crate as a starting point for the new structs, and I was able to make a few optimizations to bring down the overhead by about a third.

Todo:

- [ ] Find a paper or something for odd-sized real FFTs
- [ ] Implement an AVX version of c2r and r2c
- [ ] Clean up unit tests
- [ ] Write some integration tests
- [ ] Benchmark and write some c2r and r2c butterflies, so that using r2c is always faster than or equal to a normal FFT
- [ ] Decide what to do with the planner. Should this stuff go in the current planner? Should I make a new planner that wraps the current one? If we made a new planner, it would make it harder to integrate AVX. But I'm worried about a slippery slope where we bloat the planner struct until it's this giant monolith.