### PR TITLE
Fix size 1 simd butterflies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,3 +483,4 @@ pub use self::neon::neon_planner::FftPlannerNeon;
 
 #[cfg(test)]
 mod test_utils;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,4 +483,3 @@ pub use self::neon::neon_planner::FftPlannerNeon;
 
 #[cfg(test)]
 mod test_utils;
-

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -205,10 +205,16 @@ impl<T: FftNum> NeonF32Butterfly1<T> {
         }
     }
     #[inline(always)]
-    pub(crate) unsafe fn perform_fft_contiguous(&self, _buffer: impl NeonArrayMut<f32>) {}
+    pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f32>) {
+        let value = buffer.load_partial1_complex(0);
+        buffer.store_partial_lo_complex(value, 0);
+    }
 
     #[inline(always)]
-    pub(crate) unsafe fn perform_parallel_fft_contiguous(&self, _buffer: impl NeonArrayMut<f32>) {}
+    pub(crate) unsafe fn perform_parallel_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f32>) {
+        let value = buffer.load_complex(0);
+        buffer.store_complex(value, 0);
+    }
 }
 
 //   _             __   _  _   _     _ _
@@ -237,7 +243,10 @@ impl<T: FftNum> NeonF64Butterfly1<T> {
         }
     }
     #[inline(always)]
-    pub(crate) unsafe fn perform_fft_contiguous(&self, _buffer: impl NeonArrayMut<f64>) {}
+    pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f64>) {
+        let value = buffer.load_complex(0);
+        buffer.store_complex(value, 0);
+    }
 }
 
 //   ____            _________  _     _ _
@@ -3219,6 +3228,7 @@ mod unit_tests {
             }
         };
     }
+    test_butterfly_32_func!(test_neonf32_butterfly1, NeonF32Butterfly1, 1);
     test_butterfly_32_func!(test_neonf32_butterfly2, NeonF32Butterfly2, 2);
     test_butterfly_32_func!(test_neonf32_butterfly3, NeonF32Butterfly3, 3);
     test_butterfly_32_func!(test_neonf32_butterfly4, NeonF32Butterfly4, 4);
@@ -3246,6 +3256,7 @@ mod unit_tests {
             }
         };
     }
+    test_butterfly_64_func!(test_neonf64_butterfly1, NeonF64Butterfly1, 1);
     test_butterfly_64_func!(test_neonf64_butterfly2, NeonF64Butterfly2, 2);
     test_butterfly_64_func!(test_neonf64_butterfly3, NeonF64Butterfly3, 3);
     test_butterfly_64_func!(test_neonf64_butterfly4, NeonF64Butterfly4, 4);

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -211,7 +211,10 @@ impl<T: FftNum> NeonF32Butterfly1<T> {
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn perform_parallel_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f32>) {
+    pub(crate) unsafe fn perform_parallel_fft_contiguous(
+        &self,
+        mut buffer: impl NeonArrayMut<f32>,
+    ) {
         let value = buffer.load_complex(0);
         buffer.store_complex(value, 0);
     }

--- a/src/sse/sse_butterflies.rs
+++ b/src/sse/sse_butterflies.rs
@@ -211,10 +211,16 @@ impl<T: FftNum> SseF32Butterfly1<T> {
         }
     }
     #[inline(always)]
-    pub(crate) unsafe fn perform_fft_contiguous(&self, _buffer: impl SseArrayMut<f32>) {}
+    pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl SseArrayMut<f32>) {
+        let value = buffer.load_partial1_complex(0);
+        buffer.store_partial_lo_complex(value, 0);
+    }
 
     #[inline(always)]
-    pub(crate) unsafe fn perform_parallel_fft_contiguous(&self, _buffer: impl SseArrayMut<f32>) {}
+    pub(crate) unsafe fn perform_parallel_fft_contiguous(&self, mut buffer: impl SseArrayMut<f32>) {
+        let value = buffer.load_complex(0);
+        buffer.store_complex(value, 0);
+    }
 }
 
 //   _             __   _  _   _     _ _
@@ -243,7 +249,10 @@ impl<T: FftNum> SseF64Butterfly1<T> {
         }
     }
     #[inline(always)]
-    pub(crate) unsafe fn perform_fft_contiguous(&self, _buffer: impl SseArrayMut<f64>) {}
+    pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl SseArrayMut<f64>) {
+        let value = buffer.load_complex(0);
+        buffer.store_complex(value, 0);
+    }
 }
 
 //   ____            _________  _     _ _
@@ -3132,6 +3141,7 @@ mod unit_tests {
             }
         };
     }
+    test_butterfly_32_func!(test_ssef32_butterfly1, SseF32Butterfly1, 1);
     test_butterfly_32_func!(test_ssef32_butterfly2, SseF32Butterfly2, 2);
     test_butterfly_32_func!(test_ssef32_butterfly3, SseF32Butterfly3, 3);
     test_butterfly_32_func!(test_ssef32_butterfly4, SseF32Butterfly4, 4);
@@ -3159,6 +3169,7 @@ mod unit_tests {
             }
         };
     }
+    test_butterfly_64_func!(test_ssef64_butterfly1, SseF64Butterfly1, 1);
     test_butterfly_64_func!(test_ssef64_butterfly2, SseF64Butterfly2, 2);
     test_butterfly_64_func!(test_ssef64_butterfly3, SseF64Butterfly3, 3);
     test_butterfly_64_func!(test_ssef64_butterfly4, SseF64Butterfly4, 4);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -131,7 +131,7 @@ pub fn check_fft_algorithm<T: FftNum + Float + SampleUniform>(
     {
         let mut input = reference_input.clone();
         let mut scratch = vec![Zero::zero(); fft.get_outofplace_scratch_len()];
-        let mut output = expected_output.clone();
+        let mut output = vec![Zero::zero(); n * len];
 
         fft.process_outofplace_with_scratch(&mut input, &mut output, &mut scratch);
 


### PR DESCRIPTION
This fixes a problem where SSE and NEON size 1 butterflies don't work for out-of-place transform. The tests were not catching this because it was using a clone of the expected result as output. Therefore it could not catch that butterflies never wrote anything to the output.