### PR TITLE
Unify the f32 and f64 code paths for SIMD radix4

### DIFF
--- a/src/algorithm/radix3.rs
+++ b/src/algorithm/radix3.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use num_complex::Complex;
@@ -58,9 +57,9 @@ impl<T: FftNum> Radix3<T> {
     }
 
     /// Constructs a Radix3 instance which computes FFTs of length `3^k * base_fft.len()`
-    pub fn new_with_base(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+    pub fn new_with_base(k: u32, base_fft: Arc<dyn Fft<T>>) -> Self {
         let base_len = base_fft.len();
-        let len = base_len * 3usize.pow(k.try_into().unwrap());
+        let len = base_len * 3usize.pow(k);
 
         let direction = base_fft.fft_direction();
 
@@ -197,7 +196,7 @@ mod unit_tests {
         }
     }
 
-    fn test_radix3(k: usize, base_fft: Arc<dyn Fft<f32>>) {
+    fn test_radix3(k: u32, base_fft: Arc<dyn Fft<f32>>) {
         let len = base_fft.len() * 3usize.pow(k as u32);
         let direction = base_fft.fft_direction();
         let fft = Radix3::new_with_base(k, base_fft);

--- a/src/algorithm/radix3.rs
+++ b/src/algorithm/radix3.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::sync::Arc;
 
 use num_complex::Complex;
@@ -46,12 +47,22 @@ impl<T: FftNum> Radix3<T> {
         });
 
         // figure out which base length we're going to use
-        let (base_len, base_fft) = match exponent {
-            0 => (len, Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>),
-            1 => (len, Arc::new(Butterfly3::new(direction)) as Arc<dyn Fft<T>>),
-            2 => (len, Arc::new(Butterfly9::new(direction)) as Arc<dyn Fft<T>>),
-            _ => (27, Arc::new(Butterfly27::new(direction)) as Arc<dyn Fft<T>>),
+        let (base_exponent, base_fft) = match exponent {
+            0 => (0, Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>),
+            1 => (1, Arc::new(Butterfly3::new(direction)) as Arc<dyn Fft<T>>),
+            2 => (2, Arc::new(Butterfly9::new(direction)) as Arc<dyn Fft<T>>),
+            _ => (3, Arc::new(Butterfly27::new(direction)) as Arc<dyn Fft<T>>),
         };
+
+        Self::new_with_base(exponent - base_exponent, base_fft)
+    }
+
+    /// Constructs a Radix3 instance which computes FFTs of length `3^k * base_fft.len()`
+    pub fn new_with_base(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+        let base_len = base_fft.len();
+        let len = base_len * 3usize.pow(k.try_into().unwrap());
+
+        let direction = base_fft.fft_direction();
 
         // precompute the twiddle factors this algorithm will use.
         // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=3 and height=len/3
@@ -158,19 +169,38 @@ unsafe fn butterfly_3<T: FftNum>(
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::test_utils::check_fft_algorithm;
+    use crate::test_utils::{check_fft_algorithm, construct_base};
 
     #[test]
-    fn test_radix3() {
+    fn test_radix3_with_length() {
         for pow in 0..8 {
             let len = 3usize.pow(pow);
-            test_3adix3_with_length(len, FftDirection::Forward);
-            test_3adix3_with_length(len, FftDirection::Inverse);
+
+            let forward_fft = Radix3::new(len, FftDirection::Forward);
+            check_fft_algorithm::<f32>(&forward_fft, len, FftDirection::Forward);
+
+            let inverse_fft = Radix3::new(len, FftDirection::Inverse);
+            check_fft_algorithm::<f32>(&inverse_fft, len, FftDirection::Inverse);
         }
     }
 
-    fn test_3adix3_with_length(len: usize, direction: FftDirection) {
-        let fft = Radix3::new(len, direction);
+    #[test]
+    fn test_radix3_with_base() {
+        for base in 1..=9 {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
+
+            for k in 0..5 {
+                test_radix3(k, Arc::clone(&base_forward));
+                test_radix3(k, Arc::clone(&base_inverse));
+            }
+        }
+    }
+
+    fn test_radix3(k: usize, base_fft: Arc<dyn Fft<f32>>) {
+        let len = base_fft.len() * 3usize.pow(k as u32);
+        let direction = base_fft.fft_direction();
+        let fft = Radix3::new_with_base(k, base_fft);
 
         check_fft_algorithm::<f32>(&fft, len, direction);
     }

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -43,7 +43,7 @@ impl<T: FftNum> Radix4<T> {
         );
 
         // figure out which base length we're going to use
-        let exponent = len.trailing_zeros() as usize;
+        let exponent = len.trailing_zeros();
         let (base_exponent, base_fft) = match exponent {
             0 => (0, Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>),
             1 => (1, Arc::new(Butterfly2::new(direction)) as Arc<dyn Fft<T>>),
@@ -61,7 +61,7 @@ impl<T: FftNum> Radix4<T> {
     }
 
     /// Constructs a Radix4 instance which computes FFTs of length `4^k * base_fft.len()`
-    pub fn new_with_base(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+    pub fn new_with_base(k: u32, base_fft: Arc<dyn Fft<T>>) -> Self {
         let base_len = base_fft.len();
         let len = base_len * (1 << (k * 2));
 
@@ -203,7 +203,7 @@ mod unit_tests {
         }
     }
 
-    fn test_radix4(k: usize, base_fft: Arc<dyn Fft<f64>>) {
+    fn test_radix4(k: u32, base_fft: Arc<dyn Fft<f64>>) {
         let len = base_fft.len() * 4usize.pow(k as u32);
         let direction = base_fft.fft_direction();
         let fft = Radix4::new_with_base(k, base_fft);

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -43,19 +43,29 @@ impl<T: FftNum> Radix4<T> {
         );
 
         // figure out which base length we're going to use
-        let num_bits = len.trailing_zeros();
-        let (base_len, base_fft) = match num_bits {
-            0 => (len, Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>),
-            1 => (len, Arc::new(Butterfly2::new(direction)) as Arc<dyn Fft<T>>),
-            2 => (len, Arc::new(Butterfly4::new(direction)) as Arc<dyn Fft<T>>),
+        let exponent = len.trailing_zeros() as usize;
+        let (base_exponent, base_fft) = match exponent {
+            0 => (0, Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>),
+            1 => (1, Arc::new(Butterfly2::new(direction)) as Arc<dyn Fft<T>>),
+            2 => (2, Arc::new(Butterfly4::new(direction)) as Arc<dyn Fft<T>>),
             _ => {
-                if num_bits % 2 == 1 {
-                    (8, Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>)
+                if exponent % 2 == 1 {
+                    (3, Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>)
                 } else {
-                    (16, Arc::new(Butterfly16::new(direction)) as Arc<dyn Fft<T>>)
+                    (4, Arc::new(Butterfly16::new(direction)) as Arc<dyn Fft<T>>)
                 }
             }
         };
+
+        Self::new_with_base((exponent - base_exponent) / 2, base_fft)
+    }
+
+    /// Constructs a Radix4 instance which computes FFTs of length `4^k * base_fft.len()`
+    pub fn new_with_base(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+        let base_len = base_fft.len();
+        let len = base_len * (1 << (k * 2));
+
+        let direction = base_fft.fft_direction();
 
         // precompute the twiddle factors this algorithm will use.
         // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
@@ -165,20 +175,39 @@ unsafe fn butterfly_4<T: FftNum>(
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::test_utils::check_fft_algorithm;
+    use crate::test_utils::{check_fft_algorithm, construct_base};
 
     #[test]
-    fn test_radix4() {
-        for pow in 1..12 {
+    fn test_radix4_with_length() {
+        for pow in 0..8 {
             let len = 1 << pow;
-            test_radix4_with_length(len, FftDirection::Forward);
-            //test_radix4_with_length(len, FftDirection::Inverse);
+
+            let forward_fft = Radix4::new(len, FftDirection::Forward);
+            check_fft_algorithm::<f32>(&forward_fft, len, FftDirection::Forward);
+
+            let inverse_fft = Radix4::new(len, FftDirection::Inverse);
+            check_fft_algorithm::<f32>(&inverse_fft, len, FftDirection::Inverse);
         }
     }
 
-    fn test_radix4_with_length(len: usize, direction: FftDirection) {
-        let fft = Radix4::new(len, direction);
+    #[test]
+    fn test_radix4_with_base() {
+        for base in 1..=9 {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
 
-        check_fft_algorithm::<f32>(&fft, len, direction);
+            for k in 0..4 {
+                test_radix4(k, Arc::clone(&base_forward));
+                test_radix4(k, Arc::clone(&base_inverse));
+            }
+        }
+    }
+
+    fn test_radix4(k: usize, base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * 4usize.pow(k as u32);
+        let direction = base_fft.fft_direction();
+        let fft = Radix4::new_with_base(k, base_fft);
+
+        check_fft_algorithm::<f64>(&fft, len, direction);
     }
 }

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -205,7 +205,7 @@ pub fn bitreversed_transpose<T: Copy, const D: usize>(
 
         // verify that width is a power of d
         assert!(width_bits % d_bits == 0);
-        (width_bits / d_bits) as usize
+        width_bits / d_bits
     } else {
         compute_logarithm::<D>(width).unwrap()
     };
@@ -243,7 +243,7 @@ pub fn bitreversed_transpose<T: Copy, const D: usize>(
 // Repeatedly divide `value` by divisor `D`, `iters` times, and apply the remainders to a new value
 // When D is a power of 2, this is exactly equal (implementation and assembly)-wise to a bit reversal
 // When D is not a power of 2, think of this function as a logical equivalent to a bit reversal
-pub fn reverse_remainders<const D: usize>(value: usize, rev_digits: usize) -> usize {
+pub fn reverse_remainders<const D: usize>(value: usize, rev_digits: u32) -> usize {
     assert!(D > 1);
 
     let mut result: usize = 0;
@@ -256,7 +256,7 @@ pub fn reverse_remainders<const D: usize>(value: usize, rev_digits: usize) -> us
 }
 
 // computes `n` such that `D ^ n == value`. Returns `None` if `value` is not a perfect power of `D`, otherwise returns `Some(n)`
-pub fn compute_logarithm<const D: usize>(value: usize) -> Option<usize> {
+pub fn compute_logarithm<const D: usize>(value: usize) -> Option<u32> {
     if value == 0 || D < 2 {
         return None;
     }

--- a/src/neon/mod.rs
+++ b/src/neon/mod.rs
@@ -15,3 +15,14 @@ pub mod neon_planner;
 pub use self::neon_butterflies::*;
 pub use self::neon_prime_butterflies::*;
 pub use self::neon_radix4::*;
+
+pub trait NeonNum: FftNum {
+    type VectorType: NeonVector<ScalarType = Self>;
+}
+
+impl NeonNum for f32 {
+    type VectorType = float32x4_t;
+}
+impl NeonNum for f64 {
+    type VectorType = float64x2_t;
+}

--- a/src/neon/mod.rs
+++ b/src/neon/mod.rs
@@ -16,6 +16,11 @@ pub use self::neon_butterflies::*;
 pub use self::neon_prime_butterflies::*;
 pub use self::neon_radix4::*;
 
+use std::arch::aarch64::{float32x4_t, float64x2_t};
+
+use crate::FftNum;
+use neon_vector::NeonVector;
+
 pub trait NeonNum: FftNum {
     type VectorType: NeonVector<ScalarType = Self>;
 }

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -12,7 +12,7 @@ use crate::{Direction, Fft, Length};
 
 use super::neon_common::{assert_f32, assert_f64};
 use super::neon_utils::*;
-use super::neon_vector::NeonArrayMut;
+use super::neon_vector::{NeonArrayMut, NeonVector};
 
 #[allow(unused)]
 macro_rules! boilerplate_fft_neon_f32_butterfly {
@@ -1601,10 +1601,10 @@ impl<T: FftNum> NeonF32Butterfly9<T> {
             .perform_parallel_fft_direct(values[2], values[5], values[8]);
 
         // Apply twiddle factors. Note that we're re-using twiddle2
-        mid1[1] = mul_complex_f32(self.twiddle1, mid1[1]);
-        mid1[2] = mul_complex_f32(self.twiddle2, mid1[2]);
-        mid2[1] = mul_complex_f32(self.twiddle2, mid2[1]);
-        mid2[2] = mul_complex_f32(self.twiddle4, mid2[2]);
+        mid1[1] = NeonVector::mul_complex(self.twiddle1, mid1[1]);
+        mid1[2] = NeonVector::mul_complex(self.twiddle2, mid1[2]);
+        mid2[1] = NeonVector::mul_complex(self.twiddle2, mid2[1]);
+        mid2[2] = NeonVector::mul_complex(self.twiddle4, mid2[2]);
 
         let [output0, output1, output2] = self
             .bf3
@@ -1683,10 +1683,10 @@ impl<T: FftNum> NeonF64Butterfly9<T> {
         let mut mid2 = self.bf3.perform_fft_direct(values[2], values[5], values[8]);
 
         // Apply twiddle factors. Note that we're re-using twiddle2
-        mid1[1] = mul_complex_f64(self.twiddle1, mid1[1]);
-        mid1[2] = mul_complex_f64(self.twiddle2, mid1[2]);
-        mid2[1] = mul_complex_f64(self.twiddle2, mid2[1]);
-        mid2[2] = mul_complex_f64(self.twiddle4, mid2[2]);
+        mid1[1] = NeonVector::mul_complex(self.twiddle1, mid1[1]);
+        mid1[2] = NeonVector::mul_complex(self.twiddle2, mid1[2]);
+        mid2[1] = NeonVector::mul_complex(self.twiddle2, mid2[1]);
+        mid2[2] = NeonVector::mul_complex(self.twiddle4, mid2[2]);
 
         let [output0, output1, output2] = self.bf3.perform_fft_direct(mid0[0], mid1[0], mid2[0]);
         let [output3, output4, output5] = self.bf3.perform_fft_direct(mid0[1], mid1[1], mid2[1]);
@@ -2421,11 +2421,11 @@ impl<T: FftNum> NeonF32Butterfly16<T> {
         let mut odds3 = self.bf4.perform_fft_direct(in1503, in0711);
 
         // step 3: apply twiddle factors
-        odds1[0] = mul_complex_f32(odds1[0], self.twiddle01);
-        odds3[0] = mul_complex_f32(odds3[0], self.twiddle01conj);
+        odds1[0] = NeonVector::mul_complex(odds1[0], self.twiddle01);
+        odds3[0] = NeonVector::mul_complex(odds3[0], self.twiddle01conj);
 
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle23);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle23conj);
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle23);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle23conj);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -2465,14 +2465,14 @@ impl<T: FftNum> NeonF32Butterfly16<T> {
             .perform_parallel_fft_direct(input[15], input[3], input[7], input[11]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle1c);
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f32(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f32(odds3[2], self.twiddle2c);
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f32(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f32(odds3[3], self.twiddle3c);
+        odds1[3] = NeonVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = NeonVector::mul_complex(odds3[3], self.twiddle3c);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -2613,14 +2613,14 @@ impl<T: FftNum> NeonF64Butterfly16<T> {
             .perform_fft_direct(input[15], input[3], input[7], input[11]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f64(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f64(odds3[1], self.twiddle1c);
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f64(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f64(odds3[2], self.twiddle2c);
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f64(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f64(odds3[3], self.twiddle3c);
+        odds1[3] = NeonVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = NeonVector::mul_complex(odds3[3], self.twiddle3c);
 
         // step 4: cross FFTs
         let mut temp0 = solo_fft2_f64(odds1[0], odds3[0]);
@@ -2829,17 +2829,17 @@ impl<T: FftNum> NeonF32Butterfly32<T> {
             .perform_fft_direct([in3103, in0711, in1519, in2327]);
 
         // step 3: apply twiddle factors
-        odds1[0] = mul_complex_f32(odds1[0], self.twiddle01);
-        odds3[0] = mul_complex_f32(odds3[0], self.twiddle01conj);
+        odds1[0] = NeonVector::mul_complex(odds1[0], self.twiddle01);
+        odds3[0] = NeonVector::mul_complex(odds3[0], self.twiddle01conj);
 
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle23);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle23conj);
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle23);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle23conj);
 
-        odds1[2] = mul_complex_f32(odds1[2], self.twiddle45);
-        odds3[2] = mul_complex_f32(odds3[2], self.twiddle45conj);
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle45);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle45conj);
 
-        odds1[3] = mul_complex_f32(odds1[3], self.twiddle67);
-        odds3[3] = mul_complex_f32(odds3[3], self.twiddle67conj);
+        odds1[3] = NeonVector::mul_complex(odds1[3], self.twiddle67);
+        odds3[3] = NeonVector::mul_complex(odds3[3], self.twiddle67conj);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -2896,26 +2896,26 @@ impl<T: FftNum> NeonF32Butterfly32<T> {
         ]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle1c);
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f32(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f32(odds3[2], self.twiddle2c);
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f32(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f32(odds3[3], self.twiddle3c);
+        odds1[3] = NeonVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = NeonVector::mul_complex(odds3[3], self.twiddle3c);
 
-        odds1[4] = mul_complex_f32(odds1[4], self.twiddle4);
-        odds3[4] = mul_complex_f32(odds3[4], self.twiddle4c);
+        odds1[4] = NeonVector::mul_complex(odds1[4], self.twiddle4);
+        odds3[4] = NeonVector::mul_complex(odds3[4], self.twiddle4c);
 
-        odds1[5] = mul_complex_f32(odds1[5], self.twiddle5);
-        odds3[5] = mul_complex_f32(odds3[5], self.twiddle5c);
+        odds1[5] = NeonVector::mul_complex(odds1[5], self.twiddle5);
+        odds3[5] = NeonVector::mul_complex(odds3[5], self.twiddle5c);
 
-        odds1[6] = mul_complex_f32(odds1[6], self.twiddle6);
-        odds3[6] = mul_complex_f32(odds3[6], self.twiddle6c);
+        odds1[6] = NeonVector::mul_complex(odds1[6], self.twiddle6);
+        odds3[6] = NeonVector::mul_complex(odds3[6], self.twiddle6c);
 
-        odds1[7] = mul_complex_f32(odds1[7], self.twiddle7);
-        odds3[7] = mul_complex_f32(odds3[7], self.twiddle7c);
+        odds1[7] = NeonVector::mul_complex(odds1[7], self.twiddle7);
+        odds3[7] = NeonVector::mul_complex(odds3[7], self.twiddle7c);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -3132,26 +3132,26 @@ impl<T: FftNum> NeonF64Butterfly32<T> {
         ]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f64(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f64(odds3[1], self.twiddle1c);
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f64(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f64(odds3[2], self.twiddle2c);
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f64(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f64(odds3[3], self.twiddle3c);
+        odds1[3] = NeonVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = NeonVector::mul_complex(odds3[3], self.twiddle3c);
 
-        odds1[4] = mul_complex_f64(odds1[4], self.twiddle4);
-        odds3[4] = mul_complex_f64(odds3[4], self.twiddle4c);
+        odds1[4] = NeonVector::mul_complex(odds1[4], self.twiddle4);
+        odds3[4] = NeonVector::mul_complex(odds3[4], self.twiddle4c);
 
-        odds1[5] = mul_complex_f64(odds1[5], self.twiddle5);
-        odds3[5] = mul_complex_f64(odds3[5], self.twiddle5c);
+        odds1[5] = NeonVector::mul_complex(odds1[5], self.twiddle5);
+        odds3[5] = NeonVector::mul_complex(odds3[5], self.twiddle5c);
 
-        odds1[6] = mul_complex_f64(odds1[6], self.twiddle6);
-        odds3[6] = mul_complex_f64(odds3[6], self.twiddle6c);
+        odds1[6] = NeonVector::mul_complex(odds1[6], self.twiddle6);
+        odds3[6] = NeonVector::mul_complex(odds3[6], self.twiddle6c);
 
-        odds1[7] = mul_complex_f64(odds1[7], self.twiddle7);
-        odds3[7] = mul_complex_f64(odds3[7], self.twiddle7c);
+        odds1[7] = NeonVector::mul_complex(odds1[7], self.twiddle7);
+        odds3[7] = NeonVector::mul_complex(odds3[7], self.twiddle7c);
 
         // step 4: cross FFTs
         let mut temp0 = solo_fft2_f64(odds1[0], odds3[0]);

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -206,7 +206,7 @@ impl<T: FftNum> NeonF32Butterfly1<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f32>) {
-        let value = buffer.load_partial1_complex(0);
+        let value = buffer.load_partial_lo_complex(0);
         buffer.store_partial_lo_complex(value, 0);
     }
 
@@ -444,7 +444,7 @@ impl<T: FftNum> NeonF32Butterfly3<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f32>) {
-        let value0x = buffer.load_partial1_complex(0);
+        let value0x = buffer.load_partial_lo_complex(0);
         let value12 = buffer.load_complex(1);
 
         let out = self.perform_fft_direct(value0x, value12);

--- a/src/neon/neon_common.rs
+++ b/src/neon/neon_common.rs
@@ -96,7 +96,7 @@ macro_rules! separate_interleaved_complex_f32 {
 
 macro_rules! boilerplate_fft_neon_oop {
     ($struct_name:ident, $len_fn:expr) => {
-        impl<T: FftNum> Fft<T> for $struct_name<T> {
+        impl<N: NeonNum, T: FftNum> Fft<T> for $struct_name<N, T> {
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -174,13 +174,13 @@ macro_rules! boilerplate_fft_neon_oop {
                 0
             }
         }
-        impl<T> Length for $struct_name<T> {
+        impl<N: NeonNum, T> Length for $struct_name<N, T> {
             #[inline(always)]
             fn len(&self) -> usize {
                 $len_fn(self)
             }
         }
-        impl<T> Direction for $struct_name<T> {
+        impl<N: NeonNum, T> Direction for $struct_name<N, T> {
             #[inline(always)]
             fn fft_direction(&self) -> FftDirection {
                 self.direction

--- a/src/neon/neon_planner.rs
+++ b/src/neon/neon_planner.rs
@@ -720,7 +720,7 @@ mod unit_tests {
         for pow in 6..32 {
             let len = 1 << pow;
             let plan = planner.design_fft_for_len(len);
-            assert_eq!(*plan, Recipe::Radix4(len));
+            assert!(matches!(*plan, Recipe::Radix4 { k: _, base_fft: _ }));
             assert_eq!(plan.len(), len, "Recipe reports wrong length");
         }
     }

--- a/src/neon/neon_planner.rs
+++ b/src/neon/neon_planner.rs
@@ -626,7 +626,7 @@ impl<T: FftNum> FftPlannerNeon<T> {
                     let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
                     self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
                 } else {
-                    self.design_radix4(len)
+                    self.design_radix4(inner_fft_len_pow2)
                 };
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {

--- a/src/neon/neon_planner.rs
+++ b/src/neon/neon_planner.rs
@@ -49,7 +49,7 @@ pub enum Recipe {
         inner_fft: Arc<Recipe>,
     },
     Radix4 {
-        k: usize,
+        k: u32,
         base_fft: Arc<Recipe>,
     },
     Butterfly1,
@@ -637,7 +637,7 @@ impl<T: FftNum> FftPlannerNeon<T> {
 
     fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
         // plan a step of radix4
-        let exponent = len.trailing_zeros() as usize;
+        let exponent = len.trailing_zeros();
         let base_exponent = match exponent {
             0 => 0,
             1 => 1,

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -199,7 +199,7 @@ mod unit_tests {
     fn test_neon_radix4_64_with_base(k: usize, base_fft: Arc<dyn Fft<f64>>) {
         let len = base_fft.len() * 4usize.pow(k as u32);
         let direction = base_fft.fft_direction();
-        let fft = NeonRadix4::<f64, f64>::new(k, base_fft).unwrap();
+        let fft = NeonRadix4::<f64, f64>::new(k, base_fft);
         check_fft_algorithm::<f64>(&fft, len, direction);
     }
 
@@ -218,7 +218,7 @@ mod unit_tests {
     fn test_neon_radix4_32_with_base(k: usize, base_fft: Arc<dyn Fft<f32>>) {
         let len = base_fft.len() * 4usize.pow(k as u32);
         let direction = base_fft.fft_direction();
-        let fft = NeonRadix4::<f32, f32>::new(k, base_fft).unwrap();
+        let fft = NeonRadix4::<f32, f32>::new(k, base_fft);
         check_fft_algorithm::<f32>(&fft, len, direction);
     }
 }

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -29,7 +29,7 @@ pub struct NeonRadix4<N: NeonNum, T> {
 impl<N: NeonNum, T: FftNum> NeonRadix4<N, T> {
     /// Constructs a new NeonRadix4 which computes FFTs of size 4^k * base_fft.len()
     #[inline]
-    pub fn new(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+    pub fn new(k: u32, base_fft: Arc<dyn Fft<T>>) -> Self {
         // Internal sanity check: Make sure that S == T.
         // This struct has two generic parameters S and T, but they must always be the same, and are only kept separate to help work around the lack of specialization.
         // It would be cool if we could do this as a static_assert instead
@@ -196,8 +196,8 @@ mod unit_tests {
         }
     }
 
-    fn test_neon_radix4_64_with_base(k: usize, base_fft: Arc<dyn Fft<f64>>) {
-        let len = base_fft.len() * 4usize.pow(k as u32);
+    fn test_neon_radix4_64_with_base(k: u32, base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * 4usize.pow(k);
         let direction = base_fft.fft_direction();
         let fft = NeonRadix4::<f64, f64>::new(k, base_fft);
         check_fft_algorithm::<f64>(&fft, len, direction);
@@ -215,8 +215,8 @@ mod unit_tests {
         }
     }
 
-    fn test_neon_radix4_32_with_base(k: usize, base_fft: Arc<dyn Fft<f32>>) {
-        let len = base_fft.len() * 4usize.pow(k as u32);
+    fn test_neon_radix4_32_with_base(k: u32, base_fft: Arc<dyn Fft<f32>>) {
+        let len = base_fft.len() * 4usize.pow(k);
         let direction = base_fft.fft_direction();
         let fft = NeonRadix4::<f32, f32>::new(k, base_fft);
         check_fft_algorithm::<f32>(&fft, len, direction);

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -1,107 +1,48 @@
 use num_complex::Complex;
 
-use core::arch::aarch64::*;
+use std::any::TypeId;
+use std::sync::Arc;
 
 use crate::array_utils::{self, bitreversed_transpose, workaround_transmute_mut};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::neon::neon_butterflies::{
-    NeonF32Butterfly1, NeonF32Butterfly16, NeonF32Butterfly2, NeonF32Butterfly32,
-    NeonF32Butterfly4, NeonF32Butterfly8,
-};
-use crate::neon::neon_butterflies::{
-    NeonF64Butterfly1, NeonF64Butterfly16, NeonF64Butterfly2, NeonF64Butterfly32,
-    NeonF64Butterfly4, NeonF64Butterfly8,
-};
-use crate::{common::FftNum, twiddles, FftDirection};
+use crate::{common::FftNum, FftDirection};
 use crate::{Direction, Fft, Length};
 
-use super::neon_common::{assert_f32, assert_f64};
-use super::neon_utils::*;
+use super::NeonNum;
 
-use super::neon_vector::{NeonArray, NeonArrayMut};
+use super::neon_vector::{NeonArray, NeonArrayMut, NeonVector, Rotation90};
 
-/// FFT algorithm optimized for power-of-two sizes, Neon accelerated version.
+/// FFT algorithm optimized for power-of-two sizes, SSE accelerated version.
 /// This is designed to be used via a Planner, and not created directly.
 
-const USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
+pub struct NeonRadix4<N: NeonNum, T> {
+    twiddles: Box<[N::VectorType]>,
+    rotation: Rotation90<N::VectorType>,
 
-enum Neon32Butterfly<T> {
-    Len1(NeonF32Butterfly1<T>),
-    Len2(NeonF32Butterfly2<T>),
-    Len4(NeonF32Butterfly4<T>),
-    Len8(NeonF32Butterfly8<T>),
-    Len16(NeonF32Butterfly16<T>),
-    Len32(NeonF32Butterfly32<T>),
-}
-
-enum Neon64Butterfly<T> {
-    Len1(NeonF64Butterfly1<T>),
-    Len2(NeonF64Butterfly2<T>),
-    Len4(NeonF64Butterfly4<T>),
-    Len8(NeonF64Butterfly8<T>),
-    Len16(NeonF64Butterfly16<T>),
-    Len32(NeonF64Butterfly32<T>),
-}
-
-pub struct Neon32Radix4<T> {
-    _phantom: std::marker::PhantomData<T>,
-    twiddles: Box<[float32x4_t]>,
-
-    base_fft: Neon32Butterfly<T>,
+    base_fft: Arc<dyn Fft<T>>,
     base_len: usize,
 
     len: usize,
     direction: FftDirection,
-    bf4: NeonF32Butterfly4<T>,
 }
 
-impl<T: FftNum> Neon32Radix4<T> {
-    /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
-    pub fn new(len: usize, direction: FftDirection) -> Self {
-        assert!(
-            len.is_power_of_two(),
-            "Radix4 algorithm requires a power-of-two input size. Got {}",
-            len
-        );
-        assert_f32::<T>();
+impl<N: NeonNum, T: FftNum> NeonRadix4<N, T> {
+    /// Constructs a new NeonRadix4 which computes FFTs of size 4^k * base_fft.len()
+    #[inline]
+    pub fn new(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+        // Internal sanity check: Make sure that S == T.
+        // This struct has two generic parameters S and T, but they must always be the same, and are only kept separate to help work around the lack of specialization.
+        // It would be cool if we could do this as a static_assert instead
+        let id_a = TypeId::of::<N>();
+        let id_t = TypeId::of::<T>();
+        assert_eq!(id_a, id_t);
 
-        // figure out which base length we're going to use
-        let num_bits = len.trailing_zeros();
-        let (base_len, base_fft) = match num_bits {
-            0 => (
-                len,
-                Neon32Butterfly::Len1(NeonF32Butterfly1::new(direction)),
-            ),
-            1 => (
-                len,
-                Neon32Butterfly::Len2(NeonF32Butterfly2::new(direction)),
-            ),
-            2 => (
-                len,
-                Neon32Butterfly::Len4(NeonF32Butterfly4::new(direction)),
-            ),
-            3 => (
-                len,
-                Neon32Butterfly::Len8(NeonF32Butterfly8::new(direction)),
-            ),
-            _ => {
-                if num_bits % 2 == 1 {
-                    if len < USE_BUTTERFLY32_FROM {
-                        (8, Neon32Butterfly::Len8(NeonF32Butterfly8::new(direction)))
-                    } else {
-                        (
-                            32,
-                            Neon32Butterfly::Len32(NeonF32Butterfly32::new(direction)),
-                        )
-                    }
-                } else {
-                    (
-                        16,
-                        Neon32Butterfly::Len16(NeonF32Butterfly16::new(direction)),
-                    )
-                }
-            }
-        };
+        let direction = base_fft.fft_direction();
+        let base_len = base_fft.len();
+
+        assert!(base_len.is_power_of_two() && base_len >= 2 * N::VectorType::COMPLEX_PER_VECTOR);
+
+        let len = base_len * (1 << (k * 2));
 
         // precompute the twiddle factors this algorithm will use.
         // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
@@ -112,206 +53,18 @@ impl<T: FftNum> Neon32Radix4<T> {
         let mut twiddle_factors = Vec::with_capacity(len * 2);
         while cross_fft_len <= len {
             let num_scalar_columns = cross_fft_len / ROW_COUNT;
-            let num_vector_columns = num_scalar_columns / 2; // 2 complex<T> per float32x4_t
+            let num_vector_columns = num_scalar_columns / N::VectorType::COMPLEX_PER_VECTOR;
 
             for i in 0..num_vector_columns {
                 for k in 1..ROW_COUNT {
-                    let twiddle_a =
-                        twiddles::compute_twiddle::<f32>(2 * i * k, cross_fft_len, direction);
-                    let twiddle_b =
-                        twiddles::compute_twiddle::<f32>((2 * i + 1) * k, cross_fft_len, direction);
-                    let twiddles_packed =
-                        unsafe { [twiddle_a, twiddle_b].as_slice().load_complex(0) };
-                    twiddle_factors.push(twiddles_packed);
-                }
-            }
-            cross_fft_len *= ROW_COUNT;
-        }
-
-        Self {
-            twiddles: twiddle_factors.into_boxed_slice(),
-
-            base_fft,
-            base_len,
-
-            len,
-            direction,
-            _phantom: std::marker::PhantomData,
-            bf4: NeonF32Butterfly4::<T>::new(direction),
-        }
-    }
-
-    //#[target_feature(enable = "neon")]
-    unsafe fn perform_fft_out_of_place(
-        &self,
-        input: &[Complex<T>],
-        output: &mut [Complex<T>],
-        _scratch: &mut [Complex<T>],
-    ) {
-        // copy the data into the output vector
-        if self.len() == self.base_len {
-            output.copy_from_slice(input);
-        } else {
-            bitreversed_transpose::<Complex<T>, 4>(self.base_len, input, output);
-        }
-
-        // Base-level FFTs
-        match &self.base_fft {
-            Neon32Butterfly::Len1(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon32Butterfly::Len2(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon32Butterfly::Len4(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon32Butterfly::Len8(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon32Butterfly::Len16(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon32Butterfly::Len32(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-        };
-
-        // cross-FFTs
-        const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = self.base_len * ROW_COUNT;
-        let mut layer_twiddles: &[float32x4_t] = &self.twiddles;
-
-        while cross_fft_len <= input.len() {
-            let num_rows = input.len() / cross_fft_len;
-            let num_columns = cross_fft_len / ROW_COUNT;
-
-            for i in 0..num_rows {
-                butterfly_4_32(
-                    &mut output[i * cross_fft_len..],
-                    layer_twiddles,
-                    num_columns,
-                    &self.bf4,
-                )
-            }
-
-            // skip past all the twiddle factors used in this layer
-            // half as many twiddles because neon vectors store 2 complex<f32> each
-            let twiddle_offset = num_columns * (ROW_COUNT - 1) / 2;
-            layer_twiddles = &layer_twiddles[twiddle_offset..];
-
-            cross_fft_len *= ROW_COUNT;
-        }
-    }
-}
-boilerplate_fft_neon_oop!(Neon32Radix4, |this: &Neon32Radix4<_>| this.len);
-
-//#[target_feature(enable = "neon")]
-unsafe fn butterfly_4_32<T: FftNum>(
-    data: &mut [Complex<T>],
-    twiddles: &[float32x4_t],
-    num_ffts: usize,
-    bf4: &NeonF32Butterfly4<T>,
-) {
-    let mut idx = 0usize;
-    let mut buffer: &mut [Complex<f32>] = workaround_transmute_mut(data);
-    for tw in twiddles.chunks_exact(6).take(num_ffts / 4) {
-        let scratch0 = buffer.load_complex(idx);
-        let scratch0b = buffer.load_complex(idx + 2);
-        let mut scratch1 = buffer.load_complex(idx + 1 * num_ffts);
-        let mut scratch1b = buffer.load_complex(idx + 2 + 1 * num_ffts);
-        let mut scratch2 = buffer.load_complex(idx + 2 * num_ffts);
-        let mut scratch2b = buffer.load_complex(idx + 2 + 2 * num_ffts);
-        let mut scratch3 = buffer.load_complex(idx + 3 * num_ffts);
-        let mut scratch3b = buffer.load_complex(idx + 2 + 3 * num_ffts);
-
-        scratch1 = mul_complex_f32(scratch1, tw[0]);
-        scratch2 = mul_complex_f32(scratch2, tw[1]);
-        scratch3 = mul_complex_f32(scratch3, tw[2]);
-        scratch1b = mul_complex_f32(scratch1b, tw[3]);
-        scratch2b = mul_complex_f32(scratch2b, tw[4]);
-        scratch3b = mul_complex_f32(scratch3b, tw[5]);
-
-        let scratch = bf4.perform_parallel_fft_direct(scratch0, scratch1, scratch2, scratch3);
-        let scratchb = bf4.perform_parallel_fft_direct(scratch0b, scratch1b, scratch2b, scratch3b);
-
-        buffer.store_complex(scratch[0], idx);
-        buffer.store_complex(scratchb[0], idx + 2);
-        buffer.store_complex(scratch[1], idx + 1 * num_ffts);
-        buffer.store_complex(scratchb[1], idx + 2 + 1 * num_ffts);
-        buffer.store_complex(scratch[2], idx + 2 * num_ffts);
-        buffer.store_complex(scratchb[2], idx + 2 + 2 * num_ffts);
-        buffer.store_complex(scratch[3], idx + 3 * num_ffts);
-        buffer.store_complex(scratchb[3], idx + 2 + 3 * num_ffts);
-
-        idx += 4;
-    }
-}
-
-pub struct Neon64Radix4<T> {
-    _phantom: std::marker::PhantomData<T>,
-    twiddles: Box<[float64x2_t]>,
-
-    base_fft: Neon64Butterfly<T>,
-    base_len: usize,
-
-    len: usize,
-    direction: FftDirection,
-    bf4: NeonF64Butterfly4<T>,
-}
-
-impl<T: FftNum> Neon64Radix4<T> {
-    /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
-    pub fn new(len: usize, direction: FftDirection) -> Self {
-        assert!(
-            len.is_power_of_two(),
-            "Radix4 algorithm requires a power-of-two input size. Got {}",
-            len
-        );
-
-        assert_f64::<T>();
-
-        // figure out which base length we're going to use
-        let num_bits = len.trailing_zeros();
-        let (base_len, base_fft) = match num_bits {
-            0 => (
-                len,
-                Neon64Butterfly::Len1(NeonF64Butterfly1::new(direction)),
-            ),
-            1 => (
-                len,
-                Neon64Butterfly::Len2(NeonF64Butterfly2::new(direction)),
-            ),
-            2 => (
-                len,
-                Neon64Butterfly::Len4(NeonF64Butterfly4::new(direction)),
-            ),
-            3 => (
-                len,
-                Neon64Butterfly::Len8(NeonF64Butterfly8::new(direction)),
-            ),
-            _ => {
-                if num_bits % 2 == 1 {
-                    if len < USE_BUTTERFLY32_FROM {
-                        (8, Neon64Butterfly::Len8(NeonF64Butterfly8::new(direction)))
-                    } else {
-                        (
-                            32,
-                            Neon64Butterfly::Len32(NeonF64Butterfly32::new(direction)),
-                        )
+                    unsafe {
+                        twiddle_factors.push(NeonVector::make_mixedradix_twiddle_chunk(
+                            i * N::VectorType::COMPLEX_PER_VECTOR,
+                            k,
+                            cross_fft_len,
+                            direction,
+                        ));
                     }
-                } else {
-                    (
-                        16,
-                        Neon64Butterfly::Len16(NeonF64Butterfly16::new(direction)),
-                    )
-                }
-            }
-        };
-
-        // precompute the twiddle factors this algorithm will use.
-        // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
-        // but mixed radix only does one step and then calls itself recusrively, and this algorithm does every layer all the way down
-        // so we're going to pack all the "layers" of twiddle factors into a single array, starting with the bottom layer and going up
-        const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = base_len * ROW_COUNT;
-        let mut twiddle_factors = Vec::with_capacity(len * 2);
-        while cross_fft_len <= len {
-            let num_columns = cross_fft_len / ROW_COUNT;
-
-            for i in 0..num_columns {
-                for k in 1..ROW_COUNT {
-                    let twiddle = twiddles::compute_twiddle::<f64>(i * k, cross_fft_len, direction);
-                    let twiddle_packed = unsafe { [twiddle].as_slice().load_complex(0) };
-                    twiddle_factors.push(twiddle_packed);
                 }
             }
             cross_fft_len *= ROW_COUNT;
@@ -319,14 +72,13 @@ impl<T: FftNum> Neon64Radix4<T> {
 
         Self {
             twiddles: twiddle_factors.into_boxed_slice(),
+            rotation: unsafe { NeonVector::make_rotate90(direction) },
 
             base_fft,
             base_len,
 
             len,
             direction,
-            _phantom: std::marker::PhantomData,
-            bf4: NeonF64Butterfly4::<T>::new(direction),
         }
     }
 
@@ -345,115 +97,128 @@ impl<T: FftNum> Neon64Radix4<T> {
         }
 
         // Base-level FFTs
-        match &self.base_fft {
-            Neon64Butterfly::Len1(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon64Butterfly::Len2(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon64Butterfly::Len4(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon64Butterfly::Len8(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon64Butterfly::Len16(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Neon64Butterfly::Len32(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-        }
+        self.base_fft.process_with_scratch(output, &mut []);
 
         // cross-FFTs
         const ROW_COUNT: usize = 4;
         let mut cross_fft_len = self.base_len * ROW_COUNT;
-        let mut layer_twiddles: &[float64x2_t] = &self.twiddles;
+        let mut layer_twiddles: &[N::VectorType] = &self.twiddles;
 
         while cross_fft_len <= input.len() {
             let num_rows = input.len() / cross_fft_len;
-            let num_columns = cross_fft_len / ROW_COUNT;
+            let num_scalar_columns = cross_fft_len / ROW_COUNT;
+            let num_vector_columns = num_scalar_columns / N::VectorType::COMPLEX_PER_VECTOR;
 
             for i in 0..num_rows {
-                butterfly_4_64(
+                butterfly_4::<N, T>(
                     &mut output[i * cross_fft_len..],
                     layer_twiddles,
-                    num_columns,
-                    &self.bf4,
+                    num_scalar_columns,
+                    &self.rotation,
                 )
             }
 
             // skip past all the twiddle factors used in this layer
-            let twiddle_offset = num_columns * (ROW_COUNT - 1);
+            let twiddle_offset = num_vector_columns * (ROW_COUNT - 1);
             layer_twiddles = &layer_twiddles[twiddle_offset..];
 
             cross_fft_len *= ROW_COUNT;
         }
     }
 }
-boilerplate_fft_neon_oop!(Neon64Radix4, |this: &Neon64Radix4<_>| this.len);
+boilerplate_fft_neon_oop!(NeonRadix4, |this: &NeonRadix4<_, _>| this.len);
 
 //#[target_feature(enable = "neon")]
-unsafe fn butterfly_4_64<T: FftNum>(
+unsafe fn butterfly_4<N: NeonNum, T: FftNum>(
     data: &mut [Complex<T>],
-    twiddles: &[float64x2_t],
+    twiddles: &[N::VectorType],
     num_ffts: usize,
-    bf4: &NeonF64Butterfly4<T>,
+    rotation: &Rotation90<N::VectorType>,
 ) {
+    let unroll_offset = N::VectorType::COMPLEX_PER_VECTOR;
+
     let mut idx = 0usize;
-    let mut buffer: &mut [Complex<f64>] = workaround_transmute_mut(data);
-    for tw in twiddles.chunks_exact(6).take(num_ffts / 2) {
-        let scratch0 = buffer.load_complex(idx);
-        let scratch0b = buffer.load_complex(idx + 1);
-        let mut scratch1 = buffer.load_complex(idx + 1 * num_ffts);
-        let mut scratch1b = buffer.load_complex(idx + 1 + 1 * num_ffts);
-        let mut scratch2 = buffer.load_complex(idx + 2 * num_ffts);
-        let mut scratch2b = buffer.load_complex(idx + 1 + 2 * num_ffts);
-        let mut scratch3 = buffer.load_complex(idx + 3 * num_ffts);
-        let mut scratch3b = buffer.load_complex(idx + 1 + 3 * num_ffts);
+    let mut buffer: &mut [Complex<N>] = workaround_transmute_mut(data);
+    for tw in twiddles
+        .chunks_exact(6)
+        .take(num_ffts / (N::VectorType::COMPLEX_PER_VECTOR * 2))
+    {
+        let mut scratcha = [
+            buffer.load_complex(idx + 0 * num_ffts),
+            buffer.load_complex(idx + 1 * num_ffts),
+            buffer.load_complex(idx + 2 * num_ffts),
+            buffer.load_complex(idx + 3 * num_ffts),
+        ];
+        let mut scratchb = [
+            buffer.load_complex(idx + 0 * num_ffts + unroll_offset),
+            buffer.load_complex(idx + 1 * num_ffts + unroll_offset),
+            buffer.load_complex(idx + 2 * num_ffts + unroll_offset),
+            buffer.load_complex(idx + 3 * num_ffts + unroll_offset),
+        ];
 
-        scratch1 = mul_complex_f64(scratch1, tw[0]);
-        scratch2 = mul_complex_f64(scratch2, tw[1]);
-        scratch3 = mul_complex_f64(scratch3, tw[2]);
-        scratch1b = mul_complex_f64(scratch1b, tw[3]);
-        scratch2b = mul_complex_f64(scratch2b, tw[4]);
-        scratch3b = mul_complex_f64(scratch3b, tw[5]);
+        scratcha[1] = NeonVector::mul_complex(scratcha[1], tw[0]);
+        scratcha[2] = NeonVector::mul_complex(scratcha[2], tw[1]);
+        scratcha[3] = NeonVector::mul_complex(scratcha[3], tw[2]);
+        scratchb[1] = NeonVector::mul_complex(scratchb[1], tw[3]);
+        scratchb[2] = NeonVector::mul_complex(scratchb[2], tw[4]);
+        scratchb[3] = NeonVector::mul_complex(scratchb[3], tw[5]);
 
-        let scratch = bf4.perform_fft_direct(scratch0, scratch1, scratch2, scratch3);
-        let scratchb = bf4.perform_fft_direct(scratch0b, scratch1b, scratch2b, scratch3b);
+        let scratcha = NeonVector::column_butterfly4(scratcha, *rotation);
+        let scratchb = NeonVector::column_butterfly4(scratchb, *rotation);
 
-        buffer.store_complex(scratch[0], idx);
-        buffer.store_complex(scratchb[0], idx + 1);
-        buffer.store_complex(scratch[1], idx + 1 * num_ffts);
-        buffer.store_complex(scratchb[1], idx + 1 + 1 * num_ffts);
-        buffer.store_complex(scratch[2], idx + 2 * num_ffts);
-        buffer.store_complex(scratchb[2], idx + 1 + 2 * num_ffts);
-        buffer.store_complex(scratch[3], idx + 3 * num_ffts);
-        buffer.store_complex(scratchb[3], idx + 1 + 3 * num_ffts);
+        buffer.store_complex(scratcha[0], idx + 0 * num_ffts);
+        buffer.store_complex(scratchb[0], idx + 0 * num_ffts + unroll_offset);
+        buffer.store_complex(scratcha[1], idx + 1 * num_ffts);
+        buffer.store_complex(scratchb[1], idx + 1 * num_ffts + unroll_offset);
+        buffer.store_complex(scratcha[2], idx + 2 * num_ffts);
+        buffer.store_complex(scratchb[2], idx + 2 * num_ffts + unroll_offset);
+        buffer.store_complex(scratcha[3], idx + 3 * num_ffts);
+        buffer.store_complex(scratchb[3], idx + 3 * num_ffts + unroll_offset);
 
-        idx += 2;
+        idx += N::VectorType::COMPLEX_PER_VECTOR * 2;
     }
 }
 
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::test_utils::check_fft_algorithm;
+    use crate::test_utils::{check_fft_algorithm, construct_base};
 
     #[test]
     fn test_neon_radix4_64() {
-        for pow in 4..12 {
-            let len = 1 << pow;
-            test_neon_radix4_64_with_length(len, FftDirection::Forward);
-            test_neon_radix4_64_with_length(len, FftDirection::Inverse);
+        for base in [2, 4, 8, 16] {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
+            for k in 0..4 {
+                test_neon_radix4_64_with_base(k, Arc::clone(&base_forward));
+                test_neon_radix4_64_with_base(k, Arc::clone(&base_inverse));
+            }
         }
     }
 
-    fn test_neon_radix4_64_with_length(len: usize, direction: FftDirection) {
-        let fft = Neon64Radix4::new(len, direction);
+    fn test_neon_radix4_64_with_base(k: usize, base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * 4usize.pow(k as u32);
+        let direction = base_fft.fft_direction();
+        let fft = NeonRadix4::<f64, f64>::new(k, base_fft).unwrap();
         check_fft_algorithm::<f64>(&fft, len, direction);
     }
 
     #[test]
     fn test_neon_radix4_32() {
-        for pow in 0..12 {
-            let len = 1 << pow;
-            test_neon_radix4_32_with_length(len, FftDirection::Forward);
-            test_neon_radix4_32_with_length(len, FftDirection::Inverse);
+        for base in [4, 8, 16] {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
+            for k in 0..4 {
+                test_neon_radix4_32_with_base(k, Arc::clone(&base_forward));
+                test_neon_radix4_32_with_base(k, Arc::clone(&base_inverse));
+            }
         }
     }
 
-    fn test_neon_radix4_32_with_length(len: usize, direction: FftDirection) {
-        let fft = Neon32Radix4::new(len, direction);
+    fn test_neon_radix4_32_with_base(k: usize, base_fft: Arc<dyn Fft<f32>>) {
+        let len = base_fft.len() * 4usize.pow(k as u32);
+        let direction = base_fft.fft_direction();
+        let fft = NeonRadix4::<f32, f32>::new(k, base_fft).unwrap();
         check_fft_algorithm::<f32>(&fft, len, direction);
     }
 }

--- a/src/neon/neon_utils.rs
+++ b/src/neon/neon_utils.rs
@@ -171,18 +171,6 @@ pub unsafe fn transpose_complex_2x2_f32(left: float32x4_t, right: float32x4_t) -
     [temp02, temp13]
 }
 
-// Complex multiplication.
-// Each input contains two complex values, which are multiplied in parallel.
-#[inline(always)]
-pub unsafe fn mul_complex_f32(left: float32x4_t, right: float32x4_t) -> float32x4_t {
-    // ARMv8.2-A introduced vcmulq_f32 and vcmlaq_f32 for complex multiplication, these intrinsics are not yet available.
-    let temp1 = vtrn1q_f32(right, right);
-    let temp2 = vtrn2q_f32(right, vnegq_f32(right));
-    let temp3 = vmulq_f32(temp2, left);
-    let temp4 = vrev64q_f32(temp3);
-    vfmaq_f32(temp4, temp1, left)
-}
-
 //  __  __       _   _                __   _  _   _     _ _
 // |  \/  | __ _| |_| |__            / /_ | || | | |__ (_) |_
 // | |\/| |/ _` | __| '_ \   _____  | '_ \| || |_| '_ \| | __|
@@ -214,14 +202,6 @@ impl Rotate90F64 {
             vreinterpretq_u64_f64(self.sign),
         ))
     }
-}
-
-#[inline(always)]
-pub unsafe fn mul_complex_f64(left: float64x2_t, right: float64x2_t) -> float64x2_t {
-    // ARMv8.2-A introduced vcmulq_f64 and vcmlaq_f64 for complex multiplication, these intrinsics are not yet available.
-    let temp = vcombine_f64(vneg_f64(vget_high_f64(left)), vget_low_f64(left));
-    let sum = vmulq_laneq_f64::<0>(left, right);
-    vfmaq_laneq_f64::<1>(sum, temp, right)
 }
 
 #[cfg(test)]

--- a/src/neon/neon_utils.rs
+++ b/src/neon/neon_utils.rs
@@ -207,6 +207,7 @@ impl Rotate90F64 {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+    use crate::neon::NeonVector;
     use num_complex::Complex;
 
     #[test]
@@ -214,7 +215,7 @@ mod unit_tests {
         unsafe {
             let right = vld1q_f64([1.0, 2.0].as_ptr());
             let left = vld1q_f64([5.0, 7.0].as_ptr());
-            let res = mul_complex_f64(left, right);
+            let res = NeonVector::mul_complex(left, right);
             let expected = vld1q_f64([1.0 * 5.0 - 2.0 * 7.0, 1.0 * 7.0 + 2.0 * 5.0].as_ptr());
             assert_eq!(
                 std::mem::transmute::<float64x2_t, Complex<f64>>(res),
@@ -233,7 +234,7 @@ mod unit_tests {
 
             let nbr2 = vld1q_f32([val3, val4].as_ptr() as *const f32);
             let nbr1 = vld1q_f32([val1, val2].as_ptr() as *const f32);
-            let res = mul_complex_f32(nbr1, nbr2);
+            let res = NeonVector::mul_complex(nbr1, nbr2);
             let res = std::mem::transmute::<float32x4_t, [Complex<f32>; 2]>(res);
             let expected = [val1 * val3, val2 * val4];
             assert_eq!(res, expected);

--- a/src/neon/neon_vector.rs
+++ b/src/neon/neon_vector.rs
@@ -1,8 +1,11 @@
 use core::arch::aarch64::*;
 use num_complex::Complex;
+use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
-use crate::array_utils::DoubleBuf;
+use crate::{array_utils::DoubleBuf, twiddles, FftDirection};
+
+use super::NeonNum;
 
 // Read these indexes from an NeonArray and build an array of simd vectors.
 // Takes a name of a vector to read from, and a list of indexes to read.
@@ -123,197 +126,375 @@ macro_rules! write_complex_to_array_strided {
     }
 }
 
-pub trait NeonNum {
-    type VectorType;
+#[derive(Copy, Clone)]
+pub struct Rotation90<V: NeonVector>(V);
+
+// A trait to hold the BVectorType and COMPLEX_PER_VECTOR associated data
+pub trait NeonVector: Copy + Debug + Send + Sync {
+    const SCALAR_PER_VECTOR: usize;
     const COMPLEX_PER_VECTOR: usize;
+
+    type ScalarType: NeonNum<VectorType = Self>;
+
+    // loads of complex numbers
+    unsafe fn load_complex(ptr: *const Complex<Self::ScalarType>) -> Self;
+    unsafe fn load_partial_lo_complex(ptr: *const Complex<Self::ScalarType>) -> Self;
+    unsafe fn load1_complex(ptr: *const Complex<Self::ScalarType>) -> Self;
+
+    // stores of complex numbers
+    unsafe fn store_complex(ptr: *mut Complex<Self::ScalarType>, data: Self);
+    unsafe fn store_partial_lo_complex(ptr: *mut Complex<Self::ScalarType>, data: Self);
+    unsafe fn store_partial_hi_complex(ptr: *mut Complex<Self::ScalarType>, data: Self);
+
+    /// Generates a chunk of twiddle factors starting at (X,Y) and incrementing X `COMPLEX_PER_VECTOR` times.
+    /// The result will be [twiddle(x*y, len), twiddle((x+1)*y, len), twiddle((x+2)*y, len), ...] for as many complex numbers fit in a vector
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self;
+
+    /// Pairwise multiply the complex numbers in `left` with the complex numbers in `right`.
+    unsafe fn mul_complex(left: Self, right: Self) -> Self;
+
+    /// Constructs a Rotate90 object that will apply eithr a 90 or 270 degree rotationto the complex elements
+    unsafe fn make_rotate90(direction: FftDirection) -> Rotation90<Self>;
+
+    /// Uses a pre-constructed rotate90 object to apply the given rotation
+    unsafe fn apply_rotate90(direction: Rotation90<Self>, values: Self) -> Self;
+
+    /// Each of these Interprets the input as rows of a Self::COMPLEX_PER_VECTOR-by-N 2D array, and computes parallel butterflies down the columns of the 2D array
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2];
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Rotation90<Self>) -> [Self; 4];
 }
-impl NeonNum for f32 {
-    type VectorType = float32x4_t;
+
+impl NeonVector for float32x4_t {
+    const SCALAR_PER_VECTOR: usize = 4;
     const COMPLEX_PER_VECTOR: usize = 2;
+
+    type ScalarType = f32;
+
+    #[inline(always)]
+    unsafe fn load_complex(ptr: *const Complex<Self::ScalarType>) -> Self {
+        vld1q_f32(ptr as *const f32)
+    }
+
+    #[inline(always)]
+    unsafe fn load_partial_lo_complex(ptr: *const Complex<Self::ScalarType>) -> Self {
+        let temp = vmovq_n_f32(0.0);
+        vreinterpretq_f32_u64(vld1q_lane_u64::<0>(
+            ptr as *const f64,
+            vreinterpretq_u64_f32(temp),
+        ))
+    }
+
+    #[inline(always)]
+    unsafe fn load1_complex(ptr: *const Complex<Self::ScalarType>) -> Self {
+        vreinterpretq_f32_u64(vld1q_dup_u64(ptr as *const u64))
+    }
+
+    #[inline(always)]
+    unsafe fn store_complex(ptr: *mut Complex<Self::ScalarType>, data: Self) {
+        vst1q_f32(ptr as *mut f32, data);
+    }
+
+    #[inline(always)]
+    unsafe fn store_partial_lo_complex(ptr: *mut Complex<Self::ScalarType>, data: Self) {
+        let low = vget_low_f32(data);
+        vst1_f32(ptr as *mut f32, low);
+    }
+
+    #[inline(always)]
+    unsafe fn store_partial_hi_complex(ptr: *mut Complex<Self::ScalarType>, data: Self) {
+        let high = vget_high_f32(data);
+        vst1_f32(ptr as *mut f32, high);
+    }
+
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        let mut twiddle_chunk = [Complex::<f32>::zero(); Self::COMPLEX_PER_VECTOR];
+        for i in 0..Self::COMPLEX_PER_VECTOR {
+            twiddle_chunk[i] = twiddles::compute_twiddle(y * (x + i), len, direction);
+        }
+
+        twiddle_chunk.as_slice().load_complex(0)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        // ARMv8.2-A introduced vcmulq_f32 and vcmlaq_f32 for complex multiplication, these intrinsics are not yet available.
+        let temp1 = vtrn1q_f32(right, right);
+        let temp2 = vtrn2q_f32(right, vnegq_f32(right));
+        let temp3 = vmulq_f32(temp2, left);
+        let temp4 = vrev64q_f32(temp3);
+        vfmaq_f32(temp4, temp1, left)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Rotation90<Self> {
+        Rotation90(match direction {
+            FftDirection::Forward => vld1q_f32([0.0, -0.0, 0.0, -0.0].as_ptr()),
+            FftDirection::Inverse => vld1q_f32([-0.0, 0.0, -0.0, 0.0].as_ptr()),
+        })
+    }
+
+    #[inline(always)]
+    unsafe fn apply_rotate90(direction: Rotation90<Self>, values: Self) -> Self {
+        let temp = vrev64q_f32(values);
+        vreinterpretq_f32_u32(veorq_u32(
+            vreinterpretq_u32_f32(temp),
+            vreinterpretq_u32_f32(direction.0),
+        ))
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        [vaddq_f32(rows[0], rows[1]), vsubq_f32(rows[0], rows[1])]
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Rotation90<Self>) -> [Self; 4] {
+        // Algorithm: 2x2 mixed radix
+
+        // Perform the first set of size-2 FFTs.
+        let [mid0, mid2] = Self::column_butterfly2([rows[0], rows[2]]);
+        let [mid1, mid3] = Self::column_butterfly2([rows[1], rows[3]]);
+
+        // Apply twiddle factors (in this case just a rotation)
+        let mid3_rotated = Self::apply_rotate90(rotation, mid3);
+
+        // Transpose the data and do size-2 FFTs down the columns
+        let [output0, output1] = Self::column_butterfly2([mid0, mid1]);
+        let [output2, output3] = Self::column_butterfly2([mid2, mid3_rotated]);
+
+        // Swap outputs 1 and 2 in the output to do a square transpose
+        [output0, output2, output1, output3]
+    }
 }
-impl NeonNum for f64 {
-    type VectorType = float64x2_t;
+
+impl NeonVector for float64x2_t {
+    const SCALAR_PER_VECTOR: usize = 2;
     const COMPLEX_PER_VECTOR: usize = 1;
+
+    type ScalarType = f64;
+
+    #[inline(always)]
+    unsafe fn load_complex(ptr: *const Complex<Self::ScalarType>) -> Self {
+        vld1q_f64(ptr as *const f64)
+    }
+
+    #[inline(always)]
+    unsafe fn load_partial_lo_complex(_ptr: *const Complex<Self::ScalarType>) -> Self {
+        unimplemented!("Impossible to do a load store of complex f64's");
+    }
+
+    #[inline(always)]
+    unsafe fn load1_complex(_ptr: *const Complex<Self::ScalarType>) -> Self {
+        unimplemented!("Impossible to do a load store of complex f64's");
+    }
+
+    #[inline(always)]
+    unsafe fn store_complex(ptr: *mut Complex<Self::ScalarType>, data: Self) {
+        vst1q_f64(ptr as *mut f64, data, data);
+    }
+
+    #[inline(always)]
+    unsafe fn store_partial_lo_complex(_ptr: *mut Complex<Self::ScalarType>, _data: Self) {
+        unimplemented!("Impossible to do a partial store of complex f64's");
+    }
+
+    #[inline(always)]
+    unsafe fn store_partial_hi_complex(_ptr: *mut Complex<Self::ScalarType>, _data: Self) {
+        unimplemented!("Impossible to do a partial store of complex f64's");
+    }
+
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        let mut twiddle_chunk = [Complex::<f64>::zero(); Self::COMPLEX_PER_VECTOR];
+        for i in 0..Self::COMPLEX_PER_VECTOR {
+            twiddle_chunk[i] = twiddles::compute_twiddle(y * (x + i), len, direction);
+        }
+
+        twiddle_chunk.as_slice().load_complex(0)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        // ARMv8.2-A introduced vcmulq_f64 and vcmlaq_f64 for complex multiplication, these intrinsics are not yet available.
+        let temp = vcombine_f64(vneg_f64(vget_high_f64(left)), vget_low_f64(left));
+        let sum = vmulq_laneq_f64::<0>(left, right);
+        vfmaq_laneq_f64::<1>(sum, temp, right)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Rotation90<Self> {
+        Rotation90(match direction {
+            FftDirection::Forward => vld1q_f64([0.0, -0.0].as_ptr()),
+            FftDirection::Inverse => vld1q_f64([-0.0, 0.0].as_ptr()),
+        })
+    }
+
+    #[inline(always)]
+    unsafe fn apply_rotate90(direction: Rotation90<Self>, values: Self) -> Self {
+        let temp = vcombine_f64(vget_high_f64(values), vget_low_f64(values));
+        vreinterpretq_f64_u64(veorq_u64(
+            vreinterpretq_u64_f64(temp),
+            vreinterpretq_u64_f64(direction.0),
+        ))
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        [vaddq_f64(rows[0], rows[1]), vsubq_f64(rows[0], rows[1])]
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Rotation90<Self>) -> [Self; 4] {
+        // Algorithm: 2x2 mixed radix
+
+        // Perform the first set of size-2 FFTs.
+        let [mid0, mid2] = Self::column_butterfly2([rows[0], rows[2]]);
+        let [mid1, mid3] = Self::column_butterfly2([rows[1], rows[3]]);
+
+        // Apply twiddle factors (in this case just a rotation)
+        let mid3_rotated = Self::apply_rotate90(rotation, mid3);
+
+        // Transpose the data and do size-2 FFTs down the columns
+        let [output0, output1] = Self::column_butterfly2([mid0, mid1]);
+        let [output2, output3] = Self::column_butterfly2([mid2, mid3_rotated]);
+
+        // Swap outputs 1 and 2 in the output to do a square transpose
+        [output0, output2, output1, output3]
+    }
 }
 
-// A trait to handle reading from an array of complex floats into Neon vectors.
-// Neon works with 128-bit vectors, meaning a vector can hold two complex f32,
+// A trait to handle reading from an array of complex floats into NEON vectors.
+// NEON works with 128-bit vectors, meaning a vector can hold two complex f32,
 // or a single complex f64.
-pub trait NeonArray<T: NeonNum>: Deref {
-    // Load complex numbers from the array to fill a Neon vector.
-    unsafe fn load_complex(&self, index: usize) -> T::VectorType;
-    // Load a single complex number from the array into a Neon vector, setting the unused elements to zero.
-    unsafe fn load_partial1_complex(&self, index: usize) -> T::VectorType;
-    // Load a single complex number from the array, and copy it to all elements of a Neon vector.
-    unsafe fn load1_complex(&self, index: usize) -> T::VectorType;
+pub trait NeonArray<S: NeonNum>: Deref {
+    // Load complex numbers from the array to fill a NEON vector.
+    unsafe fn load_complex(&self, index: usize) -> S::VectorType;
+    // Load a single complex number from the array into a NEON vector, setting the unused elements to zero.
+    unsafe fn load_partial_lo_complex(&self, index: usize) -> S::VectorType;
+    // Load a single complex number from the array, and copy it to all elements of a NEON vector.
+    unsafe fn load1_complex(&self, index: usize) -> S::VectorType;
 }
 
-impl NeonArray<f32> for &[Complex<f32>] {
+impl<S: NeonNum> NeonArray<S> for &[Complex<S>] {
     #[inline(always)]
-    unsafe fn load_complex(&self, index: usize) -> <f32 as NeonNum>::VectorType {
-        debug_assert!(self.len() >= index + <f32 as NeonNum>::COMPLEX_PER_VECTOR);
-        vld1q_f32(self.as_ptr().add(index) as *const f32)
+    unsafe fn load_complex(&self, index: usize) -> S::VectorType {
+        debug_assert!(self.len() >= index + S::VectorType::COMPLEX_PER_VECTOR);
+        S::VectorType::load_complex(self.as_ptr().add(index))
     }
 
     #[inline(always)]
-    unsafe fn load_partial1_complex(&self, index: usize) -> <f32 as NeonNum>::VectorType {
+    unsafe fn load_partial_lo_complex(&self, index: usize) -> S::VectorType {
         debug_assert!(self.len() >= index + 1);
-        let temp = vmovq_n_f32(0.0);
-        vreinterpretq_f32_u64(vld1q_lane_u64::<0>(
-            self.as_ptr().add(index) as *const u64,
-            vreinterpretq_u64_f32(temp),
-        ))
+        S::VectorType::load_partial_lo_complex(self.as_ptr().add(index))
     }
 
     #[inline(always)]
-    unsafe fn load1_complex(&self, index: usize) -> <f32 as NeonNum>::VectorType {
+    unsafe fn load1_complex(&self, index: usize) -> S::VectorType {
         debug_assert!(self.len() >= index + 1);
-        vreinterpretq_f32_u64(vld1q_dup_u64(self.as_ptr().add(index) as *const u64))
+        S::VectorType::load1_complex(self.as_ptr().add(index))
     }
 }
-
-impl NeonArray<f32> for &mut [Complex<f32>] {
+impl<S: NeonNum> NeonArray<S> for &mut [Complex<S>] {
     #[inline(always)]
-    unsafe fn load_complex(&self, index: usize) -> <f32 as NeonNum>::VectorType {
-        debug_assert!(self.len() >= index + <f32 as NeonNum>::COMPLEX_PER_VECTOR);
-        vld1q_f32(self.as_ptr().add(index) as *const f32)
+    unsafe fn load_complex(&self, index: usize) -> S::VectorType {
+        debug_assert!(self.len() >= index + S::VectorType::COMPLEX_PER_VECTOR);
+        S::VectorType::load_complex(self.as_ptr().add(index))
     }
 
     #[inline(always)]
-    unsafe fn load_partial1_complex(&self, index: usize) -> <f32 as NeonNum>::VectorType {
+    unsafe fn load_partial_lo_complex(&self, index: usize) -> S::VectorType {
         debug_assert!(self.len() >= index + 1);
-        let temp = vmovq_n_f32(0.0);
-        vreinterpretq_f32_u64(vld1q_lane_u64::<0>(
-            self.as_ptr().add(index) as *const u64,
-            vreinterpretq_u64_f32(temp),
-        ))
+        S::VectorType::load_partial_lo_complex(self.as_ptr().add(index))
     }
 
     #[inline(always)]
-    unsafe fn load1_complex(&self, index: usize) -> <f32 as NeonNum>::VectorType {
+    unsafe fn load1_complex(&self, index: usize) -> S::VectorType {
         debug_assert!(self.len() >= index + 1);
-        vreinterpretq_f32_u64(vld1q_dup_u64(self.as_ptr().add(index) as *const u64))
+        S::VectorType::load1_complex(self.as_ptr().add(index))
     }
 }
 
-impl NeonArray<f64> for &[Complex<f64>] {
-    #[inline(always)]
-    unsafe fn load_complex(&self, index: usize) -> <f64 as NeonNum>::VectorType {
-        debug_assert!(self.len() >= index + <f64 as NeonNum>::COMPLEX_PER_VECTOR);
-        vld1q_f64(self.as_ptr().add(index) as *const f64)
-    }
-
-    #[inline(always)]
-    unsafe fn load_partial1_complex(&self, _index: usize) -> <f64 as NeonNum>::VectorType {
-        unimplemented!("Impossible to do a partial load of complex f64's");
-    }
-
-    #[inline(always)]
-    unsafe fn load1_complex(&self, _index: usize) -> <f64 as NeonNum>::VectorType {
-        unimplemented!("Impossible to do a partial load of complex f64's");
-    }
-}
-
-impl NeonArray<f64> for &mut [Complex<f64>] {
-    #[inline(always)]
-    unsafe fn load_complex(&self, index: usize) -> <f64 as NeonNum>::VectorType {
-        debug_assert!(self.len() >= index + <f64 as NeonNum>::COMPLEX_PER_VECTOR);
-        vld1q_f64(self.as_ptr().add(index) as *const f64)
-    }
-
-    #[inline(always)]
-    unsafe fn load_partial1_complex(&self, _index: usize) -> <f64 as NeonNum>::VectorType {
-        unimplemented!("Impossible to do a partial load of complex f64's");
-    }
-
-    #[inline(always)]
-    unsafe fn load1_complex(&self, _index: usize) -> <f64 as NeonNum>::VectorType {
-        unimplemented!("Impossible to do a partial load of complex f64's");
-    }
-}
-
-impl<'a, T: NeonNum> NeonArray<T> for DoubleBuf<'a, T>
+impl<'a, S: NeonNum> NeonArray<S> for DoubleBuf<'a, S>
 where
-    &'a [Complex<T>]: NeonArray<T>,
+    &'a [Complex<S>]: NeonArray<S>,
 {
     #[inline(always)]
-    unsafe fn load_complex(&self, index: usize) -> T::VectorType {
+    unsafe fn load_complex(&self, index: usize) -> S::VectorType {
         self.input.load_complex(index)
     }
     #[inline(always)]
-    unsafe fn load_partial1_complex(&self, index: usize) -> T::VectorType {
-        self.input.load_partial1_complex(index)
+    unsafe fn load_partial_lo_complex(&self, index: usize) -> S::VectorType {
+        self.input.load_partial_lo_complex(index)
     }
     #[inline(always)]
-    unsafe fn load1_complex(&self, index: usize) -> T::VectorType {
+    unsafe fn load1_complex(&self, index: usize) -> S::VectorType {
         self.input.load1_complex(index)
     }
 }
 
-// A trait to handle writing to an array of complex floats from Neon vectors.
-// Neon works with 128-bit vectors, meaning a vector can hold two complex f32,
+// A trait to handle writing to an array of complex floats from NEON vectors.
+// NEON works with 128-bit vectors, meaning a vector can hold two complex f32,
 // or a single complex f64.
-pub trait NeonArrayMut<T: NeonNum>: NeonArray<T> + DerefMut {
-    // Store all complex numbers from a Neon vector to the array.
-    unsafe fn store_complex(&mut self, vector: T::VectorType, index: usize);
-    // Store the low complex number from a Neon vector to the array.
-    unsafe fn store_partial_lo_complex(&mut self, vector: T::VectorType, index: usize);
-    // Store the high complex number from a Neon vector to the array.
-    unsafe fn store_partial_hi_complex(&mut self, vector: T::VectorType, index: usize);
+pub trait NeonArrayMut<S: NeonNum>: NeonArray<S> + DerefMut {
+    // Store all complex numbers from a NEON vector to the array.
+    unsafe fn store_complex(&mut self, vector: S::VectorType, index: usize);
+    // Store the low complex number from a NEON vector to the array.
+    unsafe fn store_partial_lo_complex(&mut self, vector: S::VectorType, index: usize);
+    // Store the high complex number from a NEON vector to the array.
+    unsafe fn store_partial_hi_complex(&mut self, vector: S::VectorType, index: usize);
 }
 
-impl NeonArrayMut<f32> for &mut [Complex<f32>] {
+impl<S: NeonNum> NeonArrayMut<S> for &mut [Complex<S>] {
     #[inline(always)]
-    unsafe fn store_complex(&mut self, vector: <f32 as NeonNum>::VectorType, index: usize) {
-        debug_assert!(self.len() >= index + <f32 as NeonNum>::COMPLEX_PER_VECTOR);
-        vst1q_f32(self.as_mut_ptr().add(index) as *mut f32, vector);
+    unsafe fn store_complex(&mut self, vector: S::VectorType, index: usize) {
+        debug_assert!(self.len() >= index + S::VectorType::COMPLEX_PER_VECTOR);
+        S::VectorType::store_complex(self.as_mut_ptr().add(index), vector)
     }
 
     #[inline(always)]
-    unsafe fn store_partial_hi_complex(
-        &mut self,
-        vector: <f32 as NeonNum>::VectorType,
-        index: usize,
-    ) {
+    unsafe fn store_partial_hi_complex(&mut self, vector: S::VectorType, index: usize) {
         debug_assert!(self.len() >= index + 1);
-        let high = vget_high_f32(vector);
-        vst1_f32(self.as_mut_ptr().add(index) as *mut f32, high);
+        S::VectorType::store_partial_hi_complex(self.as_mut_ptr().add(index), vector)
     }
-
     #[inline(always)]
-    unsafe fn store_partial_lo_complex(
-        &mut self,
-        vector: <f32 as NeonNum>::VectorType,
-        index: usize,
-    ) {
+    unsafe fn store_partial_lo_complex(&mut self, vector: S::VectorType, index: usize) {
         debug_assert!(self.len() >= index + 1);
-        let low = vget_low_f32(vector);
-        vst1_f32(self.as_mut_ptr().add(index) as *mut f32, low);
+        S::VectorType::store_partial_lo_complex(self.as_mut_ptr().add(index), vector)
     }
 }
 
-impl NeonArrayMut<f64> for &mut [Complex<f64>] {
+impl<'a, T: NeonNum> NeonArrayMut<T> for DoubleBuf<'a, T>
+where
+    Self: NeonArray<T>,
+    &'a mut [Complex<T>]: NeonArrayMut<T>,
+{
     #[inline(always)]
-    unsafe fn store_complex(&mut self, vector: <f64 as NeonNum>::VectorType, index: usize) {
-        debug_assert!(self.len() >= index + <f64 as NeonNum>::COMPLEX_PER_VECTOR);
-        vst1q_f64(self.as_mut_ptr().add(index) as *mut f64, vector);
-    }
-
-    #[inline(always)]
-    unsafe fn store_partial_hi_complex(
-        &mut self,
-        _vector: <f64 as NeonNum>::VectorType,
-        _index: usize,
-    ) {
-        unimplemented!("Impossible to do a partial store of complex f64's");
+    unsafe fn store_complex(&mut self, vector: T::VectorType, index: usize) {
+        self.output.store_complex(vector, index);
     }
     #[inline(always)]
-    unsafe fn store_partial_lo_complex(
-        &mut self,
-        _vector: <f64 as NeonNum>::VectorType,
-        _index: usize,
-    ) {
-        unimplemented!("Impossible to do a partial store of complex f64's");
+    unsafe fn store_partial_lo_complex(&mut self, vector: T::VectorType, index: usize) {
+        self.output.store_partial_lo_complex(vector, index);
+    }
+    #[inline(always)]
+    unsafe fn store_partial_hi_complex(&mut self, vector: T::VectorType, index: usize) {
+        self.output.store_partial_hi_complex(vector, index);
     }
 }
 

--- a/src/neon/neon_vector.rs
+++ b/src/neon/neon_vector.rs
@@ -1,5 +1,6 @@
 use core::arch::aarch64::*;
 use num_complex::Complex;
+use num_traits::Zero;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
@@ -184,7 +185,7 @@ impl NeonVector for float32x4_t {
     unsafe fn load_partial_lo_complex(ptr: *const Complex<Self::ScalarType>) -> Self {
         let temp = vmovq_n_f32(0.0);
         vreinterpretq_f32_u64(vld1q_lane_u64::<0>(
-            ptr as *const f64,
+            ptr as *const u64,
             vreinterpretq_u64_f32(temp),
         ))
     }
@@ -301,7 +302,7 @@ impl NeonVector for float64x2_t {
 
     #[inline(always)]
     unsafe fn store_complex(ptr: *mut Complex<Self::ScalarType>, data: Self) {
-        vst1q_f64(ptr as *mut f64, data, data);
+        vst1q_f64(ptr as *mut f64, data);
     }
 
     #[inline(always)]
@@ -495,25 +496,6 @@ where
     #[inline(always)]
     unsafe fn store_partial_hi_complex(&mut self, vector: T::VectorType, index: usize) {
         self.output.store_partial_hi_complex(vector, index);
-    }
-}
-
-impl<'a, T: NeonNum> NeonArrayMut<T> for DoubleBuf<'a, T>
-where
-    Self: NeonArray<T>,
-    &'a mut [Complex<T>]: NeonArrayMut<T>,
-{
-    #[inline(always)]
-    unsafe fn store_complex(&mut self, vector: T::VectorType, index: usize) {
-        self.output.store_complex(vector, index);
-    }
-    #[inline(always)]
-    unsafe fn store_partial_hi_complex(&mut self, vector: T::VectorType, index: usize) {
-        self.output.store_partial_hi_complex(vector, index);
-    }
-    #[inline(always)]
-    unsafe fn store_partial_lo_complex(&mut self, vector: T::VectorType, index: usize) {
-        self.output.store_partial_lo_complex(vector, index);
     }
 }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -159,11 +159,11 @@ pub enum Recipe {
         inner_fft: Arc<Recipe>,
     },
     Radix3 {
-        k: usize,
+        k: u32,
         base_fft: Arc<Recipe>,
     },
     Radix4 {
-        k: usize,
+        k: u32,
         base_fft: Arc<Recipe>,
     },
     Butterfly2,
@@ -190,7 +190,7 @@ impl Recipe {
     pub fn len(&self) -> usize {
         match self {
             Recipe::Dft(length) => *length,
-            Recipe::Radix3 { k, base_fft } => base_fft.len() * 3usize.pow(*k as u32),
+            Recipe::Radix3 { k, base_fft } => base_fft.len() * 3usize.pow(*k),
             Recipe::Radix4 { k, base_fft } => base_fft.len() * (1 << (k * 2)),
             Recipe::Butterfly2 => 2,
             Recipe::Butterfly3 => 3,
@@ -485,14 +485,14 @@ impl<T: FftNum> FftPlannerScalar<T> {
 
         let base_fft = self.design_fft_for_len(3usize.pow(base_exponent));
         Arc::new(Recipe::Radix3 {
-            k: (exponent - base_exponent) as usize,
+            k: exponent - base_exponent,
             base_fft,
         })
     }
 
     fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
         // plan a step of radix4
-        let exponent = len.trailing_zeros() as usize;
+        let exponent = len.trailing_zeros();
         let base_exponent = match exponent {
             0 => 0,
             1 => 1,

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -12,6 +12,24 @@ mod sse_utils;
 
 pub mod sse_planner;
 
+use std::arch::x86_64::__m128;
+use std::arch::x86_64::__m128d;
+
+use crate::FftNum;
+
 pub use self::sse_butterflies::*;
 pub use self::sse_prime_butterflies::*;
 pub use self::sse_radix4::*;
+
+use sse_vector::SseVector;
+
+pub trait SseNum: FftNum {
+    type VectorType: SseVector<ScalarType = Self>;
+}
+
+impl SseNum for f32 {
+    type VectorType = __m128;
+}
+impl SseNum for f64 {
+    type VectorType = __m128d;
+}

--- a/src/sse/sse_butterflies.rs
+++ b/src/sse/sse_butterflies.rs
@@ -12,7 +12,7 @@ use crate::{Direction, Fft, Length};
 
 use super::sse_common::{assert_f32, assert_f64};
 use super::sse_utils::*;
-use super::sse_vector::SseArrayMut;
+use super::sse_vector::{SseArrayMut, SseVector};
 
 #[allow(unused)]
 macro_rules! boilerplate_fft_sse_f32_butterfly {
@@ -212,7 +212,7 @@ impl<T: FftNum> SseF32Butterfly1<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl SseArrayMut<f32>) {
-        let value = buffer.load_partial1_complex(0);
+        let value = buffer.load_partial_lo_complex(0);
         buffer.store_partial_lo_complex(value, 0);
     }
 
@@ -441,7 +441,7 @@ impl<T: FftNum> SseF32Butterfly3<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl SseArrayMut<f32>) {
-        let value0x = buffer.load_partial1_complex(0);
+        let value0x = buffer.load_partial_lo_complex(0);
         let value12 = buffer.load_complex(1);
 
         let out = self.perform_fft_direct(value0x, value12);
@@ -1579,10 +1579,10 @@ impl<T: FftNum> SseF32Butterfly9<T> {
             .perform_parallel_fft_direct(values[2], values[5], values[8]);
 
         // Apply twiddle factors. Note that we're re-using twiddle2
-        mid1[1] = mul_complex_f32(self.twiddle1, mid1[1]);
-        mid1[2] = mul_complex_f32(self.twiddle2, mid1[2]);
-        mid2[1] = mul_complex_f32(self.twiddle2, mid2[1]);
-        mid2[2] = mul_complex_f32(self.twiddle4, mid2[2]);
+        mid1[1] = SseVector::mul_complex(self.twiddle1, mid1[1]);
+        mid1[2] = SseVector::mul_complex(self.twiddle2, mid1[2]);
+        mid2[1] = SseVector::mul_complex(self.twiddle2, mid2[1]);
+        mid2[2] = SseVector::mul_complex(self.twiddle4, mid2[2]);
 
         let [output0, output1, output2] = self
             .bf3
@@ -1660,10 +1660,10 @@ impl<T: FftNum> SseF64Butterfly9<T> {
         let mut mid2 = self.bf3.perform_fft_direct(values[2], values[5], values[8]);
 
         // Apply twiddle factors. Note that we're re-using twiddle2
-        mid1[1] = mul_complex_f64(self.twiddle1, mid1[1]);
-        mid1[2] = mul_complex_f64(self.twiddle2, mid1[2]);
-        mid2[1] = mul_complex_f64(self.twiddle2, mid2[1]);
-        mid2[2] = mul_complex_f64(self.twiddle4, mid2[2]);
+        mid1[1] = SseVector::mul_complex(self.twiddle1, mid1[1]);
+        mid1[2] = SseVector::mul_complex(self.twiddle2, mid1[2]);
+        mid2[1] = SseVector::mul_complex(self.twiddle2, mid2[1]);
+        mid2[2] = SseVector::mul_complex(self.twiddle4, mid2[2]);
 
         let [output0, output1, output2] = self.bf3.perform_fft_direct(mid0[0], mid1[0], mid2[0]);
         let [output3, output4, output5] = self.bf3.perform_fft_direct(mid0[1], mid1[1], mid2[1]);
@@ -2377,11 +2377,11 @@ impl<T: FftNum> SseF32Butterfly16<T> {
         let mut odds3 = self.bf4.perform_fft_direct(in1503, in0711);
 
         // step 3: apply twiddle factors
-        odds1[0] = mul_complex_f32(odds1[0], self.twiddle01);
-        odds3[0] = mul_complex_f32(odds3[0], self.twiddle01conj);
+        odds1[0] = SseVector::mul_complex(odds1[0], self.twiddle01);
+        odds3[0] = SseVector::mul_complex(odds3[0], self.twiddle01conj);
 
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle23);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle23conj);
+        odds1[1] = SseVector::mul_complex(odds1[1], self.twiddle23);
+        odds3[1] = SseVector::mul_complex(odds3[1], self.twiddle23conj);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -2421,14 +2421,14 @@ impl<T: FftNum> SseF32Butterfly16<T> {
             .perform_parallel_fft_direct(input[15], input[3], input[7], input[11]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle1c);
+        odds1[1] = SseVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = SseVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f32(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f32(odds3[2], self.twiddle2c);
+        odds1[2] = SseVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = SseVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f32(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f32(odds3[3], self.twiddle3c);
+        odds1[3] = SseVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = SseVector::mul_complex(odds3[3], self.twiddle3c);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -2557,14 +2557,14 @@ impl<T: FftNum> SseF64Butterfly16<T> {
             .perform_fft_direct(input[15], input[3], input[7], input[11]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f64(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f64(odds3[1], self.twiddle1c);
+        odds1[1] = SseVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = SseVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f64(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f64(odds3[2], self.twiddle2c);
+        odds1[2] = SseVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = SseVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f64(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f64(odds3[3], self.twiddle3c);
+        odds1[3] = SseVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = SseVector::mul_complex(odds3[3], self.twiddle3c);
 
         // step 4: cross FFTs
         let mut temp0 = solo_fft2_f64(odds1[0], odds3[0]);
@@ -2770,17 +2770,17 @@ impl<T: FftNum> SseF32Butterfly32<T> {
             .perform_fft_direct([in3103, in0711, in1519, in2327]);
 
         // step 3: apply twiddle factors
-        odds1[0] = mul_complex_f32(odds1[0], self.twiddle01);
-        odds3[0] = mul_complex_f32(odds3[0], self.twiddle01conj);
+        odds1[0] = SseVector::mul_complex(odds1[0], self.twiddle01);
+        odds3[0] = SseVector::mul_complex(odds3[0], self.twiddle01conj);
 
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle23);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle23conj);
+        odds1[1] = SseVector::mul_complex(odds1[1], self.twiddle23);
+        odds3[1] = SseVector::mul_complex(odds3[1], self.twiddle23conj);
 
-        odds1[2] = mul_complex_f32(odds1[2], self.twiddle45);
-        odds3[2] = mul_complex_f32(odds3[2], self.twiddle45conj);
+        odds1[2] = SseVector::mul_complex(odds1[2], self.twiddle45);
+        odds3[2] = SseVector::mul_complex(odds3[2], self.twiddle45conj);
 
-        odds1[3] = mul_complex_f32(odds1[3], self.twiddle67);
-        odds3[3] = mul_complex_f32(odds3[3], self.twiddle67conj);
+        odds1[3] = SseVector::mul_complex(odds1[3], self.twiddle67);
+        odds3[3] = SseVector::mul_complex(odds3[3], self.twiddle67conj);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -2834,26 +2834,26 @@ impl<T: FftNum> SseF32Butterfly32<T> {
         ]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f32(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f32(odds3[1], self.twiddle1c);
+        odds1[1] = SseVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = SseVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f32(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f32(odds3[2], self.twiddle2c);
+        odds1[2] = SseVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = SseVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f32(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f32(odds3[3], self.twiddle3c);
+        odds1[3] = SseVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = SseVector::mul_complex(odds3[3], self.twiddle3c);
 
-        odds1[4] = mul_complex_f32(odds1[4], self.twiddle4);
-        odds3[4] = mul_complex_f32(odds3[4], self.twiddle4c);
+        odds1[4] = SseVector::mul_complex(odds1[4], self.twiddle4);
+        odds3[4] = SseVector::mul_complex(odds3[4], self.twiddle4c);
 
-        odds1[5] = mul_complex_f32(odds1[5], self.twiddle5);
-        odds3[5] = mul_complex_f32(odds3[5], self.twiddle5c);
+        odds1[5] = SseVector::mul_complex(odds1[5], self.twiddle5);
+        odds3[5] = SseVector::mul_complex(odds3[5], self.twiddle5c);
 
-        odds1[6] = mul_complex_f32(odds1[6], self.twiddle6);
-        odds3[6] = mul_complex_f32(odds3[6], self.twiddle6c);
+        odds1[6] = SseVector::mul_complex(odds1[6], self.twiddle6);
+        odds3[6] = SseVector::mul_complex(odds3[6], self.twiddle6c);
 
-        odds1[7] = mul_complex_f32(odds1[7], self.twiddle7);
-        odds3[7] = mul_complex_f32(odds3[7], self.twiddle7c);
+        odds1[7] = SseVector::mul_complex(odds1[7], self.twiddle7);
+        odds3[7] = SseVector::mul_complex(odds3[7], self.twiddle7c);
 
         // step 4: cross FFTs
         let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
@@ -3042,26 +3042,26 @@ impl<T: FftNum> SseF64Butterfly32<T> {
         ]);
 
         // step 3: apply twiddle factors
-        odds1[1] = mul_complex_f64(odds1[1], self.twiddle1);
-        odds3[1] = mul_complex_f64(odds3[1], self.twiddle1c);
+        odds1[1] = SseVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = SseVector::mul_complex(odds3[1], self.twiddle1c);
 
-        odds1[2] = mul_complex_f64(odds1[2], self.twiddle2);
-        odds3[2] = mul_complex_f64(odds3[2], self.twiddle2c);
+        odds1[2] = SseVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = SseVector::mul_complex(odds3[2], self.twiddle2c);
 
-        odds1[3] = mul_complex_f64(odds1[3], self.twiddle3);
-        odds3[3] = mul_complex_f64(odds3[3], self.twiddle3c);
+        odds1[3] = SseVector::mul_complex(odds1[3], self.twiddle3);
+        odds3[3] = SseVector::mul_complex(odds3[3], self.twiddle3c);
 
-        odds1[4] = mul_complex_f64(odds1[4], self.twiddle4);
-        odds3[4] = mul_complex_f64(odds3[4], self.twiddle4c);
+        odds1[4] = SseVector::mul_complex(odds1[4], self.twiddle4);
+        odds3[4] = SseVector::mul_complex(odds3[4], self.twiddle4c);
 
-        odds1[5] = mul_complex_f64(odds1[5], self.twiddle5);
-        odds3[5] = mul_complex_f64(odds3[5], self.twiddle5c);
+        odds1[5] = SseVector::mul_complex(odds1[5], self.twiddle5);
+        odds3[5] = SseVector::mul_complex(odds3[5], self.twiddle5c);
 
-        odds1[6] = mul_complex_f64(odds1[6], self.twiddle6);
-        odds3[6] = mul_complex_f64(odds3[6], self.twiddle6c);
+        odds1[6] = SseVector::mul_complex(odds1[6], self.twiddle6);
+        odds3[6] = SseVector::mul_complex(odds3[6], self.twiddle6c);
 
-        odds1[7] = mul_complex_f64(odds1[7], self.twiddle7);
-        odds3[7] = mul_complex_f64(odds3[7], self.twiddle7c);
+        odds1[7] = SseVector::mul_complex(odds1[7], self.twiddle7);
+        odds3[7] = SseVector::mul_complex(odds3[7], self.twiddle7c);
 
         // step 4: cross FFTs
         let mut temp0 = solo_fft2_f64(odds1[0], odds3[0]);
@@ -3182,37 +3182,6 @@ mod unit_tests {
     test_butterfly_64_func!(test_ssef64_butterfly15, SseF64Butterfly15, 15);
     test_butterfly_64_func!(test_ssef64_butterfly16, SseF64Butterfly16, 16);
     test_butterfly_64_func!(test_ssef64_butterfly32, SseF64Butterfly32, 32);
-
-    #[test]
-    fn test_mul_complex_f64() {
-        unsafe {
-            let right = _mm_set_pd(1.0, 2.0);
-            let left = _mm_set_pd(5.0, 7.0);
-            let res = mul_complex_f64(left, right);
-            let expected = _mm_set_pd(2.0 * 5.0 + 1.0 * 7.0, 2.0 * 7.0 - 1.0 * 5.0);
-            assert_eq!(
-                std::mem::transmute::<__m128d, Complex<f64>>(res),
-                std::mem::transmute::<__m128d, Complex<f64>>(expected)
-            );
-        }
-    }
-
-    #[test]
-    fn test_mul_complex_f32() {
-        unsafe {
-            let val1 = Complex::<f32>::new(1.0, 2.5);
-            let val2 = Complex::<f32>::new(3.2, 4.2);
-            let val3 = Complex::<f32>::new(5.6, 6.2);
-            let val4 = Complex::<f32>::new(7.4, 8.3);
-
-            let nbr2 = _mm_set_ps(val4.im, val4.re, val3.im, val3.re);
-            let nbr1 = _mm_set_ps(val2.im, val2.re, val1.im, val1.re);
-            let res = mul_complex_f32(nbr1, nbr2);
-            let res = std::mem::transmute::<__m128, [Complex<f32>; 2]>(res);
-            let expected = [val1 * val3, val2 * val4];
-            assert_eq!(res, expected);
-        }
-    }
 
     #[test]
     fn test_parallel_fft4_32() {

--- a/src/sse/sse_common.rs
+++ b/src/sse/sse_common.rs
@@ -96,7 +96,7 @@ macro_rules! separate_interleaved_complex_f32 {
 
 macro_rules! boilerplate_fft_sse_oop {
     ($struct_name:ident, $len_fn:expr) => {
-        impl<T: FftNum> Fft<T> for $struct_name<T> {
+        impl<S: SseNum, T: FftNum> Fft<T> for $struct_name<S, T> {
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -174,13 +174,13 @@ macro_rules! boilerplate_fft_sse_oop {
                 0
             }
         }
-        impl<T> Length for $struct_name<T> {
+        impl<S: SseNum, T> Length for $struct_name<S, T> {
             #[inline(always)]
             fn len(&self) -> usize {
                 $len_fn(self)
             }
         }
-        impl<T> Direction for $struct_name<T> {
+        impl<S: SseNum, T> Direction for $struct_name<S, T> {
             #[inline(always)]
             fn fft_direction(&self) -> FftDirection {
                 self.direction

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -655,10 +655,10 @@ impl<T: FftNum> FftPlannerSse<T> {
             }
         };
 
-        let base = self.design_fft_for_len(1 << base_exponent);
+        let base_fft = self.design_fft_for_len(1 << base_exponent);
         Arc::new(Recipe::Radix4 {
             k: (exponent - base_exponent) / 2,
-            base_fft: base,
+            base_fft,
         })
     }
 }

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -49,7 +49,7 @@ pub enum Recipe {
         inner_fft: Arc<Recipe>,
     },
     Radix4 {
-        k: usize,
+        k: u32,
         base_fft: Arc<Recipe>,
     },
     Butterfly1,
@@ -637,7 +637,7 @@ impl<T: FftNum> FftPlannerSse<T> {
 
     fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
         // plan a step of radix4
-        let exponent = len.trailing_zeros() as usize;
+        let exponent = len.trailing_zeros();
         let base_exponent = match exponent {
             0 => 0,
             1 => 1,

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -626,7 +626,7 @@ impl<T: FftNum> FftPlannerSse<T> {
                     let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
                     self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
                 } else {
-                    self.design_radix4(len)
+                    self.design_radix4(inner_fft_len_pow2)
                 };
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -17,6 +17,7 @@ use crate::math_utils::{PrimeFactor, PrimeFactors};
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
 const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
+const RADIX4_USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
 /// It is used as a middle step in the planning process.
@@ -47,7 +48,10 @@ pub enum Recipe {
         len: usize,
         inner_fft: Arc<Recipe>,
     },
-    Radix4(usize),
+    Radix4 {
+        k: usize,
+        base_fft: Arc<Recipe>,
+    },
     Butterfly1,
     Butterfly2,
     Butterfly3,
@@ -75,7 +79,7 @@ impl Recipe {
     pub fn len(&self) -> usize {
         match self {
             Recipe::Dft(length) => *length,
-            Recipe::Radix4(length) => *length,
+            Recipe::Radix4 { k, base_fft } => base_fft.len() * (1 << (k * 2)),
             Recipe::Butterfly1 => 1,
             Recipe::Butterfly2 => 2,
             Recipe::Butterfly3 => 3,
@@ -249,11 +253,12 @@ impl<T: FftNum> FftPlannerSse<T> {
 
         match recipe {
             Recipe::Dft(len) => Arc::new(Dft::new(*len, direction)) as Arc<dyn Fft<T>>,
-            Recipe::Radix4(len) => {
+            Recipe::Radix4 { k, base_fft } => {
+                let base_fft = self.build_fft(&base_fft, direction);
                 if id_t == id_f32 {
-                    Arc::new(Sse32Radix4::new(*len, direction)) as Arc<dyn Fft<T>>
+                    Arc::new(SseRadix4::<f32, T>::new(*k, base_fft).unwrap()) as Arc<dyn Fft<T>>
                 } else if id_t == id_f64 {
-                    Arc::new(Sse64Radix4::new(*len, direction)) as Arc<dyn Fft<T>>
+                    Arc::new(SseRadix4::<f64, T>::new(*k, base_fft).unwrap()) as Arc<dyn Fft<T>>
                 } else {
                     panic!("Not f32 or f64");
                 }
@@ -497,7 +502,7 @@ impl<T: FftNum> FftPlannerSse<T> {
             self.design_prime(len)
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
             if len.is_power_of_two() {
-                Arc::new(Recipe::Radix4(len))
+                self.design_radix4(len)
             } else {
                 let non_power_of_two = factors
                     .remove_factors(PrimeFactor {
@@ -621,13 +626,40 @@ impl<T: FftNum> FftPlannerSse<T> {
                     let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
                     self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
                 } else {
-                    Arc::new(Recipe::Radix4(inner_fft_len_pow2))
+                    self.design_radix4(len)
                 };
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {
             let inner_fft = self.design_fft_with_factors(inner_fft_len_rader, raders_factors);
             Arc::new(Recipe::RadersAlgorithm { inner_fft })
         }
+    }
+
+    fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
+        // plan a step of radix4
+        let exponent = len.trailing_zeros() as usize;
+        let base_exponent = match exponent {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            _ => {
+                if exponent % 2 == 1 {
+                    if len < RADIX4_USE_BUTTERFLY32_FROM {
+                        3
+                    } else {
+                        5
+                    }
+                } else {
+                    4
+                }
+            }
+        };
+
+        let base = self.design_fft_for_len(1 << base_exponent);
+        Arc::new(Recipe::Radix4 {
+            k: (exponent - base_exponent) / 2,
+            base_fft: base,
+        })
     }
 }
 
@@ -688,7 +720,7 @@ mod unit_tests {
         for pow in 6..32 {
             let len = 1 << pow;
             let plan = planner.design_fft_for_len(len);
-            assert_eq!(*plan, Recipe::Radix4(len));
+            assert!(matches!(*plan, Recipe::Radix4 { k: _, base_fft: _ }));
             assert_eq!(plan.len(), len, "Recipe reports wrong length");
         }
     }

--- a/src/sse/sse_prime_butterflies.rs
+++ b/src/sse/sse_prime_butterflies.rs
@@ -12,7 +12,7 @@ use crate::{Direction, Fft, Length};
 
 use super::sse_common::{assert_f32, assert_f64};
 use super::sse_utils::*;
-use super::sse_vector::{SseArrayMut};
+use super::sse_vector::SseArrayMut;
 use super::sse_butterflies::{parallel_fft2_interleaved_f32, solo_fft2_f64};
 
 // Auto-generated prime length butterflies

--- a/src/sse/sse_radix4.rs
+++ b/src/sse/sse_radix4.rs
@@ -1,89 +1,59 @@
 use num_complex::Complex;
 
-use core::arch::x86_64::*;
+use std::any::TypeId;
+use std::sync::Arc;
 
 use crate::array_utils::{self, bitreversed_transpose, workaround_transmute_mut};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
-use crate::sse::sse_butterflies::{
-    SseF32Butterfly1, SseF32Butterfly16, SseF32Butterfly2, SseF32Butterfly32, SseF32Butterfly4,
-    SseF32Butterfly8,
-};
-use crate::sse::sse_butterflies::{
-    SseF64Butterfly1, SseF64Butterfly16, SseF64Butterfly2, SseF64Butterfly32, SseF64Butterfly4,
-    SseF64Butterfly8,
-};
-use crate::{common::FftNum, twiddles, FftDirection};
+use crate::{common::FftNum, FftDirection};
 use crate::{Direction, Fft, Length};
 
-use super::sse_common::{assert_f32, assert_f64};
-use super::sse_utils::*;
+use super::SseNum;
 
-use super::sse_vector::{SseArray, SseArrayMut};
+use super::sse_vector::{Rotation90, SseArray, SseArrayMut, SseVector};
 
 /// FFT algorithm optimized for power-of-two sizes, SSE accelerated version.
 /// This is designed to be used via a Planner, and not created directly.
 
-const USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
+pub struct SseRadix4<S: SseNum, T> {
+    twiddles: Box<[S::VectorType]>,
+    rotation: Rotation90<S::VectorType>,
 
-enum Sse32Butterfly<T> {
-    Len1(SseF32Butterfly1<T>),
-    Len2(SseF32Butterfly2<T>),
-    Len4(SseF32Butterfly4<T>),
-    Len8(SseF32Butterfly8<T>),
-    Len16(SseF32Butterfly16<T>),
-    Len32(SseF32Butterfly32<T>),
-}
-
-enum Sse64Butterfly<T> {
-    Len1(SseF64Butterfly1<T>),
-    Len2(SseF64Butterfly2<T>),
-    Len4(SseF64Butterfly4<T>),
-    Len8(SseF64Butterfly8<T>),
-    Len16(SseF64Butterfly16<T>),
-    Len32(SseF64Butterfly32<T>),
-}
-
-pub struct Sse32Radix4<T> {
-    _phantom: std::marker::PhantomData<T>,
-    twiddles: Box<[__m128]>,
-
-    base_fft: Sse32Butterfly<T>,
+    base_fft: Arc<dyn Fft<T>>,
     base_len: usize,
 
     len: usize,
     direction: FftDirection,
-    bf4: SseF32Butterfly4<T>,
 }
 
-impl<T: FftNum> Sse32Radix4<T> {
-    /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
-    pub fn new(len: usize, direction: FftDirection) -> Self {
-        assert!(
-            len.is_power_of_two(),
-            "Radix4 algorithm requires a power-of-two input size. Got {}",
-            len
-        );
-        assert_f32::<T>();
+impl<S: SseNum, T: FftNum> SseRadix4<S, T> {
+    /// Constructs a new SseRadix4 which computes FFTs of size 4^k * base_fft.len()
+    #[inline]
+    pub fn new(k: usize, base_fft: Arc<dyn Fft<T>>) -> Result<Self, ()> {
+        // Internal sanity check: Make sure that S == T.
+        // This struct has two generic parameters S and T, but they must always be the same, and are only kept separate to help work around the lack of specialization.
+        // It would be cool if we could do this as a static_assert instead
+        let id_a = TypeId::of::<S>();
+        let id_t = TypeId::of::<T>();
+        assert_eq!(id_a, id_t);
 
-        // figure out which base length we're going to use
-        let num_bits = len.trailing_zeros();
-        let (base_len, base_fft) = match num_bits {
-            0 => (len, Sse32Butterfly::Len1(SseF32Butterfly1::new(direction))),
-            1 => (len, Sse32Butterfly::Len2(SseF32Butterfly2::new(direction))),
-            2 => (len, Sse32Butterfly::Len4(SseF32Butterfly4::new(direction))),
-            3 => (len, Sse32Butterfly::Len8(SseF32Butterfly8::new(direction))),
-            _ => {
-                if num_bits % 2 == 1 {
-                    if len < USE_BUTTERFLY32_FROM {
-                        (8, Sse32Butterfly::Len8(SseF32Butterfly8::new(direction)))
-                    } else {
-                        (32, Sse32Butterfly::Len32(SseF32Butterfly32::new(direction)))
-                    }
-                } else {
-                    (16, Sse32Butterfly::Len16(SseF32Butterfly16::new(direction)))
-                }
-            }
-        };
+        let has_sse = is_x86_feature_detected!("sse4.1");
+        if has_sse {
+            // Safety: new_with_sse requires the "sse4.1" feature set. Since we know it's present, we're safe
+            Ok(unsafe { Self::new_with_sse(k, base_fft) })
+        } else {
+            Err(())
+        }
+    }
+
+    #[target_feature(enable = "sse4.1")]
+    unsafe fn new_with_sse(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+        let direction = base_fft.fft_direction();
+        let base_len = base_fft.len();
+
+        assert!(base_len.is_power_of_two() && base_len >= 2 * S::VectorType::COMPLEX_PER_VECTOR);
+
+        let len = base_len * (1 << (k * 2));
 
         // precompute the twiddle factors this algorithm will use.
         // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
@@ -94,19 +64,16 @@ impl<T: FftNum> Sse32Radix4<T> {
         let mut twiddle_factors = Vec::with_capacity(len * 2);
         while cross_fft_len <= len {
             let num_scalar_columns = cross_fft_len / ROW_COUNT;
-            let num_vector_columns = num_scalar_columns / 2; // 2 complex<T> per __m128
+            let num_vector_columns = num_scalar_columns / S::VectorType::COMPLEX_PER_VECTOR;
 
             for i in 0..num_vector_columns {
                 for k in 1..ROW_COUNT {
-                    unsafe {
-                        let twiddle_a =
-                            twiddles::compute_twiddle(2 * i * k, cross_fft_len, direction);
-                        let twiddle_b =
-                            twiddles::compute_twiddle((2 * i + 1) * k, cross_fft_len, direction);
-                        let twiddles_packed =
-                            _mm_set_ps(twiddle_b.im, twiddle_b.re, twiddle_a.im, twiddle_a.re);
-                        twiddle_factors.push(twiddles_packed);
-                    }
+                    twiddle_factors.push(SseVector::make_mixedradix_twiddle_chunk(
+                        i * S::VectorType::COMPLEX_PER_VECTOR,
+                        k,
+                        cross_fft_len,
+                        direction,
+                    ));
                 }
             }
             cross_fft_len *= ROW_COUNT;
@@ -114,14 +81,13 @@ impl<T: FftNum> Sse32Radix4<T> {
 
         Self {
             twiddles: twiddle_factors.into_boxed_slice(),
+            rotation: SseVector::make_rotate90(direction),
 
             base_fft,
             base_len,
 
             len,
             direction,
-            _phantom: std::marker::PhantomData,
-            bf4: SseF32Butterfly4::<T>::new(direction),
         }
     }
 
@@ -140,288 +106,128 @@ impl<T: FftNum> Sse32Radix4<T> {
         }
 
         // Base-level FFTs
-        match &self.base_fft {
-            Sse32Butterfly::Len1(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse32Butterfly::Len2(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse32Butterfly::Len4(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse32Butterfly::Len8(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse32Butterfly::Len16(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse32Butterfly::Len32(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-        };
+        self.base_fft.process_with_scratch(output, &mut []);
 
         // cross-FFTs
         const ROW_COUNT: usize = 4;
         let mut cross_fft_len = self.base_len * ROW_COUNT;
-        let mut layer_twiddles: &[__m128] = &self.twiddles;
+        let mut layer_twiddles: &[S::VectorType] = &self.twiddles;
 
         while cross_fft_len <= input.len() {
             let num_rows = input.len() / cross_fft_len;
-            let num_columns = cross_fft_len / ROW_COUNT;
+            let num_scalar_columns = cross_fft_len / ROW_COUNT;
+            let num_vector_columns = num_scalar_columns / S::VectorType::COMPLEX_PER_VECTOR;
 
             for i in 0..num_rows {
-                butterfly_4_32(
+                butterfly_4::<S, T>(
                     &mut output[i * cross_fft_len..],
                     layer_twiddles,
-                    num_columns,
-                    &self.bf4,
+                    num_scalar_columns,
+                    &self.rotation,
                 )
             }
 
             // skip past all the twiddle factors used in this layer
-            // half as many twiddles because sse vectors store 2 complex<f32> each
-            let twiddle_offset = num_columns * (ROW_COUNT - 1) / 2;
+            let twiddle_offset = num_vector_columns * (ROW_COUNT - 1);
             layer_twiddles = &layer_twiddles[twiddle_offset..];
 
             cross_fft_len *= ROW_COUNT;
         }
     }
 }
-boilerplate_fft_sse_oop!(Sse32Radix4, |this: &Sse32Radix4<_>| this.len);
+boilerplate_fft_sse_oop!(SseRadix4, |this: &SseRadix4<_, _>| this.len);
 
 #[target_feature(enable = "sse4.1")]
-unsafe fn butterfly_4_32<T: FftNum>(
+unsafe fn butterfly_4<S: SseNum, T: FftNum>(
     data: &mut [Complex<T>],
-    twiddles: &[__m128],
+    twiddles: &[S::VectorType],
     num_ffts: usize,
-    bf4: &SseF32Butterfly4<T>,
+    rotation: &Rotation90<S::VectorType>,
 ) {
+    let unroll_offset = S::VectorType::COMPLEX_PER_VECTOR;
+
     let mut idx = 0usize;
-    let mut buffer: &mut [Complex<f32>] = workaround_transmute_mut(data);
-    for tw in twiddles.chunks_exact(6).take(num_ffts / 4) {
-        let scratch0 = buffer.load_complex(idx);
-        let scratch0b = buffer.load_complex(idx + 2);
-        let mut scratch1 = buffer.load_complex(idx + 1 * num_ffts);
-        let mut scratch1b = buffer.load_complex(idx + 2 + 1 * num_ffts);
-        let mut scratch2 = buffer.load_complex(idx + 2 * num_ffts);
-        let mut scratch2b = buffer.load_complex(idx + 2 + 2 * num_ffts);
-        let mut scratch3 = buffer.load_complex(idx + 3 * num_ffts);
-        let mut scratch3b = buffer.load_complex(idx + 2 + 3 * num_ffts);
+    let mut buffer: &mut [Complex<S>] = workaround_transmute_mut(data);
+    for tw in twiddles
+        .chunks_exact(6)
+        .take(num_ffts / (S::VectorType::COMPLEX_PER_VECTOR * 2))
+    {
+        let mut scratcha = [
+            buffer.load_complex(idx + 0 * num_ffts),
+            buffer.load_complex(idx + 1 * num_ffts),
+            buffer.load_complex(idx + 2 * num_ffts),
+            buffer.load_complex(idx + 3 * num_ffts),
+        ];
+        let mut scratchb = [
+            buffer.load_complex(idx + 0 * num_ffts + unroll_offset),
+            buffer.load_complex(idx + 1 * num_ffts + unroll_offset),
+            buffer.load_complex(idx + 2 * num_ffts + unroll_offset),
+            buffer.load_complex(idx + 3 * num_ffts + unroll_offset),
+        ];
 
-        scratch1 = mul_complex_f32(scratch1, tw[0]);
-        scratch2 = mul_complex_f32(scratch2, tw[1]);
-        scratch3 = mul_complex_f32(scratch3, tw[2]);
-        scratch1b = mul_complex_f32(scratch1b, tw[3]);
-        scratch2b = mul_complex_f32(scratch2b, tw[4]);
-        scratch3b = mul_complex_f32(scratch3b, tw[5]);
+        scratcha[1] = SseVector::mul_complex(scratcha[1], tw[0]);
+        scratcha[2] = SseVector::mul_complex(scratcha[2], tw[1]);
+        scratcha[3] = SseVector::mul_complex(scratcha[3], tw[2]);
+        scratchb[1] = SseVector::mul_complex(scratchb[1], tw[3]);
+        scratchb[2] = SseVector::mul_complex(scratchb[2], tw[4]);
+        scratchb[3] = SseVector::mul_complex(scratchb[3], tw[5]);
 
-        let scratch = bf4.perform_parallel_fft_direct(scratch0, scratch1, scratch2, scratch3);
-        let scratchb = bf4.perform_parallel_fft_direct(scratch0b, scratch1b, scratch2b, scratch3b);
+        let scratcha = SseVector::column_butterfly4(scratcha, *rotation);
+        let scratchb = SseVector::column_butterfly4(scratchb, *rotation);
 
-        buffer.store_complex(scratch[0], idx);
-        buffer.store_complex(scratchb[0], idx + 2);
-        buffer.store_complex(scratch[1], idx + 1 * num_ffts);
-        buffer.store_complex(scratchb[1], idx + 2 + 1 * num_ffts);
-        buffer.store_complex(scratch[2], idx + 2 * num_ffts);
-        buffer.store_complex(scratchb[2], idx + 2 + 2 * num_ffts);
-        buffer.store_complex(scratch[3], idx + 3 * num_ffts);
-        buffer.store_complex(scratchb[3], idx + 2 + 3 * num_ffts);
+        buffer.store_complex(scratcha[0], idx + 0 * num_ffts);
+        buffer.store_complex(scratchb[0], idx + 0 * num_ffts + unroll_offset);
+        buffer.store_complex(scratcha[1], idx + 1 * num_ffts);
+        buffer.store_complex(scratchb[1], idx + 1 * num_ffts + unroll_offset);
+        buffer.store_complex(scratcha[2], idx + 2 * num_ffts);
+        buffer.store_complex(scratchb[2], idx + 2 * num_ffts + unroll_offset);
+        buffer.store_complex(scratcha[3], idx + 3 * num_ffts);
+        buffer.store_complex(scratchb[3], idx + 3 * num_ffts + unroll_offset);
 
-        idx += 4;
-    }
-}
-
-pub struct Sse64Radix4<T> {
-    _phantom: std::marker::PhantomData<T>,
-    twiddles: Box<[__m128d]>,
-
-    base_fft: Sse64Butterfly<T>,
-    base_len: usize,
-
-    len: usize,
-    direction: FftDirection,
-    bf4: SseF64Butterfly4<T>,
-}
-
-impl<T: FftNum> Sse64Radix4<T> {
-    /// Preallocates necessary arrays and precomputes necessary data to efficiently compute the power-of-two FFT
-    pub fn new(len: usize, direction: FftDirection) -> Self {
-        assert!(
-            len.is_power_of_two(),
-            "Radix4 algorithm requires a power-of-two input size. Got {}",
-            len
-        );
-
-        assert_f64::<T>();
-
-        // figure out which base length we're going to use
-        let num_bits = len.trailing_zeros();
-        let (base_len, base_fft) = match num_bits {
-            0 => (len, Sse64Butterfly::Len1(SseF64Butterfly1::new(direction))),
-            1 => (len, Sse64Butterfly::Len2(SseF64Butterfly2::new(direction))),
-            2 => (len, Sse64Butterfly::Len4(SseF64Butterfly4::new(direction))),
-            3 => (len, Sse64Butterfly::Len8(SseF64Butterfly8::new(direction))),
-            _ => {
-                if num_bits % 2 == 1 {
-                    if len < USE_BUTTERFLY32_FROM {
-                        (8, Sse64Butterfly::Len8(SseF64Butterfly8::new(direction)))
-                    } else {
-                        (32, Sse64Butterfly::Len32(SseF64Butterfly32::new(direction)))
-                    }
-                } else {
-                    (16, Sse64Butterfly::Len16(SseF64Butterfly16::new(direction)))
-                }
-            }
-        };
-
-        // precompute the twiddle factors this algorithm will use.
-        // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=4 and height=len/4
-        // but mixed radix only does one step and then calls itself recusrively, and this algorithm does every layer all the way down
-        // so we're going to pack all the "layers" of twiddle factors into a single array, starting with the bottom layer and going up
-        const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = base_len * ROW_COUNT;
-        let mut twiddle_factors = Vec::with_capacity(len * 2);
-        while cross_fft_len <= len {
-            let num_columns = cross_fft_len / ROW_COUNT;
-
-            for i in 0..num_columns {
-                for k in 1..ROW_COUNT {
-                    unsafe {
-                        let twiddle = twiddles::compute_twiddle(i * k, cross_fft_len, direction);
-                        let twiddle_packed = _mm_set_pd(twiddle.im, twiddle.re);
-                        twiddle_factors.push(twiddle_packed);
-                    }
-                }
-            }
-            cross_fft_len *= ROW_COUNT;
-        }
-
-        Self {
-            twiddles: twiddle_factors.into_boxed_slice(),
-
-            base_fft,
-            base_len,
-
-            len,
-            direction,
-            _phantom: std::marker::PhantomData,
-            bf4: SseF64Butterfly4::<T>::new(direction),
-        }
-    }
-
-    #[target_feature(enable = "sse4.1")]
-    unsafe fn perform_fft_out_of_place(
-        &self,
-        input: &[Complex<T>],
-        output: &mut [Complex<T>],
-        _scratch: &mut [Complex<T>],
-    ) {
-        // copy the data into the output vector
-        if self.len() == self.base_len {
-            output.copy_from_slice(input);
-        } else {
-            bitreversed_transpose::<Complex<T>, 4>(self.base_len, input, output);
-        }
-
-        // Base-level FFTs
-        match &self.base_fft {
-            Sse64Butterfly::Len1(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse64Butterfly::Len2(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse64Butterfly::Len4(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse64Butterfly::Len8(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse64Butterfly::Len16(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-            Sse64Butterfly::Len32(bf) => bf.perform_fft_butterfly_multi(output).unwrap(),
-        }
-
-        // cross-FFTs
-        const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = self.base_len * ROW_COUNT;
-        let mut layer_twiddles: &[__m128d] = &self.twiddles;
-
-        while cross_fft_len <= input.len() {
-            let num_rows = input.len() / cross_fft_len;
-            let num_columns = cross_fft_len / ROW_COUNT;
-
-            for i in 0..num_rows {
-                butterfly_4_64(
-                    &mut output[i * cross_fft_len..],
-                    layer_twiddles,
-                    num_columns,
-                    &self.bf4,
-                )
-            }
-
-            // skip past all the twiddle factors used in this layer
-            let twiddle_offset = num_columns * (ROW_COUNT - 1);
-            layer_twiddles = &layer_twiddles[twiddle_offset..];
-
-            cross_fft_len *= ROW_COUNT;
-        }
-    }
-}
-boilerplate_fft_sse_oop!(Sse64Radix4, |this: &Sse64Radix4<_>| this.len);
-
-#[target_feature(enable = "sse4.1")]
-unsafe fn butterfly_4_64<T: FftNum>(
-    data: &mut [Complex<T>],
-    twiddles: &[__m128d],
-    num_ffts: usize,
-    bf4: &SseF64Butterfly4<T>,
-) {
-    let mut idx = 0usize;
-    let mut buffer: &mut [Complex<f64>] = workaround_transmute_mut(data);
-    for tw in twiddles.chunks_exact(6).take(num_ffts / 2) {
-        let scratch0 = buffer.load_complex(idx);
-        let scratch0b = buffer.load_complex(idx + 1);
-        let mut scratch1 = buffer.load_complex(idx + 1 * num_ffts);
-        let mut scratch1b = buffer.load_complex(idx + 1 + 1 * num_ffts);
-        let mut scratch2 = buffer.load_complex(idx + 2 * num_ffts);
-        let mut scratch2b = buffer.load_complex(idx + 1 + 2 * num_ffts);
-        let mut scratch3 = buffer.load_complex(idx + 3 * num_ffts);
-        let mut scratch3b = buffer.load_complex(idx + 1 + 3 * num_ffts);
-
-        scratch1 = mul_complex_f64(scratch1, tw[0]);
-        scratch2 = mul_complex_f64(scratch2, tw[1]);
-        scratch3 = mul_complex_f64(scratch3, tw[2]);
-        scratch1b = mul_complex_f64(scratch1b, tw[3]);
-        scratch2b = mul_complex_f64(scratch2b, tw[4]);
-        scratch3b = mul_complex_f64(scratch3b, tw[5]);
-
-        let scratch = bf4.perform_fft_direct(scratch0, scratch1, scratch2, scratch3);
-        let scratchb = bf4.perform_fft_direct(scratch0b, scratch1b, scratch2b, scratch3b);
-
-        buffer.store_complex(scratch[0], idx);
-        buffer.store_complex(scratchb[0], idx + 1);
-        buffer.store_complex(scratch[1], idx + 1 * num_ffts);
-        buffer.store_complex(scratchb[1], idx + 1 + 1 * num_ffts);
-        buffer.store_complex(scratch[2], idx + 2 * num_ffts);
-        buffer.store_complex(scratchb[2], idx + 1 + 2 * num_ffts);
-        buffer.store_complex(scratch[3], idx + 3 * num_ffts);
-        buffer.store_complex(scratchb[3], idx + 1 + 3 * num_ffts);
-
-        idx += 2;
+        idx += S::VectorType::COMPLEX_PER_VECTOR * 2;
     }
 }
 
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::test_utils::check_fft_algorithm;
+    use crate::test_utils::{check_fft_algorithm, construct_base};
 
     #[test]
     fn test_sse_radix4_64() {
-        for pow in 4..12 {
-            let len = 1 << pow;
-            test_sse_radix4_64_with_length(len, FftDirection::Forward);
-            test_sse_radix4_64_with_length(len, FftDirection::Inverse);
+        for base in [2, 4, 8, 16] {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
+            for k in 0..4 {
+                test_sse_radix4_64_with_base(k, Arc::clone(&base_forward));
+                test_sse_radix4_64_with_base(k, Arc::clone(&base_inverse));
+            }
         }
     }
 
-    fn test_sse_radix4_64_with_length(len: usize, direction: FftDirection) {
-        let fft = Sse64Radix4::new(len, direction);
+    fn test_sse_radix4_64_with_base(k: usize, base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * 4usize.pow(k as u32);
+        let direction = base_fft.fft_direction();
+        let fft = SseRadix4::<f64, f64>::new(k, base_fft).unwrap();
         check_fft_algorithm::<f64>(&fft, len, direction);
     }
 
     #[test]
     fn test_sse_radix4_32() {
-        for pow in 0..12 {
-            let len = 1 << pow;
-            test_sse_radix4_32_with_length(len, FftDirection::Forward);
-            test_sse_radix4_32_with_length(len, FftDirection::Inverse);
+        for base in [4, 8, 16] {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
+            for k in 0..4 {
+                test_sse_radix4_32_with_base(k, Arc::clone(&base_forward));
+                test_sse_radix4_32_with_base(k, Arc::clone(&base_inverse));
+            }
         }
     }
 
-    fn test_sse_radix4_32_with_length(len: usize, direction: FftDirection) {
-        let fft = Sse32Radix4::new(len, direction);
+    fn test_sse_radix4_32_with_base(k: usize, base_fft: Arc<dyn Fft<f32>>) {
+        let len = base_fft.len() * 4usize.pow(k as u32);
+        let direction = base_fft.fft_direction();
+        let fft = SseRadix4::<f32, f32>::new(k, base_fft).unwrap();
         check_fft_algorithm::<f32>(&fft, len, direction);
     }
 }

--- a/src/sse/sse_radix4.rs
+++ b/src/sse/sse_radix4.rs
@@ -29,7 +29,7 @@ pub struct SseRadix4<S: SseNum, T> {
 impl<S: SseNum, T: FftNum> SseRadix4<S, T> {
     /// Constructs a new SseRadix4 which computes FFTs of size 4^k * base_fft.len()
     #[inline]
-    pub fn new(k: usize, base_fft: Arc<dyn Fft<T>>) -> Result<Self, ()> {
+    pub fn new(k: u32, base_fft: Arc<dyn Fft<T>>) -> Result<Self, ()> {
         // Internal sanity check: Make sure that S == T.
         // This struct has two generic parameters S and T, but they must always be the same, and are only kept separate to help work around the lack of specialization.
         // It would be cool if we could do this as a static_assert instead
@@ -47,7 +47,7 @@ impl<S: SseNum, T: FftNum> SseRadix4<S, T> {
     }
 
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new_with_sse(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+    unsafe fn new_with_sse(k: u32, base_fft: Arc<dyn Fft<T>>) -> Self {
         let direction = base_fft.fft_direction();
         let base_len = base_fft.len();
 
@@ -205,8 +205,8 @@ mod unit_tests {
         }
     }
 
-    fn test_sse_radix4_64_with_base(k: usize, base_fft: Arc<dyn Fft<f64>>) {
-        let len = base_fft.len() * 4usize.pow(k as u32);
+    fn test_sse_radix4_64_with_base(k: u32, base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * 4usize.pow(k);
         let direction = base_fft.fft_direction();
         let fft = SseRadix4::<f64, f64>::new(k, base_fft).unwrap();
         check_fft_algorithm::<f64>(&fft, len, direction);
@@ -224,8 +224,8 @@ mod unit_tests {
         }
     }
 
-    fn test_sse_radix4_32_with_base(k: usize, base_fft: Arc<dyn Fft<f32>>) {
-        let len = base_fft.len() * 4usize.pow(k as u32);
+    fn test_sse_radix4_32_with_base(k: u32, base_fft: Arc<dyn Fft<f32>>) {
+        let len = base_fft.len() * 4usize.pow(k);
         let direction = base_fft.fft_direction();
         let fft = SseRadix4::<f32, f32>::new(k, base_fft).unwrap();
         check_fft_algorithm::<f32>(&fft, len, direction);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,9 +1,15 @@
+use std::sync::Arc;
+
 use num_complex::Complex;
 use num_traits::{Float, One, Zero};
 
 use rand::distributions::{uniform::SampleUniform, Distribution, Uniform};
 use rand::{rngs::StdRng, SeedableRng};
 
+use crate::algorithm::butterflies::{
+    Butterfly1, Butterfly16, Butterfly2, Butterfly3, Butterfly4, Butterfly5, Butterfly6,
+    Butterfly7, Butterfly8, Butterfly9,
+};
 use crate::{algorithm::Dft, Direction, FftNum, Length};
 use crate::{Fft, FftDirection};
 
@@ -90,9 +96,6 @@ pub fn check_fft_algorithm<T: FftNum + Float + SampleUniform>(
         fft.process(&mut buffer);
 
         if !compare_vectors(&expected_output, &buffer) {
-            dbg!(&expected_output);
-            dbg!(&buffer);
-
             panic!(
                 "process() failed, length = {}, direction = {}",
                 len, direction
@@ -208,5 +211,21 @@ impl Length for BigScratchAlgorithm {
 impl Direction for BigScratchAlgorithm {
     fn fft_direction(&self) -> FftDirection {
         self.direction
+    }
+}
+
+pub fn construct_base<T: FftNum>(n: usize, direction: FftDirection) -> Arc<dyn Fft<T>> {
+    match n {
+        1 => Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>,
+        2 => Arc::new(Butterfly2::new(direction)) as Arc<dyn Fft<T>>,
+        3 => Arc::new(Butterfly3::new(direction)) as Arc<dyn Fft<T>>,
+        4 => Arc::new(Butterfly4::new(direction)) as Arc<dyn Fft<T>>,
+        5 => Arc::new(Butterfly5::new(direction)) as Arc<dyn Fft<T>>,
+        6 => Arc::new(Butterfly6::new(direction)) as Arc<dyn Fft<T>>,
+        7 => Arc::new(Butterfly7::new(direction)) as Arc<dyn Fft<T>>,
+        8 => Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>,
+        9 => Arc::new(Butterfly9::new(direction)) as Arc<dyn Fft<T>>,
+        16 => Arc::new(Butterfly16::new(direction)) as Arc<dyn Fft<T>>,
+        _ => unimplemented!(),
     }
 }

--- a/src/wasm_simd/mod.rs
+++ b/src/wasm_simd/mod.rs
@@ -12,6 +12,32 @@ mod wasm_simd_utils;
 
 pub mod wasm_simd_planner;
 
+use crate::FftNum;
+use core::arch::wasm32::v128;
+
 pub use self::wasm_simd_butterflies::*;
 pub use self::wasm_simd_prime_butterflies::*;
 pub use self::wasm_simd_radix4::*;
+use self::wasm_simd_vector::WasmVector;
+use self::wasm_simd_vector::WasmVector32;
+use self::wasm_simd_vector::WasmVector64;
+
+pub trait WasmNum: FftNum {
+    type VectorType: WasmVector<ScalarType = Self>;
+    fn wrap(input: v128) -> Self::VectorType;
+}
+
+impl WasmNum for f32 {
+    type VectorType = WasmVector32;
+
+    fn wrap(input: v128) -> Self::VectorType {
+        WasmVector32(input)
+    }
+}
+impl WasmNum for f64 {
+    type VectorType = WasmVector64;
+
+    fn wrap(input: v128) -> Self::VectorType {
+        WasmVector64(input)
+    }
+}

--- a/src/wasm_simd/wasm_simd_butterflies.rs
+++ b/src/wasm_simd/wasm_simd_butterflies.rs
@@ -216,8 +216,8 @@ impl<T: FftNum> WasmSimdF32Butterfly1<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f32>) {
-        let value = buffer.load_partial1_complex(0);
-        buffer.store_partial_lo_complex(value, 0);
+        let value = buffer.load_partial_lo_complex_v128(0);
+        buffer.store_partial_lo_complex_v128(value, 0);
     }
 
     #[inline(always)]
@@ -225,8 +225,8 @@ impl<T: FftNum> WasmSimdF32Butterfly1<T> {
         &self,
         mut buffer: impl WasmSimdArrayMut<f32>,
     ) {
-        let value = buffer.load_complex(0);
-        buffer.store_complex(value, 0);
+        let value = buffer.load_complex_v128(0);
+        buffer.store_complex_v128(value, 0);
     }
 }
 
@@ -263,8 +263,8 @@ impl<T: FftNum> WasmSimdF64Butterfly1<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f64>) {
-        let value = buffer.load_complex(0);
-        buffer.store_complex(value, 0);
+        let value = buffer.load_complex_v128(0);
+        buffer.store_complex_v128(value, 0);
     }
 }
 
@@ -301,11 +301,11 @@ impl<T: FftNum> WasmSimdF32Butterfly2<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f32>) {
-        let values = buffer.load_complex(0);
+        let values = buffer.load_complex_v128(0);
 
         let temp = self.perform_fft_direct(values);
 
-        buffer.store_complex(temp, 0);
+        buffer.store_complex_v128(temp, 0);
     }
 
     #[inline(always)]
@@ -313,15 +313,15 @@ impl<T: FftNum> WasmSimdF32Butterfly2<T> {
         &self,
         mut buffer: impl WasmSimdArrayMut<f32>,
     ) {
-        let values_a = buffer.load_complex(0);
-        let values_b = buffer.load_complex(2);
+        let values_a = buffer.load_complex_v128(0);
+        let values_b = buffer.load_complex_v128(2);
 
         let out = self.perform_parallel_fft_direct(values_a, values_b);
 
         let [out02, out13] = transpose_complex_2x2_f32(out[0], out[1]);
 
-        buffer.store_complex(out02, 0);
-        buffer.store_complex(out13, 2);
+        buffer.store_complex_v128(out02, 0);
+        buffer.store_complex_v128(out13, 2);
     }
 
     // length 2 fft of x, given as [x0, x1]
@@ -404,13 +404,13 @@ impl<T: FftNum> WasmSimdF64Butterfly2<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f64>) {
-        let value0 = buffer.load_complex(0);
-        let value1 = buffer.load_complex(1);
+        let value0 = buffer.load_complex_v128(0);
+        let value1 = buffer.load_complex_v128(1);
 
         let out = self.perform_fft_direct(value0, value1);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
     }
 
     #[inline(always)]
@@ -472,13 +472,13 @@ impl<T: FftNum> WasmSimdF32Butterfly3<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f32>) {
-        let value0x = buffer.load_partial1_complex(0);
-        let value12 = buffer.load_complex(1);
+        let value0x = buffer.load_partial_lo_complex_v128(0);
+        let value12 = buffer.load_complex_v128(1);
 
         let out = self.perform_fft_direct(value0x, value12);
 
-        buffer.store_partial_lo_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
+        buffer.store_partial_lo_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
     }
 
     #[inline(always)]
@@ -486,9 +486,9 @@ impl<T: FftNum> WasmSimdF32Butterfly3<T> {
         &self,
         mut buffer: impl WasmSimdArrayMut<f32>,
     ) {
-        let valuea0a1 = buffer.load_complex(0);
-        let valuea2b0 = buffer.load_complex(2);
-        let valueb1b2 = buffer.load_complex(4);
+        let valuea0a1 = buffer.load_complex_v128(0);
+        let valuea2b0 = buffer.load_complex_v128(2);
+        let valueb1b2 = buffer.load_complex_v128(4);
 
         let value0 = extract_lo_hi_f32(valuea0a1, valuea2b0);
         let value1 = extract_hi_lo_f32(valuea0a1, valueb1b2);
@@ -500,9 +500,9 @@ impl<T: FftNum> WasmSimdF32Butterfly3<T> {
         let out1 = extract_lo_hi_f32(out[2], out[0]);
         let out2 = extract_hi_hi_f32(out[1], out[2]);
 
-        buffer.store_complex(out0, 0);
-        buffer.store_complex(out1, 2);
-        buffer.store_complex(out2, 4);
+        buffer.store_complex_v128(out0, 0);
+        buffer.store_complex_v128(out1, 2);
+        buffer.store_complex_v128(out2, 4);
     }
 
     // length 3 fft of a, given as [x0, 0.0], [x1, x2]
@@ -592,15 +592,15 @@ impl<T: FftNum> WasmSimdF64Butterfly3<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f64>) {
-        let value0 = buffer.load_complex(0);
-        let value1 = buffer.load_complex(1);
-        let value2 = buffer.load_complex(2);
+        let value0 = buffer.load_complex_v128(0);
+        let value1 = buffer.load_complex_v128(1);
+        let value2 = buffer.load_complex_v128(2);
 
         let out = self.perform_fft_direct(value0, value1, value2);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
-        buffer.store_complex(out[2], 2);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
+        buffer.store_complex_v128(out[2], 2);
     }
 
     // length 3 fft of x, given as x0, x1, x2.
@@ -669,13 +669,13 @@ impl<T: FftNum> WasmSimdF32Butterfly4<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f32>) {
-        let value01 = buffer.load_complex(0);
-        let value23 = buffer.load_complex(2);
+        let value01 = buffer.load_complex_v128(0);
+        let value23 = buffer.load_complex_v128(2);
 
         let out = self.perform_fft_direct(value01, value23);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 2);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 2);
     }
 
     #[inline(always)]
@@ -683,10 +683,10 @@ impl<T: FftNum> WasmSimdF32Butterfly4<T> {
         &self,
         mut buffer: impl WasmSimdArrayMut<f32>,
     ) {
-        let value01a = buffer.load_complex(0);
-        let value23a = buffer.load_complex(2);
-        let value01b = buffer.load_complex(4);
-        let value23b = buffer.load_complex(6);
+        let value01a = buffer.load_complex_v128(0);
+        let value23a = buffer.load_complex_v128(2);
+        let value01b = buffer.load_complex_v128(4);
+        let value23b = buffer.load_complex_v128(6);
 
         let [value0ab, value1ab] = transpose_complex_2x2_f32(value01a, value01b);
         let [value2ab, value3ab] = transpose_complex_2x2_f32(value23a, value23b);
@@ -696,10 +696,10 @@ impl<T: FftNum> WasmSimdF32Butterfly4<T> {
         let [out0, out1] = transpose_complex_2x2_f32(out[0], out[1]);
         let [out2, out3] = transpose_complex_2x2_f32(out[2], out[3]);
 
-        buffer.store_complex(out0, 0);
-        buffer.store_complex(out1, 4);
-        buffer.store_complex(out2, 2);
-        buffer.store_complex(out3, 6);
+        buffer.store_complex_v128(out0, 0);
+        buffer.store_complex_v128(out1, 4);
+        buffer.store_complex_v128(out2, 2);
+        buffer.store_complex_v128(out3, 6);
     }
 
     // length 4 fft of a, given as [x0, x1], [x2, x3]
@@ -798,17 +798,17 @@ impl<T: FftNum> WasmSimdF64Butterfly4<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f64>) {
-        let value0 = buffer.load_complex(0);
-        let value1 = buffer.load_complex(1);
-        let value2 = buffer.load_complex(2);
-        let value3 = buffer.load_complex(3);
+        let value0 = buffer.load_complex_v128(0);
+        let value1 = buffer.load_complex_v128(1);
+        let value2 = buffer.load_complex_v128(2);
+        let value3 = buffer.load_complex_v128(3);
 
         let out = self.perform_fft_direct(value0, value1, value2, value3);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
-        buffer.store_complex(out[2], 2);
-        buffer.store_complex(out[3], 3);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
+        buffer.store_complex_v128(out[2], 2);
+        buffer.store_complex_v128(out[3], 3);
     }
 
     #[inline(always)]
@@ -905,15 +905,15 @@ impl<T: FftNum> WasmSimdF32Butterfly5<T> {
     }
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f32>) {
-        let value00 = buffer.load1_complex(0);
-        let value12 = buffer.load_complex(1);
-        let value34 = buffer.load_complex(3);
+        let value00 = buffer.load1_complex_v128(0);
+        let value12 = buffer.load_complex_v128(1);
+        let value34 = buffer.load_complex_v128(3);
 
         let out = self.perform_fft_direct(value00, value12, value34);
 
-        buffer.store_partial_lo_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
-        buffer.store_complex(out[2], 3);
+        buffer.store_partial_lo_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
+        buffer.store_complex_v128(out[2], 3);
     }
 
     #[inline(always)]
@@ -1071,19 +1071,19 @@ impl<T: FftNum> WasmSimdF64Butterfly5<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f64>) {
-        let value0 = buffer.load_complex(0);
-        let value1 = buffer.load_complex(1);
-        let value2 = buffer.load_complex(2);
-        let value3 = buffer.load_complex(3);
-        let value4 = buffer.load_complex(4);
+        let value0 = buffer.load_complex_v128(0);
+        let value1 = buffer.load_complex_v128(1);
+        let value2 = buffer.load_complex_v128(2);
+        let value3 = buffer.load_complex_v128(3);
+        let value4 = buffer.load_complex_v128(4);
 
         let out = self.perform_fft_direct(value0, value1, value2, value3, value4);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
-        buffer.store_complex(out[2], 2);
-        buffer.store_complex(out[3], 3);
-        buffer.store_complex(out[4], 4);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
+        buffer.store_complex_v128(out[2], 2);
+        buffer.store_complex_v128(out[3], 3);
+        buffer.store_complex_v128(out[4], 4);
     }
 
     // length 5 fft of x, given as x0, x1, x2, x3, x4.
@@ -1169,15 +1169,15 @@ impl<T: FftNum> WasmSimdF32Butterfly6<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f32>) {
-        let value01 = buffer.load_complex(0);
-        let value23 = buffer.load_complex(2);
-        let value45 = buffer.load_complex(4);
+        let value01 = buffer.load_complex_v128(0);
+        let value23 = buffer.load_complex_v128(2);
+        let value45 = buffer.load_complex_v128(4);
 
         let out = self.perform_fft_direct(value01, value23, value45);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 2);
-        buffer.store_complex(out[2], 4);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 2);
+        buffer.store_complex_v128(out[2], 4);
     }
 
     #[inline(always)]
@@ -1293,21 +1293,21 @@ impl<T: FftNum> WasmSimdF64Butterfly6<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl WasmSimdArrayMut<f64>) {
-        let value0 = buffer.load_complex(0);
-        let value1 = buffer.load_complex(1);
-        let value2 = buffer.load_complex(2);
-        let value3 = buffer.load_complex(3);
-        let value4 = buffer.load_complex(4);
-        let value5 = buffer.load_complex(5);
+        let value0 = buffer.load_complex_v128(0);
+        let value1 = buffer.load_complex_v128(1);
+        let value2 = buffer.load_complex_v128(2);
+        let value3 = buffer.load_complex_v128(3);
+        let value4 = buffer.load_complex_v128(4);
+        let value5 = buffer.load_complex_v128(5);
 
         let out = self.perform_fft_direct(value0, value1, value2, value3, value4, value5);
 
-        buffer.store_complex(out[0], 0);
-        buffer.store_complex(out[1], 1);
-        buffer.store_complex(out[2], 2);
-        buffer.store_complex(out[3], 3);
-        buffer.store_complex(out[4], 4);
-        buffer.store_complex(out[5], 5);
+        buffer.store_complex_v128(out[0], 0);
+        buffer.store_complex_v128(out[1], 1);
+        buffer.store_complex_v128(out[2], 2);
+        buffer.store_complex_v128(out[3], 3);
+        buffer.store_complex_v128(out[4], 4);
+        buffer.store_complex_v128(out[5], 5);
     }
 
     #[inline(always)]
@@ -1622,7 +1622,7 @@ impl<T: FftNum> WasmSimdF32Butterfly9<T> {
         let out = self.perform_parallel_fft_direct(values);
 
         for n in 0..9 {
-            buffer.store_partial_lo_complex(out[n], n);
+            buffer.store_partial_lo_complex_v128(out[n], n);
         }
     }
 
@@ -2241,7 +2241,7 @@ impl<T: FftNum> WasmSimdF32Butterfly15<T> {
         let out = self.perform_parallel_fft_direct(values);
 
         for n in 0..15 {
-            buffer.store_partial_lo_complex(out[n], n);
+            buffer.store_partial_lo_complex_v128(out[n], n);
         }
     }
 

--- a/src/wasm_simd/wasm_simd_common.rs
+++ b/src/wasm_simd/wasm_simd_common.rs
@@ -98,7 +98,7 @@ macro_rules! separate_interleaved_complex_f32 {
 
 macro_rules! boilerplate_fft_wasm_simd_oop {
     ($struct_name:ident, $len_fn:expr) => {
-        impl<T: FftNum> Fft<T> for $struct_name<T> {
+        impl<S: WasmNum, T: FftNum> Fft<T> for $struct_name<S, T> {
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -176,13 +176,13 @@ macro_rules! boilerplate_fft_wasm_simd_oop {
                 0
             }
         }
-        impl<T> Length for $struct_name<T> {
+        impl<S: WasmNum, T> Length for $struct_name<S, T> {
             #[inline(always)]
             fn len(&self) -> usize {
                 $len_fn(self)
             }
         }
-        impl<T> Direction for $struct_name<T> {
+        impl<S: WasmNum, T> Direction for $struct_name<S, T> {
             #[inline(always)]
             fn fft_direction(&self) -> FftDirection {
                 self.direction

--- a/src/wasm_simd/wasm_simd_planner.rs
+++ b/src/wasm_simd/wasm_simd_planner.rs
@@ -12,6 +12,7 @@ use std::{any::TypeId, collections::HashMap, sync::Arc};
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
 const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
+const RADIX4_USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
 /// It is used as a middle step in the planning process.
@@ -42,7 +43,10 @@ pub enum Recipe {
         len: usize,
         inner_fft: Arc<Recipe>,
     },
-    Radix4(usize),
+    Radix4 {
+        k: usize,
+        base_fft: Arc<Recipe>,
+    },
     Butterfly1,
     Butterfly2,
     Butterfly3,
@@ -70,7 +74,7 @@ impl Recipe {
     pub fn len(&self) -> usize {
         match self {
             Recipe::Dft(length) => *length,
-            Recipe::Radix4(length) => *length,
+            Recipe::Radix4 { k, base_fft } => base_fft.len() * (1 << (k * 2)),
             Recipe::Butterfly1 => 1,
             Recipe::Butterfly2 => 2,
             Recipe::Butterfly3 => 3,
@@ -222,11 +226,12 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
 
         match recipe {
             Recipe::Dft(len) => Arc::new(Dft::new(*len, direction)) as Arc<dyn Fft<T>>,
-            Recipe::Radix4(len) => {
+            Recipe::Radix4 { k, base_fft } => {
+                let base_fft = self.build_fft(&base_fft, direction);
                 if id_t == id_f32 {
-                    Arc::new(WasmSimd32Radix4::new(*len, direction)) as Arc<dyn Fft<T>>
+                    Arc::new(WasmSimdRadix4::<f32, T>::new(*k, base_fft)) as Arc<dyn Fft<T>>
                 } else if id_t == id_f64 {
-                    Arc::new(WasmSimd64Radix4::new(*len, direction)) as Arc<dyn Fft<T>>
+                    Arc::new(WasmSimdRadix4::<f64, T>::new(*k, base_fft)) as Arc<dyn Fft<T>>
                 } else {
                     panic!("Not f32 or f64");
                 }
@@ -470,7 +475,7 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
             self.design_prime(len)
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
             if len.is_power_of_two() {
-                Arc::new(Recipe::Radix4(len))
+                self.design_radix4(len)
             } else {
                 let non_power_of_two = factors
                     .remove_factors(PrimeFactor {
@@ -593,13 +598,40 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
                     let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
                     self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
                 } else {
-                    Arc::new(Recipe::Radix4(inner_fft_len_pow2))
+                    self.design_radix4(inner_fft_len_pow2)
                 };
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {
             let inner_fft = self.design_fft_with_factors(inner_fft_len_rader, raders_factors);
             Arc::new(Recipe::RadersAlgorithm { inner_fft })
         }
+    }
+
+    fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
+        // plan a step of radix4
+        let exponent = len.trailing_zeros() as usize;
+        let base_exponent = match exponent {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            _ => {
+                if exponent % 2 == 1 {
+                    if len < RADIX4_USE_BUTTERFLY32_FROM {
+                        3
+                    } else {
+                        5
+                    }
+                } else {
+                    4
+                }
+            }
+        };
+
+        let base_fft = self.design_fft_for_len(1 << base_exponent);
+        Arc::new(Recipe::Radix4 {
+            k: (exponent - base_exponent) / 2,
+            base_fft,
+        })
     }
 }
 
@@ -661,7 +693,7 @@ mod unit_tests {
         for pow in 6..32 {
             let len = 1 << pow;
             let plan = planner.design_fft_for_len(len);
-            assert_eq!(*plan, Recipe::Radix4(len));
+            assert!(matches!(*plan, Recipe::Radix4 { k: _, base_fft: _ }));
             assert_eq!(plan.len(), len, "Recipe reports wrong length");
         }
     }

--- a/src/wasm_simd/wasm_simd_planner.rs
+++ b/src/wasm_simd/wasm_simd_planner.rs
@@ -44,7 +44,7 @@ pub enum Recipe {
         inner_fft: Arc<Recipe>,
     },
     Radix4 {
-        k: usize,
+        k: u32,
         base_fft: Arc<Recipe>,
     },
     Butterfly1,
@@ -609,7 +609,7 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
 
     fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
         // plan a step of radix4
-        let exponent = len.trailing_zeros() as usize;
+        let exponent = len.trailing_zeros();
         let base_exponent = match exponent {
             0 => 0,
             1 => 1,

--- a/src/wasm_simd/wasm_simd_radix4.rs
+++ b/src/wasm_simd/wasm_simd_radix4.rs
@@ -28,7 +28,7 @@ pub struct WasmSimdRadix4<S: WasmNum, T> {
 
 impl<S: WasmNum, T: FftNum> WasmSimdRadix4<S, T> {
     /// Constructs a new WasmSimdRadix4 which computes FFTs of size 4^k * base_fft.len()
-    pub fn new(k: usize, base_fft: Arc<dyn Fft<T>>) -> Self {
+    pub fn new(k: u32, base_fft: Arc<dyn Fft<T>>) -> Self {
         // Internal sanity check: Make sure that S == T.
         // This struct has two generic parameters S and T, but they must always be the same, and are only kept separate to help work around the lack of specialization.
         // It would be cool if we could do this as a static_assert instead
@@ -195,8 +195,8 @@ mod unit_tests {
         }
     }
 
-    fn test_wasm_simd_radix4_64_with_base(k: usize, base_fft: Arc<dyn Fft<f64>>) {
-        let len = base_fft.len() * 4usize.pow(k as u32);
+    fn test_wasm_simd_radix4_64_with_base(k: u32, base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * 4usize.pow(k);
         let direction = base_fft.fft_direction();
         let fft = WasmSimdRadix4::<f64, f64>::new(k, base_fft);
         check_fft_algorithm::<f64>(&fft, len, direction);
@@ -214,8 +214,8 @@ mod unit_tests {
         }
     }
 
-    fn test_wasm_simd_radix4_32_with_base(k: usize, base_fft: Arc<dyn Fft<f32>>) {
-        let len = base_fft.len() * 4usize.pow(k as u32);
+    fn test_wasm_simd_radix4_32_with_base(k: u32, base_fft: Arc<dyn Fft<f32>>) {
+        let len = base_fft.len() * 4usize.pow(k);
         let direction = base_fft.fft_direction();
         let fft = WasmSimdRadix4::<f32, f32>::new(k, base_fft);
         check_fft_algorithm::<f32>(&fft, len, direction);


### PR DESCRIPTION
This PR de-monomorphizes the code for the SSE, NEON, and Wasm Simd Radix4 implementations, replacing them with a single generic implementation. It follows a similar technique to the AVX generic algorithms, where we define a "SseVector", "NeonVector", etc trait that has generic methods for loading/storing, and only call those methods from the radix4 implementation.

The SseVector, NeonVector etc traits are much simpler than their AVX counterparts, both because we don't have half vs full vectors to worry about, and because I only included the absolute minimum in the trait to get radix4 to work.

One interesting thing to note is that because the radix4 structs can't refer to f32 vs f64 in their constructors, I had to move the construction of butterflies out of the structs and into the planners. The Radix4 structs now take a base FFT and a parameter `k`, and compute their length to be `base_fft.len() * 4^k`. This refactor actually feels very natural, and I wish we had done it before now.

Another thing I noticed: The base FFT length for radix4 does not need to be a power of 2. The radix4 struct is one of the oldest in the project, and I've been taking a "if it works don't fix it" approach for very long, and therefore haven't been questioning some of its very outdated design decisions. This opens up some cool optimization opportunities - like, I noticed that the planner has loogic for checking the size when planning bluestein's, and if the size is over a certain threhold it tries to switch to a mixed radix with a factor of 3. Instead, we could introduce a factor of 3 by continuing to use Radix4, but switching from a base FFT of 16 to a base FFT of 12, or from 32 to 24, and we could be certain that this would be pretty much unconditionally faster. There's a lot more we can do, and I intend to explore this in the next few days.

One final thing I noticed: The SseVector, NeonVector, etc traits are completely identical. We could probably get some benefit out of factoring those out into a target-agnostic simd utils file. If any SIMD path needs functionality not provided by the target-agnostic trait, they can just declare their own child trait with the functionality they need.