### PR TITLE
Release 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [6.2]
+Released 22nd January 2024
+### Minimum Rustc Version
+ - The MSRV for RustFFT is now 1.61.0
+### Added
+ - Implemented a code path for SIMD-optimized FFTs on WASM targets (Thanks to @pr1metine) (#120)
+### Fixed
+ - Fixed pointer aliasing causing unsoundness and miri check failures (#113)
+ - Fixed computation of size-1 FFTs (#119)
+ - Fixed readme type (#121)
+
 ## [6.1]
 Released 7th Novemeber 2022
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustfft"
-version = "6.1.0"
+version = "6.2.0"
 authors = ["Allen Welkie <allen.welkie at gmail>", "Elliott Mahler <join.together at gmail>"]
 edition = "2018"
 
@@ -16,13 +16,16 @@ license = "MIT OR Apache-2.0"
 default = ["avx", "sse", "neon"]
 
 # On x86_64, the "avx" feature enables compilation of AVX-acclerated code. 
-# Similarly, the "sse" feature enables SSE-accelerated code. 
+# Similarly, the "sse" feature enables compilation of SSE-accelerated code. 
 # Enabling these improves performance if the client CPU supports AVX or SSE, while disabling them reduces compile time and binary size.
 # If both are enabled, RustFFT will use AVX if the CPU supports it. If not, it will check for SSE4.1.
 # If neither instruction set is available, it will fall back to the scalar code.  
-# On every other platform, these features do nothing, and RustFFT will behave like they are not set.
 #
 # On AArch64, the "neon" feature enables compilation of Neon-accelerated code.
+#
+# On wasm32, the "wasm_simd" feature enables compilation of Wasm SIMD accelerated code.
+#
+# For all of the above features, on every platform other than the intended platform for the feature, these features do nothing, and RustFFT will behave like they are not set.
 avx = []
 sse = []
 neon = []

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On other platforms than WASM, this feature does nothing and RustFFT will behave 
 
 ## Stability/Future Breaking Changes
 
-Version 5.0 contains several breaking API changes. Check out the [Upgrade Guide](/UpgradeGuide4to5.md) for a walkthrough of the changes RustFFT 5.0 requires. In the interest of stability, we're committing to making no more breaking changes for 3 years, aka until 2024.
+The latest version is 6.2 - Version 5.0 was released at the beginning of 2022 and contains several breaking API changes from previous versions. For users on very old version of RustFFT, check out the [Upgrade Guide](/UpgradeGuide4to5.md) for a walkthrough of the changes RustFFT 5.0 requires to upgrade. In the interest of stability, we're committing to making no more breaking changes for 3 years, aka until 2024.
 
 This policy has one exception: We currently re-export pre-1.0 versions of the [num-complex](https://crates.io/crates/num-complex) and [num-traits](https://crates.io/crates/num-traits) crates. In the interest of avoiding ecosystem fragmentation, we will keep up with these crates even if it requires major version bumps. When those crates release new major versions, we will upgrade as soon as possible, which will require a major version change of our own. In these situations, the version increase of num-complex/num-traits will be the only breaking change in the release.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RustFFT supports the NEON instruction set in 64-bit Arm, AArch64. As with AVX an
 
 ### WebAssembly Targets
 
-RustFFT additionally supports [the fixed-width SIMD extension for WebAssembly](https://github.com/WebAssembly/spec/blob/main/proposals/simd/SIMD.md). Just like AVX, SSE, and NEON, no special code is needed to take advantage of this code path; all you need to do is plan a FFT using the `FftPlanner`.
+RustFFT supports [the fixed-width SIMD extension for WebAssembly](https://github.com/WebAssembly/spec/blob/main/proposals/simd/SIMD.md). Just like AVX, SSE, and NEON, no special code is needed to take advantage of this code path; all you need to do is plan a FFT using the `FftPlanner`.
 
 **Note:** There is an important caveat when compiling WASM SIMD accelerated code: Unlike AVX, SSE, and NEON, WASM does not allow dynamic feature detection. Because of this limitation, RustFFT **cannot** detect CPU features and automatically switch to WASM SIMD accelerated algorithms. Instead, it unconditionally uses the SIMD code path if the `wasm_simd` crate feature is enabled. Read more about this limitation [in the official Rust docs](https://doc.rust-lang.org/1.75.0/core/arch/wasm32/index.html#simd).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RustFFT supports the NEON instruction set in 64-bit Arm, AArch64. As with AVX an
 
 ### WebAssembly Targets
 
-RustFFT supports [the fixed-width SIMD extension for WebAssembly](https://github.com/WebAssembly/spec/blob/main/proposals/simd/SIMD.md). Just like AVX, SSE, and NEON, no special code is needed to take advantage of this code path; all you need to do is plan a FFT using the `FftPlanner`.
+RustFFT supports [the fixed-width SIMD extension for WebAssembly](https://github.com/WebAssembly/spec/blob/main/proposals/simd/SIMD.md). Just like AVX, SSE, and NEON, no special code is needed to take advantage of this code path: All you need to do is plan a FFT using the `FftPlanner`.
 
 **Note:** There is an important caveat when compiling WASM SIMD accelerated code: Unlike AVX, SSE, and NEON, WASM does not allow dynamic feature detection. Because of this limitation, RustFFT **cannot** detect CPU features and automatically switch to WASM SIMD accelerated algorithms. Instead, it unconditionally uses the SIMD code path if the `wasm_simd` crate feature is enabled. Read more about this limitation [in the official Rust docs](https://doc.rust-lang.org/1.75.0/core/arch/wasm32/index.html#simd).
 

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,7 @@
 extern crate version_check;
 
-// All platforms except AArch64 with neon support enabled.
 static MIN_RUSTC: &str = "1.61.0";
-// On AArch64 with neon support enabled.
-#[cfg(all(target_arch = "aarch64", feature = "neon"))]
-static MIN_RUSTC_NEON: &str = "1.61.0";
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
-static MIN_RUSTC_WASM_SIMD: &str = "1.61.0";
-
-#[cfg(not(any(
-    all(target_arch = "aarch64", feature = "neon"),
-    all(target_arch = "wasm32", feature = "wasm_simd")
-)))]
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     match version_check::is_min_version(MIN_RUSTC) {
@@ -20,37 +9,6 @@ fn main() {
         Some(false) => panic!(
             "\n====\nUnsupported rustc version {}\nRustFFT needs at least {}\n====\n",
             version_check::Version::read().unwrap(),
-            MIN_RUSTC
-        ),
-        None => panic!("Unable to determine rustc version."),
-    };
-}
-
-#[cfg(all(target_arch = "aarch64", feature = "neon"))]
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    match version_check::is_min_version(MIN_RUSTC_NEON) {
-        Some(true) => {}
-        Some(false) => panic!(
-            "\n====\nUnsupported rustc version {}\nRustFFT with neon support needs at least {}\nIf the 'neon' feature flag is disabled, the minimum version is {}\n====\n",
-            version_check::Version::read().unwrap(),
-            MIN_RUSTC_NEON,
-            MIN_RUSTC
-        ),
-        None => panic!("Unable to determine rustc version."),
-    };
-}
-
-// Weird bug with wasm-pack, may not work. It may use host information instead, i. e. target_arch = "aarch64" for M1
-#[cfg(all(target_arch = "wasm32", feature = "wasm_simd"))]
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    match version_check::is_min_version(MIN_RUSTC_WASM_SIMD) {
-        Some(true) => {}
-        Some(false) => panic!(
-            "\n====\nUnsupported rustc version {}\nRustFFT with WASM SIMD support needs at least {}\nIf the 'neon' feature flag is disabled, the minimum version is {}\n====\n",
-            version_check::Version::read().unwrap(),
-            MIN_RUSTC_WASM_SIMD,
             MIN_RUSTC
         ),
         None => panic!("Unable to determine rustc version."),

--- a/src/avx/avx_planner.rs
+++ b/src/avx/avx_planner.rs
@@ -103,7 +103,7 @@ impl MixedRadixPlan {
 /// }
 /// ~~~
 ///
-/// If you plan on creating multiple FFT instances, it is recommended to reuse the same planner for all of them. This
+/// If you plan on creating multiple FFT instances, it is recommended to re-use the same planner for all of them. This
 /// is because the planner re-uses internal data across FFT instances wherever possible, saving memory and reducing
 /// setup time. (FFT instances created with one planner will never re-use data and buffers with FFT instances created
 /// by a different planner)
@@ -116,8 +116,8 @@ pub struct FftPlannerAvx<T: FftNum> {
 impl<T: FftNum> FftPlannerAvx<T> {
     /// Constructs a new `FftPlannerAvx` instance.
     ///
-    /// Returns `Ok(planner_instance)` if this machine has the required instruction sets and the `avx` feature flag is set.
-    /// Returns `Err(())` if some instruction sets are missing, or if the `avx` feature flag is not set.
+    /// Returns `Ok(planner_instance)` if we're compiling for X86_64, AVX support was enabled in feature flags, and the current CPU supports the `avx` and `fma` CPU features.
+    /// Returns `Err(())` if AVX support is not available.
     pub fn new() -> Result<Self, ()> {
         // Eventually we might make AVX algorithms that don't also require FMA.
         // If that happens, we can only check for AVX here? seems like a pretty low-priority addition

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,13 @@
 //!
 //!     On AArch64 (64-bit ARM) the `neon` feature enables compilation of Neon-accelerated code. Enabling it improves
 //!     performance, while disabling it reduces compile time and binary size.
-//!     Note that Rust's Neon support requires using rustc 1.61 or newer.
+//! 
+//!     On every platform besides AArch64, this feature does nothing, and RustFFT will behave like it's not set.
 //! * `wasm_simd` (Disabled by default)
 //!
-//!     The feature `wasm_simd` is disabled by default. On the WASM platform, this feature enables compilation of WASM SIMD accelerated code.
-//!     To compile with `wasm_simd`, you need rustc v1.61.0 or newer and a [browser or runtime which supports `fixed-width SIMD`](https://webassembly.org/roadmap/).
+//!     On the WASM platform, this feature enables compilation of WASM SIMD accelerated code.
+//! 
+//!     To execute binaries compiled with `wasm_simd`, you need a [target browser or runtime which supports `fixed-width SIMD`](https://webassembly.org/roadmap/).
 //!     If you run your SIMD accelerated code on an unsupported platform, WebAssembly will specify a [trap](https://webassembly.github.io/spec/core/intro/overview.html#trap) leading to immediate execution cancelation.
 //!
 //!     On every platform besides WASM, this feature does nothing and RustFFT will behave like it is not set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,12 @@
 //!
 //!     On AArch64 (64-bit ARM) the `neon` feature enables compilation of Neon-accelerated code. Enabling it improves
 //!     performance, while disabling it reduces compile time and binary size.
-//! 
+//!
 //!     On every platform besides AArch64, this feature does nothing, and RustFFT will behave like it's not set.
 //! * `wasm_simd` (Disabled by default)
 //!
 //!     On the WASM platform, this feature enables compilation of WASM SIMD accelerated code.
-//! 
+//!
 //!     To execute binaries compiled with `wasm_simd`, you need a [target browser or runtime which supports `fixed-width SIMD`](https://webassembly.org/roadmap/).
 //!     If you run your SIMD accelerated code on an unsupported platform, WebAssembly will specify a [trap](https://webassembly.github.io/spec/core/intro/overview.html#trap) leading to immediate execution cancelation.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,15 @@
 
 //! RustFFT is a high-performance FFT library written in pure Rust.
 //!
-//! RustFFT supports the AVX instruction set for increased performance. No special code is needed to activate AVX:
+//! On X86_64, RustFFT supports the AVX instruction set for increased performance. No special code is needed to activate AVX:
 //! Simply plan a FFT using the FftPlanner on a machine that supports the `avx` and `fma` CPU features, and RustFFT
 //! will automatically switch to faster AVX-accelerated algorithms.
 //!
 //! For machines that do not have AVX, RustFFT also supports the SSE4.1 instruction set.
 //! As for AVX, this is enabled automatically when using the FftPlanner.
 //!
-//! Additionally, there is (opt-in) support for the Neon instruction set on AArch64.
+//! Additionally, there is automatic support for the Neon instruction set on AArch64,
+//! and support for WASM SIMD when compiling for WASM targets.
 //!
 //! ### Usage
 //!

--- a/src/neon/neon_planner.rs
+++ b/src/neon/neon_planner.rs
@@ -142,7 +142,7 @@ impl Recipe {
 /// }
 /// ~~~
 ///
-/// If you plan on creating multiple FFT instances, it is recommended to reuse the same planner for all of them. This
+/// If you plan on creating multiple FFT instances, it is recommended to re-use the same planner for all of them. This
 /// is because the planner re-uses internal data across FFT instances wherever possible, saving memory and reducing
 /// setup time. (FFT instances created with one planner will never re-use data and buffers with FFT instances created
 /// by a different planner)
@@ -157,8 +157,8 @@ pub struct FftPlannerNeon<T: FftNum> {
 impl<T: FftNum> FftPlannerNeon<T> {
     /// Creates a new `FftPlannerNeon` instance.
     ///
-    /// Returns `Ok(planner_instance)` if this machine has the required instruction sets.
-    /// Returns `Err(())` if some instruction sets are missing.
+    /// Returns `Ok(planner_instance)` if we're compiling for AArch64 and NEON support was enabled in feature flags.
+    /// Returns `Err(())` if NEON support is not available.
     pub fn new() -> Result<Self, ()> {
         if std::arch::is_aarch64_feature_detected!("neon") {
             // Ideally, we would implement the planner with specialization.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -53,10 +53,14 @@ enum ChosenFftPlanner<T: FftNum> {
 /// Each FFT instance owns [`Arc`s](std::sync::Arc) to its internal data, rather than borrowing it from the planner, so it's perfectly
 /// safe to drop the planner after creating Fft instances.
 ///
-/// In the constructor, the FftPlanner will detect available CPU features. If AVX is available, it will set itself up to plan AVX-accelerated FFTs.
-/// If AVX isn't available, the planner will seamlessly fall back to planning non-SIMD FFTs.
+/// In the constructor, the FftPlanner will detect available CPU features. If AVX, SSE, Neon, or WASM SIMD are available, it will set itself up to plan FFTs with the fastest available instruction set.
+/// If no SIMD instruction sets are available, the planner will seamlessly fall back to planning non-SIMD FFTs.
 ///
-/// If you'd prefer not to compute a FFT at all if AVX isn't available, consider creating a [`FftPlannerAvx`](crate::FftPlannerAvx) instead.
+/// If you'd prefer not to compute a FFT at all if a certain SIMD instruction set isn't available, or otherwise specify your own custom fallback, RustFFT exposes dedicated planners for each instruction set:
+///  - [`FftPlannerAvx`](crate::FftPlannerAvx)
+///  - [`FftPlannerSse`](crate::FftPlannerSse)
+///  - [`FftPlannerNeon`](crate::FftPlannerNeon)
+///  - [`FftPlannerWasmSimd`](crate::FftPlannerWasmSimd)
 ///
 /// If you'd prefer to opt out of SIMD algorithms, consider creating a [`FftPlannerScalar`](crate::FftPlannerScalar) instead.
 pub struct FftPlanner<T: FftNum> {

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -142,7 +142,7 @@ impl Recipe {
 /// }
 /// ~~~
 ///
-/// If you plan on creating multiple FFT instances, it is recommended to reuse the same planner for all of them. This
+/// If you plan on creating multiple FFT instances, it is recommended to re-use the same planner for all of them. This
 /// is because the planner re-uses internal data across FFT instances wherever possible, saving memory and reducing
 /// setup time. (FFT instances created with one planner will never re-use data and buffers with FFT instances created
 /// by a different planner)
@@ -157,8 +157,8 @@ pub struct FftPlannerSse<T: FftNum> {
 impl<T: FftNum> FftPlannerSse<T> {
     /// Creates a new `FftPlannerSse` instance.
     ///
-    /// Returns `Ok(planner_instance)` if this machine has the required instruction sets.
-    /// Returns `Err(())` if some instruction sets are missing.
+    /// Returns `Ok(planner_instance)` if we're compiling for X86_64, SSE support was enabled in feature flags, and the current CPU supports the `sse4.1` CPU feature.
+    /// Returns `Err(())` if SSE support is not available.
     pub fn new() -> Result<Self, ()> {
         if is_x86_feature_detected!("sse4.1") {
             // Ideally, we would implement the planner with specialization.

--- a/src/wasm_simd/wasm_simd_planner.rs
+++ b/src/wasm_simd/wasm_simd_planner.rs
@@ -115,7 +115,7 @@ impl Recipe {
 }
 
 /// The WASM FFT planner creates new FFT algorithm instances using a mix of scalar and WASM SIMD accelerated algorithms.
-/// It is supported when using fairly recent browser versions as outlined in [the WebAssembly roadmap](https://webassembly.org/roadmap/).
+/// WASM SIMD is supported when using fairly recent browser versions as outlined in [the WebAssembly roadmap](https://webassembly.org/roadmap/).
 ///
 /// RustFFT has several FFT algorithms available. For a given FFT size, `FftPlannerWasmSimd` decides which of the
 /// available FFT algorithms to use and then initializes them.
@@ -137,7 +137,7 @@ impl Recipe {
 /// }
 /// ~~~
 ///
-/// If you plan on creating multiple FFT instances, it is recommended to reuse the same planner for all of them. This
+/// If you plan on creating multiple FFT instances, it is recommended to re-use the same planner for all of them. This
 /// is because the planner re-uses internal data across FFT instances wherever possible, saving memory and reducing
 /// setup time. (FFT instances created with one planner will never re-use data and buffers with FFT instances created
 /// by a different planner)
@@ -151,8 +151,8 @@ pub struct FftPlannerWasmSimd<T: FftNum> {
 impl<T: FftNum> FftPlannerWasmSimd<T> {
     /// Creates a new `FftPlannerWasmSimd` instance.
     ///
-    /// Returns `Ok(planner_instance)` if this machine has the required instruction sets.
-    /// Returns `Err(())` if some instruction sets are missing.
+    /// Returns `Ok(planner_instance)` if we're compiling for the WASM target and WASM SIMD was enabled in feature flags.
+    /// Returns `Err(())` if WASM SIMD support is not available.
     pub fn new() -> Result<Self, ()> {
         let id_f32 = TypeId::of::<f32>();
         let id_f64 = TypeId::of::<f64>();


### PR DESCRIPTION
Documentation, toml, and build-rs changes for the 6.2 release. There were many leftover references to our split MSRV for neon vs non-neon - since we moved back to a single MSRV for webassembly, I got rid of those and just documented everything at 1.61.