### PR TITLE
Add neon feature that works with stable rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "compression", "multimedia::encoding", "science"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["avx", "sse"]
+default = ["avx", "neon", "sse"]
 
 # On x86_64, the "avx" feature enables compilation of AVX-acclerated code. 
 # Similarly, the "sse" feature enables SSE-accelerated code. 
@@ -25,7 +25,8 @@ default = ["avx", "sse"]
 # On AArch64, the "neon-nightly" feature enables compilation of Neon-accelerated code. It requires a nightly compiler, and is disabled by default.
 avx = []
 sse = []
-neon-nightly = []
+neon = []
+neon-nightly = ["neon"]
 
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,13 +410,13 @@ mod sse {
 
 pub use self::sse::sse_planner::FftPlannerSse;
 
-// Algorithms implemented to use Neon instructions. Only compiled on AArch64, and only compiled if the "neon-nightly" feature flag is set.
-#[cfg(all(target_arch = "aarch64", feature = "neon-nightly"))]
+// Algorithms implemented to use Neon instructions. Only compiled on AArch64, and only compiled if the "neon" feature flag is set.
+#[cfg(all(target_arch = "aarch64", feature = "neon"))]
 mod neon;
 
-// If we're not on AArch64, or if the "neon-nightly" feature was disabled, keep a stub implementation around that has the same API, but does nothing
+// If we're not on AArch64, or if the "neon" feature was disabled, keep a stub implementation around that has the same API, but does nothing
 // That way, users can write code using the Neon planner and compile it on any platform
-#[cfg(not(all(target_arch = "aarch64", feature = "neon-nightly")))]
+#[cfg(not(all(target_arch = "aarch64", feature = "neon")))]
 mod neon {
     pub mod neon_planner {
         use crate::{Fft, FftDirection, FftNum};

--- a/src/neon/neon_planner.rs
+++ b/src/neon/neon_planner.rs
@@ -160,7 +160,7 @@ impl<T: FftNum> FftPlannerNeon<T> {
     /// Returns `Ok(planner_instance)` if this machine has the required instruction sets.
     /// Returns `Err(())` if some instruction sets are missing.
     pub fn new() -> Result<Self, ()> {
-        if is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             // Ideally, we would implement the planner with specialization.
             // Specialization won't be on stable rust for a long time though, so in the meantime, we can hack around it.
             //


### PR DESCRIPTION
Neon support doesn't require nightly rustc anymore, so add a new "neon" feature flag for that. Not sure if it should be in defaults or not?