### PR TITLE
Remove unnecessary num_traits re-export

### DIFF
--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -24,7 +24,6 @@ use crate::{Direction, Fft, Length};
 /// use rustfft::algorithm::GoodThomasAlgorithm;
 /// use rustfft::{Fft, FftPlanner};
 /// use rustfft::num_complex::Complex;
-/// use rustfft::num_traits::Zero;
 ///
 /// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 1200];
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@
 use std::fmt::Display;
 
 pub use num_complex;
-pub use num_traits;
 
 #[macro_use]
 mod common;

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -7,12 +7,13 @@
 use std::sync::Arc;
 
 use num_traits::Float;
+use num_traits::Zero;
+use rustfft::FftDirection;
 use rustfft::{
     algorithm::{BluesteinsAlgorithm, Radix4},
     num_complex::Complex,
     Fft, FftNum, FftPlanner,
 };
-use rustfft::{num_traits::Zero, FftDirection};
 
 use rand::distributions::{uniform::SampleUniform, Distribution, Uniform};
 use rand::{rngs::StdRng, SeedableRng};


### PR DESCRIPTION
Nothing in the external API requires the consumer to use num_traits directly. Removing this will decouple the rustfft major version from the the num_traits major version.

FftNum is defined in terms of the `FromPrimitive` and `Signed` traits in the num_traits crate however, so whenever they undergo a breaking change, rustfft will still require a major version change.

Since this is a possible breaking change for consumers that happen to consume num_traits via rustfft, this would require a major version bump.