### PR TITLE
Update deps, most importantly num-complex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ default = ["avx"]
 avx = []
 
 [dependencies]
-num-complex = "0.3"
+num-complex = "0.4"
 num-traits = "0.2"
-num-integer = "^0.1.40"
+num-integer = "^0.1.44"
 strength_reduce = "^0.2.1"
-transpose = "0.2"
+transpose = "0.2.1"
 primal-check = "0.3.1"
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.8.3"


### PR DESCRIPTION
Bumping versions in preparation of the next release (triggered by the new version of num-complex). Apart from bumping the versions, no other changes are needed.
