### PR TITLE
use FloatConst/Float and from_usize to reduce conversion loss

### DIFF
--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -50,7 +50,7 @@ pub struct BluesteinsAlgorithm<T> {
 
 impl<T: FftNum> BluesteinsAlgorithm<T> {
     fn compute_bluesteins_twiddle(index: usize, len: usize, direction: FftDirection) -> Complex<T> {
-        let index_float = index as f64;
+        let index_float = T::from_usize(index).unwrap();
         let index_squared = index_float * index_float;
 
         twiddles::compute_twiddle_floatindex(index_squared, len * 2, direction.opposite_direction())

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -680,7 +680,7 @@ impl<T: FftNum> Butterfly8<T> {
     #[inline(always)]
     pub fn new(direction: FftDirection) -> Self {
         Self {
-            root2: T::from_f64(0.5f64.sqrt()).unwrap(),
+            root2: T::FRAC_1_SQRT_2(),
             direction,
         }
     }

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -84,7 +84,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
         } as usize;
 
         // precompute the coefficients to use inside the process method
-        let unity_scale = T::from_f64(1f64 / inner_fft_len as f64).unwrap();
+        let unity_scale = T::from_usize(inner_fft_len).unwrap().recip();
         let mut inner_fft_input = vec![Complex::zero(); inner_fft_len];
         let mut twiddle_input = 1;
         for input_cell in &mut inner_fft_input {

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -34,7 +34,7 @@ boilerplate_avx_fft_commondata!(BluesteinsAvx);
 
 impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
     fn compute_bluesteins_twiddle(index: usize, len: usize, direction: FftDirection) -> Complex<A> {
-        let index_float = index as f64;
+        let index_float = A::from_usize(index).unwrap();
         let index_squared = index_float * index_float;
 
         twiddles::compute_twiddle_floatindex(index_squared, len * 2, direction.opposite_direction())

--- a/src/avx/avx_raders.rs
+++ b/src/avx/avx_raders.rs
@@ -161,7 +161,7 @@ impl<A: AvxNum, T: FftNum> RadersAvx2<A, T> {
         } as usize;
 
         // precompute the coefficients to use inside the process method
-        let unity_scale = T::from_f64(1f64 / inner_fft_len as f64).unwrap();
+        let unity_scale = T::from_usize(inner_fft_len).unwrap().recip();
         let mut inner_fft_input = vec![Complex::zero(); inner_fft_len];
         let mut twiddle_input = 1;
         for input_cell in &mut inner_fft_input {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,10 @@
-use num_traits::{FromPrimitive, Signed};
+use num_traits::{FromPrimitive, Signed, Float, FloatConst};
 use std::fmt::Debug;
 
 /// Generic floating point number, implemented for f32 and f64
-pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
+pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + Float + FloatConst + 'static {}
 
-impl<T> FftNum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
+impl<T> FftNum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debug + Float + FloatConst + 'static {}
 
 // Prints an error raised by an in-place FFT algorithm's `process_inplace` method
 // Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -6,12 +6,12 @@ pub fn compute_twiddle<T: FftNum>(
     fft_len: usize,
     direction: FftDirection,
 ) -> Complex<T> {
-    let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
-    let angle = constant * index as f64;
+    let constant = -T::TAU() / T::from_usize(fft_len).unwrap();
+    let angle = constant * T::from_usize(index).unwrap();
 
     let result = Complex {
-        re: T::from_f64(angle.cos()).unwrap(),
-        im: T::from_f64(angle.sin()).unwrap(),
+        re: angle.cos(),
+        im: angle.sin(),
     };
 
     match direction {
@@ -21,16 +21,16 @@ pub fn compute_twiddle<T: FftNum>(
 }
 
 pub fn compute_twiddle_floatindex<T: FftNum>(
-    index: f64,
+    index: T,
     fft_len: usize,
     direction: FftDirection,
 ) -> Complex<T> {
-    let constant = -2f64 * std::f64::consts::PI / fft_len as f64;
+    let constant = -T::TAU() / T::from_usize(fft_len).unwrap();
     let angle = constant * index;
 
     let result = Complex {
-        re: T::from_f64(angle.cos()).unwrap(),
-        im: T::from_f64(angle.sin()).unwrap(),
+        re: angle.cos(),
+        im: angle.sin(),
     };
 
     match direction {


### PR DESCRIPTION
This is a follow-up to #62. 

I'm not familiar with the codebase so I only tried to find `as f64` or `T::from_f64` and modify them accordingly. It's very possible that I missed something.

I also ran `cargo test` and it seems to be fine. 
