### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ sse = []
 num-complex = "0.4"
 num-traits = "0.2"
 num-integer = "^0.1.40"
-strength_reduce = "^0.2.1"
+strength_reduce = "0.2.3"
 transpose = "0.2"
 primal-check = "0.3.1"
 


### PR DESCRIPTION
strength_reduce 0.2.1 and 0.2.2 do not have 'StrengthReducedU128' in their root module so you cannot compile RustFFT on those versions. should enforce strength_reduce version of 0.2.3.
