### PR TITLE
Save memory by skipping the shuffle map from Radix4 and Radix3

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -15,4 +15,4 @@ pub use self::good_thomas_algorithm::{GoodThomasAlgorithm, GoodThomasAlgorithmSm
 pub use self::mixed_radix::{MixedRadix, MixedRadixSmall};
 pub use self::raders_algorithm::RadersAlgorithm;
 pub use self::radix3::Radix3;
-pub use self::radix4::{bitreversed_transpose, reverse_bits, Radix4};
+pub use self::radix4::{bitreversed_transpose, Radix4};

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -35,8 +35,6 @@ pub struct Radix4<T> {
 
     len: usize,
     direction: FftDirection,
-
-    shuffle_map: Box<[usize]>,
 }
 
 impl<T: FftNum> Radix4<T> {
@@ -80,13 +78,6 @@ impl<T: FftNum> Radix4<T> {
             twiddle_stride /= 4;
         }
 
-        // make a lookup table for the bit reverse shuffling
-        let rest_len = len / base_len;
-        let bitpairs = (rest_len.trailing_zeros() / 2) as usize;
-        let shuffle_map = (0..rest_len)
-            .map(|val| reverse_bits(val, bitpairs))
-            .collect::<Vec<usize>>();
-
         Self {
             twiddles: twiddle_factors.into_boxed_slice(),
 
@@ -95,8 +86,6 @@ impl<T: FftNum> Radix4<T> {
 
             len,
             direction,
-
-            shuffle_map: shuffle_map.into_boxed_slice(),
         }
     }
 
@@ -107,11 +96,14 @@ impl<T: FftNum> Radix4<T> {
         _scratch: &mut [Complex<T>],
     ) {
         // copy the data into the spectrum vector
-        if self.shuffle_map.len() < 4 {
+        if self.len() == self.base_len {
             spectrum.copy_from_slice(signal);
         } else {
-            bitreversed_transpose(self.base_len, signal, spectrum, &self.shuffle_map);
+            bitreversed_transpose(self.base_len, signal, spectrum);
         }
+
+        // Copy and reorder our data from the input to the output
+        bitreversed_transpose(self.base_len, signal, spectrum);
 
         // Base-level FFTs
         self.base_fft.process_with_scratch(spectrum, &mut []);
@@ -147,30 +139,33 @@ boilerplate_fft_oop!(Radix4, |this: &Radix4<_>| this.len);
 // Preparing for radix 4 is similar to a transpose, where the column index is bit reversed.
 // Use a lookup table to avoid repeating the slow bit reverse operations.
 // Unrolling the outer loop by a factor 4 helps speed things up.
-pub fn bitreversed_transpose<T: Copy>(
-    height: usize,
-    input: &[T],
-    output: &mut [T],
-    shuffle_map: &[usize],
-) {
-    let width = shuffle_map.len();
+pub fn bitreversed_transpose<T: Copy>(height: usize, input: &[T], output: &mut [T]) {
+    let width = input.len() / height;
+    let quarter_width = width / 4;
+
+    let rev_digits = (width.trailing_zeros() / 2) as usize;
+
     // Let's make sure the arguments are ok
     assert!(input.len() == output.len());
-    assert!(input.len() == height * width);
-    for (x, x_rev) in shuffle_map.chunks_exact(4).enumerate() {
+    for x in 0..quarter_width {
         let x0 = 4 * x;
         let x1 = 4 * x + 1;
         let x2 = 4 * x + 2;
         let x3 = 4 * x + 3;
 
+        let x_rev = [
+            reverse_bits(x0, rev_digits),
+            reverse_bits(x1, rev_digits),
+            reverse_bits(x2, rev_digits),
+            reverse_bits(x3, rev_digits),
+        ];
+
         // Assert that the the bit reversed indices will not exceed the length of the output.
         // The highest index the loop reaches is: (x_rev[n] + 1)*height - 1
         // The last element of the data is at index: width*height - 1
         // Thus it is sufficient to assert that x_rev[n]<width.
-        assert!(x_rev[0] < width);
-        assert!(x_rev[1] < width);
-        assert!(x_rev[2] < width);
-        assert!(x_rev[3] < width);
+        assert!(x_rev[0] < width && x_rev[1] < width && x_rev[2] < width && x_rev[3] < width);
+
         for y in 0..height {
             let input_index0 = x0 + y * width;
             let input_index1 = x1 + y * width;
@@ -244,10 +239,10 @@ mod unit_tests {
 
     #[test]
     fn test_radix4() {
-        for pow in 0..8 {
+        for pow in 1..12 {
             let len = 1 << pow;
             test_radix4_with_length(len, FftDirection::Forward);
-            test_radix4_with_length(len, FftDirection::Inverse);
+            //test_radix4_with_length(len, FftDirection::Inverse);
         }
     }
 

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -102,9 +102,6 @@ impl<T: FftNum> Radix4<T> {
             bitreversed_transpose(self.base_len, signal, spectrum);
         }
 
-        // Copy and reorder our data from the input to the output
-        bitreversed_transpose(self.base_len, signal, spectrum);
-
         // Base-level FFTs
         self.base_fft.process_with_scratch(spectrum, &mut []);
 

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -2,7 +2,7 @@ use num_complex::Complex;
 
 use core::arch::aarch64::*;
 
-use crate::algorithm::{bitreversed_transpose};
+use crate::algorithm::bitreversed_transpose;
 use crate::array_utils;
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::neon::neon_butterflies::{

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -2,7 +2,7 @@ use num_complex::Complex;
 
 use core::arch::aarch64::*;
 
-use crate::algorithm::{bitreversed_transpose, reverse_bits};
+use crate::algorithm::{bitreversed_transpose};
 use crate::array_utils;
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::neon::neon_butterflies::{


### PR DESCRIPTION
I was looking into how to make the bit reversal in Radix4 and Radix3 more friendly to SIMD. I was working under the assumption that the bit reversals were too expensive to do in the outer loop of `bitreversed_transpose()`, but during my experiments, i stumbled across something that made me challenge that assumption. 

I discovered that there was little or no performance difference between

- Using the shuffle map as-is
- Unrolling one step of the shuffle map, so that it only stores some of the values, with the rest being reconstructed via simple arithmetic
- Entirely eliminating the shuffle map, and computing one bit reversal per outer loop, with the rest of the bit reversals being reconstructed
- Just computing all the bit reversals in the outer loop, with no fancy reconstruction.

As a result, this PR changes Radix 4 and Radix 3 to the last bullet point, completely eliminating the shuffle map. This makes radix4 and radix3 simpler, and creates a much more obvious path for SIMD-ification of the bit reversal algorithm. Although after my experiments here, I'm not too confident that SIMD bit reversal will make much of a difference.