### PR TITLE
Radix4transpose

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -13,4 +13,4 @@ pub use self::dft::Dft;
 pub use self::good_thomas_algorithm::{GoodThomasAlgorithm, GoodThomasAlgorithmSmall};
 pub use self::mixed_radix::{MixedRadix, MixedRadixSmall};
 pub use self::raders_algorithm::RadersAlgorithm;
-pub use self::radix4::{Radix4, bitreversed_transpose, reverse_bits};
+pub use self::radix4::{bitreversed_transpose, reverse_bits, Radix4};

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -13,4 +13,4 @@ pub use self::dft::Dft;
 pub use self::good_thomas_algorithm::{GoodThomasAlgorithm, GoodThomasAlgorithmSmall};
 pub use self::mixed_radix::{MixedRadix, MixedRadixSmall};
 pub use self::raders_algorithm::RadersAlgorithm;
-pub use self::radix4::Radix4;
+pub use self::radix4::{Radix4, bitreversed_transpose, reverse_bits};

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -156,24 +156,32 @@ pub unsafe fn bitreversed_transpose<T: Copy>(
     shuffle_map: &[usize],
 ) {
     let width = shuffle_map.len();
-    for x in 0..width / 4 {
+    // Let's make sure the arguments are ok
+    assert!(input.len() == output.len());
+    assert!(input.len() == height*width);
+    for (x, x_rev) in shuffle_map.chunks_exact(4).enumerate() {
         let x0 = 4 * x;
         let x1 = 4 * x + 1;
         let x2 = 4 * x + 2;
         let x3 = 4 * x + 3;
-        let x_rev0 = shuffle_map.get_unchecked(x0);
-        let x_rev1 = shuffle_map.get_unchecked(x1);
-        let x_rev2 = shuffle_map.get_unchecked(x2);
-        let x_rev3 = shuffle_map.get_unchecked(x3);
+
+        // Assert that the the bit reversed indices will not exceed the length of the output.
+        // The highest index the loop reaches is: (x_rev[n] + 1)*height - 1
+        // The last element of the data is at index: width*height - 1
+        // Thus it is sufficient to assert that x_rev[n]<width.
+        assert!(x_rev[0]<width);
+        assert!(x_rev[1]<width);
+        assert!(x_rev[2]<width);
+        assert!(x_rev[3]<width);
         for y in 0..height {
             let input_index0 = x0 + y * width;
             let input_index1 = x1 + y * width;
             let input_index2 = x2 + y * width;
             let input_index3 = x3 + y * width;
-            let output_index0 = y + x_rev0 * height;
-            let output_index1 = y + x_rev1 * height;
-            let output_index2 = y + x_rev2 * height;
-            let output_index3 = y + x_rev3 * height;
+            let output_index0 = y + x_rev[0] * height;
+            let output_index1 = y + x_rev[1] * height;
+            let output_index2 = y + x_rev[2] * height;
+            let output_index3 = y + x_rev[3] * height;
 
             let temp0 = *input.get_unchecked(input_index0);
             let temp1 = *input.get_unchecked(input_index1);

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -107,11 +107,8 @@ impl<T: FftNum> Radix4<T> {
         _scratch: &mut [Complex<T>],
     ) {
         // copy the data into the spectrum vector
-        //prepare_radix4(signal.len(), self.base_len, signal, spectrum, 1);
-        // copy the data into the spectrum vector
         if self.shuffle_map.len() < 4 {
             spectrum.copy_from_slice(signal);
-            //bitreversed_transpose_simple(self.base_len, signal, spectrum, &self.shuffle_map);
         } else {
             unsafe {
                 bitreversed_transpose(self.base_len, signal, spectrum, &self.shuffle_map);

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -158,7 +158,7 @@ pub unsafe fn bitreversed_transpose<T: Copy>(
     let width = shuffle_map.len();
     // Let's make sure the arguments are ok
     assert!(input.len() == output.len());
-    assert!(input.len() == height*width);
+    assert!(input.len() == height * width);
     for (x, x_rev) in shuffle_map.chunks_exact(4).enumerate() {
         let x0 = 4 * x;
         let x1 = 4 * x + 1;
@@ -169,10 +169,10 @@ pub unsafe fn bitreversed_transpose<T: Copy>(
         // The highest index the loop reaches is: (x_rev[n] + 1)*height - 1
         // The last element of the data is at index: width*height - 1
         // Thus it is sufficient to assert that x_rev[n]<width.
-        assert!(x_rev[0]<width);
-        assert!(x_rev[1]<width);
-        assert!(x_rev[2]<width);
-        assert!(x_rev[3]<width);
+        assert!(x_rev[0] < width);
+        assert!(x_rev[1] < width);
+        assert!(x_rev[2] < width);
+        assert!(x_rev[3] < width);
         for y in 0..height {
             let input_index0 = x0 + y * width;
             let input_index1 = x1 + y * width;

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -152,22 +152,22 @@ boilerplate_fft_oop!(Radix4, |this: &Radix4<_>| this.len);
 // Preparing for radix 4 is similar to a transpose, where the column index is bit reversed.
 // Use a lookup table to avoid repeating the slow bit reverse operations.
 // Unrolling the outer loop by a factor 4 helps speed things up.
-pub(crate) unsafe fn bitreversed_transpose<T: Copy>(
+pub unsafe fn bitreversed_transpose<T: Copy>(
     height: usize,
     input: &[T],
     output: &mut [T],
-    shuffled: &[usize],
+    shuffle_map: &[usize],
 ) {
-    let width = shuffled.len();
+    let width = shuffle_map.len();
     for x in 0..width / 4 {
         let x0 = 4 * x;
         let x1 = 4 * x + 1;
         let x2 = 4 * x + 2;
         let x3 = 4 * x + 3;
-        let x_rev0 = shuffled.get_unchecked(x0);
-        let x_rev1 = shuffled.get_unchecked(x1);
-        let x_rev2 = shuffled.get_unchecked(x2);
-        let x_rev3 = shuffled.get_unchecked(x3);
+        let x_rev0 = shuffle_map.get_unchecked(x0);
+        let x_rev1 = shuffle_map.get_unchecked(x1);
+        let x_rev2 = shuffle_map.get_unchecked(x2);
+        let x_rev3 = shuffle_map.get_unchecked(x3);
         for y in 0..height {
             let input_index0 = x0 + y * width;
             let input_index1 = x1 + y * width;
@@ -193,7 +193,7 @@ pub(crate) unsafe fn bitreversed_transpose<T: Copy>(
 
 // Reverse bits of value, in pairs.
 // For 8 bits: abcdefgh -> ghefcdab
-pub(crate) fn reverse_bits(value: usize, bitpairs: usize) -> usize {
+pub fn reverse_bits(value: usize, bitpairs: usize) -> usize {
     let mut result: usize = 0;
     let mut value = value;
     for _ in 0..bitpairs {

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -110,9 +110,7 @@ impl<T: FftNum> Radix4<T> {
         if self.shuffle_map.len() < 4 {
             spectrum.copy_from_slice(signal);
         } else {
-            unsafe {
-                bitreversed_transpose(self.base_len, signal, spectrum, &self.shuffle_map);
-            }
+            bitreversed_transpose(self.base_len, signal, spectrum, &self.shuffle_map);
         }
 
         // Base-level FFTs
@@ -149,7 +147,7 @@ boilerplate_fft_oop!(Radix4, |this: &Radix4<_>| this.len);
 // Preparing for radix 4 is similar to a transpose, where the column index is bit reversed.
 // Use a lookup table to avoid repeating the slow bit reverse operations.
 // Unrolling the outer loop by a factor 4 helps speed things up.
-pub unsafe fn bitreversed_transpose<T: Copy>(
+pub fn bitreversed_transpose<T: Copy>(
     height: usize,
     input: &[T],
     output: &mut [T],
@@ -183,15 +181,17 @@ pub unsafe fn bitreversed_transpose<T: Copy>(
             let output_index2 = y + x_rev[2] * height;
             let output_index3 = y + x_rev[3] * height;
 
-            let temp0 = *input.get_unchecked(input_index0);
-            let temp1 = *input.get_unchecked(input_index1);
-            let temp2 = *input.get_unchecked(input_index2);
-            let temp3 = *input.get_unchecked(input_index3);
+            unsafe {
+                let temp0 = *input.get_unchecked(input_index0);
+                let temp1 = *input.get_unchecked(input_index1);
+                let temp2 = *input.get_unchecked(input_index2);
+                let temp3 = *input.get_unchecked(input_index3);
 
-            *output.get_unchecked_mut(output_index0) = temp0;
-            *output.get_unchecked_mut(output_index1) = temp1;
-            *output.get_unchecked_mut(output_index2) = temp2;
-            *output.get_unchecked_mut(output_index3) = temp3;
+                *output.get_unchecked_mut(output_index0) = temp0;
+                *output.get_unchecked_mut(output_index1) = temp1;
+                *output.get_unchecked_mut(output_index2) = temp2;
+                *output.get_unchecked_mut(output_index3) = temp3;
+            }
         }
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -366,7 +366,8 @@ impl<T: FftNum> FftPlannerScalar<T> {
             fft_instance
         } else if factors.is_prime() {
             self.design_prime(len)
-        } else if len.trailing_zeros() <= MAX_RADIX4_BITS && len.trailing_zeros() >= MIN_RADIX4_BITS
+        //} else if len.trailing_zeros() <= MAX_RADIX4_BITS && len.trailing_zeros() >= MIN_RADIX4_BITS
+        } else if len.trailing_zeros() >= MIN_RADIX4_BITS
         {
             if len.is_power_of_two() {
                 Arc::new(Recipe::Radix4(len))

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -105,7 +105,6 @@ impl<T: FftNum> FftPlanner<T> {
 }
 
 const MIN_RADIX4_BITS: u32 = 5; // smallest size to consider radix 4 an option is 2^5 = 32
-const MAX_RADIX4_BITS: u32 = 16; // largest size to consider radix 4 an option is 2^16 = 65536
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
 const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
 
@@ -366,9 +365,7 @@ impl<T: FftNum> FftPlannerScalar<T> {
             fft_instance
         } else if factors.is_prime() {
             self.design_prime(len)
-        //} else if len.trailing_zeros() <= MAX_RADIX4_BITS && len.trailing_zeros() >= MIN_RADIX4_BITS
-        } else if len.trailing_zeros() >= MIN_RADIX4_BITS
-        {
+        } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
             if len.is_power_of_two() {
                 Arc::new(Recipe::Radix4(len))
             } else {
@@ -523,25 +520,13 @@ mod unit_tests {
     }
 
     #[test]
-    fn test_plan_scalar_mediumpoweroftwo() {
-        // Powers of 2 between 64 and 32768 should use Radix4
+    fn test_plan_scalar_largepoweroftwo() {
+        // Powers of 2 above 64 should use Radix4
         let mut planner = FftPlannerScalar::<f64>::new();
-        for pow in 6..16 {
+        for pow in 6..32 {
             let len = 1 << pow;
             let plan = planner.design_fft_for_len(len);
             assert_eq!(*plan, Recipe::Radix4(len));
-            assert_eq!(plan.len(), len, "Recipe reports wrong length");
-        }
-    }
-
-    #[test]
-    fn test_plan_scalar_largepoweroftwo() {
-        // Powers of 2 from 65536 and up should use MixedRadix
-        let mut planner = FftPlannerScalar::<f64>::new();
-        for pow in 17..32 {
-            let len = 1 << pow;
-            let plan = planner.design_fft_for_len(len);
-            assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
             assert_eq!(plan.len(), len, "Recipe reports wrong length");
         }
     }

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -496,7 +496,8 @@ impl<T: FftNum> FftPlannerSse<T> {
             fft_instance
         } else if factors.is_prime() {
             self.design_prime(len)
-        } else if len.trailing_zeros() <= MAX_RADIX4_BITS && len.trailing_zeros() >= MIN_RADIX4_BITS
+        //} else if len.trailing_zeros() <= MAX_RADIX4_BITS && len.trailing_zeros() >= MIN_RADIX4_BITS
+        } else if len.trailing_zeros() >= MIN_RADIX4_BITS
         {
             if len.is_power_of_two() {
                 Arc::new(Recipe::Radix4(len))

--- a/src/sse/sse_radix4.rs
+++ b/src/sse/sse_radix4.rs
@@ -25,6 +25,8 @@ use crate::array_utils::{RawSlice, RawSliceMut};
 /// FFT algorithm optimized for power-of-two sizes, SSE accelerated version.
 /// This is designed to be used via a Planner, and not created directly.
 
+const USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
+
 enum Sse32Butterfly<T> {
     Len1(SseF32Butterfly1<T>),
     Len2(SseF32Butterfly2<T>),
@@ -76,7 +78,11 @@ impl<T: FftNum> Sse32Radix4<T> {
             3 => (len, Sse32Butterfly::Len8(SseF32Butterfly8::new(direction))),
             _ => {
                 if num_bits % 2 == 1 {
-                    (32, Sse32Butterfly::Len32(SseF32Butterfly32::new(direction)))
+                    if len < USE_BUTTERFLY32_FROM {
+                        (8, Sse32Butterfly::Len8(SseF32Butterfly8::new(direction)))
+                    } else {
+                        (32, Sse32Butterfly::Len32(SseF32Butterfly32::new(direction)))
+                    }
                 } else {
                     (16, Sse32Butterfly::Len16(SseF32Butterfly16::new(direction)))
                 }
@@ -262,7 +268,11 @@ impl<T: FftNum> Sse64Radix4<T> {
             3 => (len, Sse64Butterfly::Len8(SseF64Butterfly8::new(direction))),
             _ => {
                 if num_bits % 2 == 1 {
-                    (32, Sse64Butterfly::Len32(SseF64Butterfly32::new(direction)))
+                    if len < USE_BUTTERFLY32_FROM {
+                        (8, Sse64Butterfly::Len8(SseF64Butterfly8::new(direction)))
+                    } else {
+                        (32, Sse64Butterfly::Len32(SseF64Butterfly32::new(direction)))
+                    }
                 } else {
                     (16, Sse64Butterfly::Len16(SseF64Butterfly16::new(direction)))
                 }


### PR DESCRIPTION
This PR replaces the existing radix4 shuffler with a much faster one. This is used in both scalar and sse versions.
With this shuffler, there is no need to use mixer radix for long ffts, since radix4 is now the fastest also there.