### PR TITLE
Relax Radix4's restriction that the base FFT must be a power of 2

### DIFF
--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -274,6 +274,33 @@ impl<T: FftNum> Butterfly4<T> {
         buffer.store(value1, 2);
         buffer.store(value3, 3);
     }
+
+    #[inline(always)]
+    unsafe fn perform_fft_strided(
+        &self,
+        value0: &mut Complex<T>,
+        value1: &mut Complex<T>,
+        value2: &mut Complex<T>,
+        value3: &mut Complex<T>,
+    ) {
+        // step 2: column FFTs
+        Butterfly2::perform_fft_strided(value0, value2);
+        Butterfly2::perform_fft_strided(value1, value3);
+
+        // step 3: apply twiddle factors (only one in this case, and it's either 0 + i or 0 - i)
+        *value3 = twiddles::rotate_90(*value3, self.direction);
+
+        // step 4: transpose, which we're skipping because we're the previous FFTs were non-contiguous
+
+        // step 5: row FFTs
+        Butterfly2::perform_fft_strided(value0, value1);
+        Butterfly2::perform_fft_strided(value2, value3);
+
+        // step 6: transpose
+        let temp = *value1;
+        *value1 = *value2;
+        *value2 = temp;
+    }
 }
 
 pub struct Butterfly5<T> {
@@ -1041,6 +1068,83 @@ impl<T: FftNum> Butterfly11<T> {
             },
             10,
         );
+    }
+}
+
+pub struct Butterfly12<T> {
+    butterfly3: Butterfly3<T>,
+    butterfly4: Butterfly4<T>,
+}
+boilerplate_fft_butterfly!(Butterfly12, 12, |this: &Butterfly12<_>| this
+    .butterfly3
+    .fft_direction());
+impl<T: FftNum> Butterfly12<T> {
+    #[inline(always)]
+    pub fn new(direction: FftDirection) -> Self {
+        Self {
+            butterfly3: Butterfly3::new(direction),
+            butterfly4: Butterfly4::new(direction),
+        }
+    }
+    #[inline(always)]
+    unsafe fn perform_fft_contiguous(&self, mut buffer: impl LoadStore<T>) {
+        //since GCD(4,3) == 1 we're going to hardcode a step of the Good-Thomas algorithm to avoid twiddle factors
+
+        // step 1: reorder the input directly into the scratch. normally there's a whole thing to compute this ordering
+        //but thankfully we can just precompute it and hardcode it
+        let mut scratch0 = [
+            buffer.load(0),
+            buffer.load(3),
+            buffer.load(6),
+            buffer.load(9),
+        ];
+        let mut scratch1 = [
+            buffer.load(4),
+            buffer.load(7),
+            buffer.load(10),
+            buffer.load(1),
+        ];
+        let mut scratch2 = [
+            buffer.load(8),
+            buffer.load(11),
+            buffer.load(2),
+            buffer.load(5),
+        ];
+
+        // step 2: column FFTs
+        self.butterfly4.perform_fft_contiguous(&mut scratch0);
+        self.butterfly4.perform_fft_contiguous(&mut scratch1);
+        self.butterfly4.perform_fft_contiguous(&mut scratch2);
+
+        // step 3: apply twiddle factors -- SKIPPED because good-thomas doesn't have twiddle factors :)
+
+        // step 4: SKIPPED because the next FFTs will be non-contiguous
+
+        // step 5: row FFTs
+        self.butterfly3
+            .perform_fft_strided(&mut scratch0[0], &mut scratch1[0], &mut scratch2[0]);
+        self.butterfly3
+            .perform_fft_strided(&mut scratch0[1], &mut scratch1[1], &mut scratch2[1]);
+        self.butterfly3
+            .perform_fft_strided(&mut scratch0[2], &mut scratch1[2], &mut scratch2[2]);
+        self.butterfly3
+            .perform_fft_strided(&mut scratch0[3], &mut scratch1[3], &mut scratch2[3]);
+
+        // step 6: reorder the result back into the buffer. again we would normally have to do an expensive computation
+        // but instead we can precompute and hardcode the ordering
+        // note that we're also rolling a transpose step into this reorder
+        buffer.store(scratch0[0], 0);
+        buffer.store(scratch1[1], 1);
+        buffer.store(scratch2[2], 2);
+        buffer.store(scratch0[3], 3);
+        buffer.store(scratch1[0], 4);
+        buffer.store(scratch2[1], 5);
+        buffer.store(scratch0[2], 6);
+        buffer.store(scratch1[3], 7);
+        buffer.store(scratch2[0], 8);
+        buffer.store(scratch0[1], 9);
+        buffer.store(scratch1[2], 10);
+        buffer.store(scratch2[3], 11);
     }
 }
 
@@ -3300,6 +3404,168 @@ impl<T: FftNum> Butterfly23<T> {
             },
             22,
         );
+    }
+}
+
+pub struct Butterfly24<T> {
+    butterfly4: Butterfly4<T>,
+    butterfly6: Butterfly6<T>,
+    twiddle1: Complex<T>,
+    twiddle2: Complex<T>,
+    twiddle4: Complex<T>,
+    twiddle5: Complex<T>,
+    twiddle8: Complex<T>,
+    twiddle10: Complex<T>,
+    root2: T,
+}
+boilerplate_fft_butterfly!(Butterfly24, 24, |this: &Butterfly24<_>| this
+    .butterfly4
+    .fft_direction());
+impl<T: FftNum> Butterfly24<T> {
+    #[inline(always)]
+    pub fn new(direction: FftDirection) -> Self {
+        Self {
+            butterfly4: Butterfly4::new(direction),
+            butterfly6: Butterfly6::new(direction),
+            twiddle1: twiddles::compute_twiddle(1, 24, direction),
+            twiddle2: twiddles::compute_twiddle(2, 24, direction),
+            twiddle4: twiddles::compute_twiddle(4, 24, direction),
+            twiddle5: twiddles::compute_twiddle(5, 24, direction),
+            twiddle8: twiddles::compute_twiddle(8, 24, direction),
+            twiddle10: twiddles::compute_twiddle(10, 24, direction),
+            root2: T::from_f64(0.5f64.sqrt()).unwrap(),
+        }
+    }
+    #[inline(never)]
+    unsafe fn perform_fft_contiguous(&self, mut buffer: impl LoadStore<T>) {
+        // step 1: reorder the input directly into the scratch. normally there's a whole thing to compute this ordering
+        //but thankfully we can just precompute it and hardcode it
+        let mut scratch0 = [
+            buffer.load(0),
+            buffer.load(4),
+            buffer.load(8),
+            buffer.load(12),
+            buffer.load(16),
+            buffer.load(20),
+        ];
+        let mut scratch1 = [
+            buffer.load(1),
+            buffer.load(5),
+            buffer.load(9),
+            buffer.load(13),
+            buffer.load(17),
+            buffer.load(21),
+        ];
+        let mut scratch2 = [
+            buffer.load(2),
+            buffer.load(6),
+            buffer.load(10),
+            buffer.load(14),
+            buffer.load(18),
+            buffer.load(22),
+        ];
+        let mut scratch3 = [
+            buffer.load(3),
+            buffer.load(7),
+            buffer.load(11),
+            buffer.load(15),
+            buffer.load(19),
+            buffer.load(23),
+        ];
+
+        // step 2: column FFTs
+        self.butterfly6.perform_fft_contiguous(&mut scratch0);
+        self.butterfly6.perform_fft_contiguous(&mut scratch1);
+        self.butterfly6.perform_fft_contiguous(&mut scratch2);
+        self.butterfly6.perform_fft_contiguous(&mut scratch3);
+
+        // step 3: apply twiddle factors
+        scratch1[1] = scratch1[1] * self.twiddle1;
+        scratch1[2] = scratch1[2] * self.twiddle2;
+        scratch1[3] =
+            (twiddles::rotate_90(scratch1[3], self.fft_direction()) + scratch1[3]) * self.root2;
+        scratch1[4] = scratch1[4] * self.twiddle4;
+        scratch1[5] = scratch1[5] * self.twiddle5;
+        scratch2[1] = scratch2[1] * self.twiddle2;
+        scratch2[2] = scratch2[2] * self.twiddle4;
+        scratch2[3] = twiddles::rotate_90(scratch2[3], self.fft_direction());
+        scratch2[4] = scratch2[4] * self.twiddle8;
+        scratch2[5] = scratch2[5] * self.twiddle10;
+        scratch3[1] =
+            (twiddles::rotate_90(scratch3[1], self.fft_direction()) + scratch3[1]) * self.root2;
+        scratch3[2] = twiddles::rotate_90(scratch3[2], self.fft_direction());
+        scratch3[3] =
+            (twiddles::rotate_90(scratch3[3], self.fft_direction()) - scratch3[3]) * self.root2;
+        scratch3[4] = -scratch3[4];
+        scratch3[5] =
+            (twiddles::rotate_90(scratch3[5], self.fft_direction()) + scratch3[5]) * -self.root2;
+        // step 4: SKIPPED because the next FFTs will be non-contiguous
+
+        // step 5: row FFTs
+        self.butterfly4.perform_fft_strided(
+            &mut scratch0[0],
+            &mut scratch1[0],
+            &mut scratch2[0],
+            &mut scratch3[0],
+        );
+        self.butterfly4.perform_fft_strided(
+            &mut scratch0[1],
+            &mut scratch1[1],
+            &mut scratch2[1],
+            &mut scratch3[1],
+        );
+        self.butterfly4.perform_fft_strided(
+            &mut scratch0[2],
+            &mut scratch1[2],
+            &mut scratch2[2],
+            &mut scratch3[2],
+        );
+        self.butterfly4.perform_fft_strided(
+            &mut scratch0[3],
+            &mut scratch1[3],
+            &mut scratch2[3],
+            &mut scratch3[3],
+        );
+        self.butterfly4.perform_fft_strided(
+            &mut scratch0[4],
+            &mut scratch1[4],
+            &mut scratch2[4],
+            &mut scratch3[4],
+        );
+        self.butterfly4.perform_fft_strided(
+            &mut scratch0[5],
+            &mut scratch1[5],
+            &mut scratch2[5],
+            &mut scratch3[5],
+        );
+
+        // step 6: reorder the result back into the buffer. again we would normally have to do an expensive computation
+        // but instead we can precompute and hardcode the ordering
+        // note that we're also rolling a transpose step into this reorder
+        buffer.store(scratch0[0], 0);
+        buffer.store(scratch0[1], 1);
+        buffer.store(scratch0[2], 2);
+        buffer.store(scratch0[3], 3);
+        buffer.store(scratch0[4], 4);
+        buffer.store(scratch0[5], 5);
+        buffer.store(scratch1[0], 6);
+        buffer.store(scratch1[1], 7);
+        buffer.store(scratch1[2], 8);
+        buffer.store(scratch1[3], 9);
+        buffer.store(scratch1[4], 10);
+        buffer.store(scratch1[5], 11);
+        buffer.store(scratch2[0], 12);
+        buffer.store(scratch2[1], 13);
+        buffer.store(scratch2[2], 14);
+        buffer.store(scratch2[3], 15);
+        buffer.store(scratch2[4], 16);
+        buffer.store(scratch2[5], 17);
+        buffer.store(scratch3[0], 18);
+        buffer.store(scratch3[1], 19);
+        buffer.store(scratch3[2], 20);
+        buffer.store(scratch3[3], 21);
+        buffer.store(scratch3[4], 22);
+        buffer.store(scratch3[5], 23);
     }
 }
 
@@ -6138,11 +6404,13 @@ mod unit_tests {
     test_butterfly_func!(test_butterfly8, Butterfly8, 8);
     test_butterfly_func!(test_butterfly9, Butterfly9, 9);
     test_butterfly_func!(test_butterfly11, Butterfly11, 11);
+    test_butterfly_func!(test_butterfly12, Butterfly12, 12);
     test_butterfly_func!(test_butterfly13, Butterfly13, 13);
     test_butterfly_func!(test_butterfly16, Butterfly16, 16);
     test_butterfly_func!(test_butterfly17, Butterfly17, 17);
     test_butterfly_func!(test_butterfly19, Butterfly19, 19);
     test_butterfly_func!(test_butterfly23, Butterfly23, 23);
+    test_butterfly_func!(test_butterfly24, Butterfly24, 24);
     test_butterfly_func!(test_butterfly27, Butterfly27, 27);
     test_butterfly_func!(test_butterfly29, Butterfly29, 29);
     test_butterfly_func!(test_butterfly31, Butterfly31, 31);

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -3499,7 +3499,7 @@ impl<T: FftNum> Butterfly24<T> {
         scratch3[4] = -scratch3[4];
         scratch3[5] =
             (twiddles::rotate_90(scratch3[5], self.fft_direction()) + scratch3[5]) * -self.root2;
-            
+
         // step 4: SKIPPED because the next FFTs will be non-contiguous
 
         // step 5: row FFTs

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::Zero;
 
-use crate::algorithm::butterflies::{Butterfly1, Butterfly16, Butterfly2, Butterfly4, Butterfly8};
+use crate::algorithm::butterflies::{
+    Butterfly1, Butterfly16, Butterfly2, Butterfly32, Butterfly4, Butterfly8,
+};
 use crate::array_utils::{self, bitreversed_transpose};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles, FftDirection};
@@ -48,9 +50,10 @@ impl<T: FftNum> Radix4<T> {
             0 => (0, Arc::new(Butterfly1::new(direction)) as Arc<dyn Fft<T>>),
             1 => (1, Arc::new(Butterfly2::new(direction)) as Arc<dyn Fft<T>>),
             2 => (2, Arc::new(Butterfly4::new(direction)) as Arc<dyn Fft<T>>),
+            3 => (3, Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>),
             _ => {
                 if exponent % 2 == 1 {
-                    (3, Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>)
+                    (5, Arc::new(Butterfly32::new(direction)) as Arc<dyn Fft<T>>)
                 } else {
                     (4, Arc::new(Butterfly16::new(direction)) as Arc<dyn Fft<T>>)
                 }

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -14,6 +14,15 @@ use super::neon_common::{assert_f32, assert_f64};
 use super::neon_utils::*;
 use super::neon_vector::{NeonArrayMut, NeonVector};
 
+#[inline(always)]
+unsafe fn pack32(a: Complex<f32>, b: Complex<f32>) -> float32x4_t {
+    vld1q_f32([a.re, a.im, b.re, b.im].as_ptr())
+}
+#[inline(always)]
+unsafe fn pack64(a: Complex<f64>) -> float64x2_t {
+    vld1q_f64([a.re, a.im].as_ptr())
+}
+
 #[allow(unused)]
 macro_rules! boilerplate_fft_neon_f32_butterfly {
     ($struct_name:ident, $len:expr, $direction_fn:expr) => {
@@ -2656,6 +2665,414 @@ impl<T: FftNum> NeonF64Butterfly16<T> {
     }
 }
 
+//    ___ _  _             _________  _     _ _
+//   |__ \ || |           |___ /___ \| |__ (_) |_
+//    __) ||| |_   _____    |_ \ __) | '_ \| | __|
+//   / __/__   _| |_____|  ___) / __/| |_) | | |_
+//  |____}  |_|           |____/_____|_.__/|_|\__|
+//
+
+pub struct NeonF32Butterfly24<T> {
+    direction: FftDirection,
+    bf6: NeonF32Butterfly6<T>,
+    bf12: NeonF32Butterfly12<T>,
+    rotate90: Rotate90F32,
+    twiddle01: float32x4_t,
+    twiddle23: float32x4_t,
+    twiddle45: float32x4_t,
+    twiddle01conj: float32x4_t,
+    twiddle23conj: float32x4_t,
+    twiddle45conj: float32x4_t,
+    twiddle1: float32x4_t,
+    twiddle2: float32x4_t,
+    twiddle4: float32x4_t,
+    twiddle5: float32x4_t,
+    twiddle1c: float32x4_t,
+    twiddle2c: float32x4_t,
+    twiddle4c: float32x4_t,
+    twiddle5c: float32x4_t,
+}
+
+boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly24, 24, |this: &NeonF32Butterfly24<_>| {
+    this.direction
+});
+boilerplate_fft_neon_common_butterfly!(NeonF32Butterfly24, 24, |this: &NeonF32Butterfly24<_>| this
+    .direction);
+impl<T: FftNum> NeonF32Butterfly24<T> {
+    #[inline(always)]
+    pub fn new(direction: FftDirection) -> Self {
+        assert_f32::<T>();
+        let tw0 = Complex { re: 1.0, im: 0.0 };
+        let tw1 = twiddles::compute_twiddle(1, 24, direction);
+        let tw2 = twiddles::compute_twiddle(2, 24, direction);
+        let tw3 = twiddles::compute_twiddle(3, 24, direction);
+        let tw4 = twiddles::compute_twiddle(4, 24, direction);
+        let tw5 = twiddles::compute_twiddle(5, 24, direction);
+        unsafe {
+            Self {
+                direction,
+                bf6: NeonF32Butterfly6::new(direction),
+                bf12: NeonF32Butterfly12::new(direction),
+                rotate90: Rotate90F32::new(direction == FftDirection::Inverse),
+                twiddle01: pack32(tw0, tw1),
+                twiddle23: pack32(tw2, tw3),
+                twiddle45: pack32(tw4, tw5),
+                twiddle01conj: pack32(tw0.conj(), tw1.conj()),
+                twiddle23conj: pack32(tw2.conj(), tw3.conj()),
+                twiddle45conj: pack32(tw4.conj(), tw5.conj()),
+                twiddle1: pack32(tw1, tw1),
+                twiddle2: pack32(tw2, tw2),
+                twiddle4: pack32(tw4, tw4),
+                twiddle5: pack32(tw5, tw5),
+                twiddle1c: pack32(tw1.conj(), tw1.conj()),
+                twiddle2c: pack32(tw2.conj(), tw2.conj()),
+                twiddle4c: pack32(tw4.conj(), tw4.conj()),
+                twiddle5c: pack32(tw5.conj(), tw5.conj()),
+            }
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn perform_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f32>) {
+        let input_packed =
+            read_complex_to_array!(buffer, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22});
+
+        let out = self.perform_fft_direct(input_packed);
+
+        write_complex_to_array_strided!(out, buffer, 2, {0,1,2,3,4,5,6,7,8,9,10,11});
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn perform_parallel_fft_contiguous(
+        &self,
+        mut buffer: impl NeonArrayMut<f32>,
+    ) {
+        let input_packed = read_complex_to_array!(buffer, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46});
+
+        let values =
+            interleave_complex_f32!(input_packed, 12, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+
+        let out = self.perform_parallel_fft_direct(values);
+
+        let out_sorted =
+            separate_interleaved_complex_f32!(out, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22});
+
+        write_complex_to_array_strided!(out_sorted, buffer, 2, {0,1,2,3,4,5,6,7,8,9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 });
+    }
+
+    #[inline(always)]
+    unsafe fn perform_fft_direct(&self, input: [float32x4_t; 12]) -> [float32x4_t; 12] {
+        // we're going to hardcode a step of split radix
+
+        // step 1: copy and reorder the input into the scratch
+        let in0002 = extract_lo_lo_f32(input[0], input[1]);
+        let in0406 = extract_lo_lo_f32(input[2], input[3]);
+        let in0810 = extract_lo_lo_f32(input[4], input[5]);
+        let in1214 = extract_lo_lo_f32(input[6], input[7]);
+        let in1618 = extract_lo_lo_f32(input[8], input[9]);
+        let in2022 = extract_lo_lo_f32(input[10], input[11]);
+
+        let in0105 = extract_hi_hi_f32(input[0], input[2]);
+        let in0913 = extract_hi_hi_f32(input[4], input[6]);
+        let in1721 = extract_hi_hi_f32(input[8], input[10]);
+
+        let in2303 = extract_hi_hi_f32(input[11], input[1]);
+        let in0711 = extract_hi_hi_f32(input[3], input[5]);
+        let in1519 = extract_hi_hi_f32(input[7], input[9]);
+
+        let in_evens = [in0002, in0406, in0810, in1214, in1618, in2022];
+
+        // step 2: column FFTs
+        let evens = self.bf12.perform_fft_direct(in_evens);
+        let mut odds1 = self.bf6.perform_fft_direct(in0105, in0913, in1721);
+        let mut odds3 = self.bf6.perform_fft_direct(in2303, in0711, in1519);
+
+        // step 3: apply twiddle factors
+        odds1[0] = NeonVector::mul_complex(odds1[0], self.twiddle01);
+        odds3[0] = NeonVector::mul_complex(odds3[0], self.twiddle01conj);
+
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle23);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle23conj);
+
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle45);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle45conj);
+
+        // step 4: cross FFTs
+        let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
+        let mut temp1 = parallel_fft2_interleaved_f32(odds1[1], odds3[1]);
+        let mut temp2 = parallel_fft2_interleaved_f32(odds1[2], odds3[2]);
+
+        // apply the butterfly 4 twiddle factor, which is just a rotation
+        temp0[1] = self.rotate90.rotate_both(temp0[1]);
+        temp1[1] = self.rotate90.rotate_both(temp1[1]);
+        temp2[1] = self.rotate90.rotate_both(temp2[1]);
+
+        //step 5: copy/add/subtract data back to buffer
+        [
+            vaddq_f32(evens[0], temp0[0]),
+            vaddq_f32(evens[1], temp1[0]),
+            vaddq_f32(evens[2], temp2[0]),
+            vaddq_f32(evens[3], temp0[1]),
+            vaddq_f32(evens[4], temp1[1]),
+            vaddq_f32(evens[5], temp2[1]),
+            vsubq_f32(evens[0], temp0[0]),
+            vsubq_f32(evens[1], temp1[0]),
+            vsubq_f32(evens[2], temp2[0]),
+            vsubq_f32(evens[3], temp0[1]),
+            vsubq_f32(evens[4], temp1[1]),
+            vsubq_f32(evens[5], temp2[1]),
+        ]
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn perform_parallel_fft_direct(
+        &self,
+        input: [float32x4_t; 24],
+    ) -> [float32x4_t; 24] {
+        // we're going to hardcode a step of split radix
+
+        // step 1: copy and reorder the  input into the scratch
+        // and
+        // step 2: column FFTs
+        let evens = self.bf12.perform_parallel_fft_direct([
+            input[0], input[2], input[4], input[6], input[8], input[10], input[12], input[14],
+            input[16], input[18], input[20], input[22],
+        ]);
+        let mut odds1 = self.bf6.perform_parallel_fft_direct(
+            input[1], input[5], input[9], input[13], input[17], input[21],
+        );
+        let mut odds3 = self.bf6.perform_parallel_fft_direct(
+            input[23], input[3], input[7], input[11], input[15], input[19],
+        );
+
+        // twiddle factor helpers
+        let rotate45 = |vec| {
+            let rotated = self.rotate90.rotate_both(vec);
+            let sum = vaddq_f32(vec, rotated);
+            vmulq_f32(sum, vld1q_dup_f32(&0.5f32.sqrt()))
+        };
+        let rotate315 = |vec| {
+            let rotated = self.rotate90.rotate_both(vec);
+            let sum = vsubq_f32(vec, rotated);
+            vmulq_f32(sum, vld1q_dup_f32(&0.5f32.sqrt()))
+        };
+
+        // step 3: apply twiddle factors
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle1c);
+
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle2c);
+
+        odds1[3] = rotate45(odds1[3]);
+        odds3[3] = rotate315(odds3[3]);
+
+        odds1[4] = NeonVector::mul_complex(odds1[4], self.twiddle4);
+        odds3[4] = NeonVector::mul_complex(odds3[4], self.twiddle4c);
+
+        odds1[5] = NeonVector::mul_complex(odds1[5], self.twiddle5);
+        odds3[5] = NeonVector::mul_complex(odds3[5], self.twiddle5c);
+
+        // step 4: cross FFTs
+        let mut temp0 = parallel_fft2_interleaved_f32(odds1[0], odds3[0]);
+        let mut temp1 = parallel_fft2_interleaved_f32(odds1[1], odds3[1]);
+        let mut temp2 = parallel_fft2_interleaved_f32(odds1[2], odds3[2]);
+        let mut temp3 = parallel_fft2_interleaved_f32(odds1[3], odds3[3]);
+        let mut temp4 = parallel_fft2_interleaved_f32(odds1[4], odds3[4]);
+        let mut temp5 = parallel_fft2_interleaved_f32(odds1[5], odds3[5]);
+
+        // apply the butterfly 4 twiddle factor, which is just a rotation
+        temp0[1] = self.rotate90.rotate_both(temp0[1]);
+        temp1[1] = self.rotate90.rotate_both(temp1[1]);
+        temp2[1] = self.rotate90.rotate_both(temp2[1]);
+        temp3[1] = self.rotate90.rotate_both(temp3[1]);
+        temp4[1] = self.rotate90.rotate_both(temp4[1]);
+        temp5[1] = self.rotate90.rotate_both(temp5[1]);
+
+        //step 5: copy/add/subtract data back to buffer
+        [
+            vaddq_f32(evens[0], temp0[0]),
+            vaddq_f32(evens[1], temp1[0]),
+            vaddq_f32(evens[2], temp2[0]),
+            vaddq_f32(evens[3], temp3[0]),
+            vaddq_f32(evens[4], temp4[0]),
+            vaddq_f32(evens[5], temp5[0]),
+            vaddq_f32(evens[6], temp0[1]),
+            vaddq_f32(evens[7], temp1[1]),
+            vaddq_f32(evens[8], temp2[1]),
+            vaddq_f32(evens[9], temp3[1]),
+            vaddq_f32(evens[10], temp4[1]),
+            vaddq_f32(evens[11], temp5[1]),
+            vsubq_f32(evens[0], temp0[0]),
+            vsubq_f32(evens[1], temp1[0]),
+            vsubq_f32(evens[2], temp2[0]),
+            vsubq_f32(evens[3], temp3[0]),
+            vsubq_f32(evens[4], temp4[0]),
+            vsubq_f32(evens[5], temp5[0]),
+            vsubq_f32(evens[6], temp0[1]),
+            vsubq_f32(evens[7], temp1[1]),
+            vsubq_f32(evens[8], temp2[1]),
+            vsubq_f32(evens[9], temp3[1]),
+            vsubq_f32(evens[10], temp4[1]),
+            vsubq_f32(evens[11], temp5[1]),
+        ]
+    }
+}
+
+//    ___ _  _              __   _  _   _     _ _
+//   |__ \ || |            / /_ | || | | |__ (_) |_
+//    __) ||| |_   _____  | '_ \| || |_| '_ \| | __|
+//   / __/__   _| |_____| | (_) |__   _| |_) | | |_
+//  |____}  |_|            \___/   |_| |_.__/|_|\__|
+//
+
+pub struct NeonF64Butterfly24<T> {
+    direction: FftDirection,
+    bf6: NeonF64Butterfly6<T>,
+    bf12: NeonF64Butterfly12<T>,
+    rotate90: Rotate90F64,
+    twiddle1: float64x2_t,
+    twiddle2: float64x2_t,
+    twiddle4: float64x2_t,
+    twiddle5: float64x2_t,
+    twiddle1c: float64x2_t,
+    twiddle2c: float64x2_t,
+    twiddle4c: float64x2_t,
+    twiddle5c: float64x2_t,
+}
+
+boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly24, 24, |this: &NeonF64Butterfly24<_>| {
+    this.direction
+});
+boilerplate_fft_neon_common_butterfly!(NeonF64Butterfly24, 24, |this: &NeonF64Butterfly24<_>| this
+    .direction);
+impl<T: FftNum> NeonF64Butterfly24<T> {
+    #[inline(always)]
+    pub fn new(direction: FftDirection) -> Self {
+        assert_f64::<T>();
+        let twiddle1 = twiddles::compute_twiddle(1, 24, direction);
+        let twiddle2 = twiddles::compute_twiddle(2, 24, direction);
+        let twiddle4 = twiddles::compute_twiddle(4, 24, direction);
+        let twiddle5 = twiddles::compute_twiddle(5, 24, direction);
+        unsafe {
+            Self {
+                direction,
+                bf6: NeonF64Butterfly6::new(direction),
+                bf12: NeonF64Butterfly12::new(direction),
+                rotate90: Rotate90F64::new(direction == FftDirection::Inverse),
+                twiddle1: pack64(twiddle1),
+                twiddle2: pack64(twiddle2),
+                twiddle4: pack64(twiddle4),
+                twiddle5: pack64(twiddle5),
+                twiddle1c: pack64(twiddle1.conj()),
+                twiddle2c: pack64(twiddle2.conj()),
+                twiddle4c: pack64(twiddle4.conj()),
+                twiddle5c: pack64(twiddle5.conj()),
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn perform_fft_contiguous(&self, mut buffer: impl NeonArrayMut<f64>) {
+        let values = read_complex_to_array!(buffer, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23});
+
+        let out = self.perform_fft_direct(values);
+
+        write_complex_to_array!(out, buffer, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23});
+    }
+
+    #[inline(always)]
+    unsafe fn perform_fft_direct(&self, input: [float64x2_t; 24]) -> [float64x2_t; 24] {
+        // we're going to hardcode a step of split radix
+
+        // step 1: copy and reorder the  input into the scratch
+        // and
+        // step 2: column FFTs
+        let evens = self.bf12.perform_fft_direct([
+            input[0], input[2], input[4], input[6], input[8], input[10], input[12], input[14],
+            input[16], input[18], input[20], input[22],
+        ]);
+        let mut odds1 = self.bf6.perform_fft_direct(
+            input[1], input[5], input[9], input[13], input[17], input[21],
+        );
+        let mut odds3 = self.bf6.perform_fft_direct(
+            input[23], input[3], input[7], input[11], input[15], input[19],
+        );
+
+        // twiddle factor helpers
+        let rotate45 = |vec| {
+            let rotated = self.rotate90.rotate(vec);
+            let sum = vaddq_f64(vec, rotated);
+            vmulq_f64(sum, vld1q_dup_f64(&0.5f64.sqrt()))
+        };
+        let rotate315 = |vec| {
+            let rotated = self.rotate90.rotate(vec);
+            let sum = vsubq_f64(vec, rotated);
+            vmulq_f64(sum, vld1q_dup_f64(&0.5f64.sqrt()))
+        };
+
+        // step 3: apply twiddle factors
+        odds1[1] = NeonVector::mul_complex(odds1[1], self.twiddle1);
+        odds3[1] = NeonVector::mul_complex(odds3[1], self.twiddle1c);
+
+        odds1[2] = NeonVector::mul_complex(odds1[2], self.twiddle2);
+        odds3[2] = NeonVector::mul_complex(odds3[2], self.twiddle2c);
+
+        odds1[3] = rotate45(odds1[3]);
+        odds3[3] = rotate315(odds3[3]);
+
+        odds1[4] = NeonVector::mul_complex(odds1[4], self.twiddle4);
+        odds3[4] = NeonVector::mul_complex(odds3[4], self.twiddle4c);
+
+        odds1[5] = NeonVector::mul_complex(odds1[5], self.twiddle5);
+        odds3[5] = NeonVector::mul_complex(odds3[5], self.twiddle5c);
+
+        // step 4: cross FFTs
+        let mut temp0 = solo_fft2_f64(odds1[0], odds3[0]);
+        let mut temp1 = solo_fft2_f64(odds1[1], odds3[1]);
+        let mut temp2 = solo_fft2_f64(odds1[2], odds3[2]);
+        let mut temp3 = solo_fft2_f64(odds1[3], odds3[3]);
+        let mut temp4 = solo_fft2_f64(odds1[4], odds3[4]);
+        let mut temp5 = solo_fft2_f64(odds1[5], odds3[5]);
+
+        // apply the butterfly 4 twiddle factor, which is just a rotation
+        temp0[1] = self.rotate90.rotate(temp0[1]);
+        temp1[1] = self.rotate90.rotate(temp1[1]);
+        temp2[1] = self.rotate90.rotate(temp2[1]);
+        temp3[1] = self.rotate90.rotate(temp3[1]);
+        temp4[1] = self.rotate90.rotate(temp4[1]);
+        temp5[1] = self.rotate90.rotate(temp5[1]);
+
+        //step 5: copy/add/subtract data back to buffer
+        [
+            vaddq_f64(evens[0], temp0[0]),
+            vaddq_f64(evens[1], temp1[0]),
+            vaddq_f64(evens[2], temp2[0]),
+            vaddq_f64(evens[3], temp3[0]),
+            vaddq_f64(evens[4], temp4[0]),
+            vaddq_f64(evens[5], temp5[0]),
+            vaddq_f64(evens[6], temp0[1]),
+            vaddq_f64(evens[7], temp1[1]),
+            vaddq_f64(evens[8], temp2[1]),
+            vaddq_f64(evens[9], temp3[1]),
+            vaddq_f64(evens[10], temp4[1]),
+            vaddq_f64(evens[11], temp5[1]),
+            vsubq_f64(evens[0], temp0[0]),
+            vsubq_f64(evens[1], temp1[0]),
+            vsubq_f64(evens[2], temp2[0]),
+            vsubq_f64(evens[3], temp3[0]),
+            vsubq_f64(evens[4], temp4[0]),
+            vsubq_f64(evens[5], temp5[0]),
+            vsubq_f64(evens[6], temp0[1]),
+            vsubq_f64(evens[7], temp1[1]),
+            vsubq_f64(evens[8], temp2[1]),
+            vsubq_f64(evens[9], temp3[1]),
+            vsubq_f64(evens[10], temp4[1]),
+            vsubq_f64(evens[11], temp5[1]),
+        ]
+    }
+}
+
 //   _________            _________  _     _ _
 //  |___ /___ \          |___ /___ \| |__ (_) |_
 //    |_ \ __) |  _____    |_ \ __) | '_ \| | __|
@@ -3243,6 +3660,7 @@ mod unit_tests {
     test_butterfly_32_func!(test_neonf32_butterfly12, NeonF32Butterfly12, 12);
     test_butterfly_32_func!(test_neonf32_butterfly15, NeonF32Butterfly15, 15);
     test_butterfly_32_func!(test_neonf32_butterfly16, NeonF32Butterfly16, 16);
+    test_butterfly_32_func!(test_neonf32_butterfly24, NeonF32Butterfly24, 24);
     test_butterfly_32_func!(test_neonf32_butterfly32, NeonF32Butterfly32, 32);
 
     //the tests for all butterflies will be identical except for the identifiers used and size
@@ -3271,6 +3689,7 @@ mod unit_tests {
     test_butterfly_64_func!(test_neonf64_butterfly12, NeonF64Butterfly12, 12);
     test_butterfly_64_func!(test_neonf64_butterfly15, NeonF64Butterfly15, 15);
     test_butterfly_64_func!(test_neonf64_butterfly16, NeonF64Butterfly16, 16);
+    test_butterfly_64_func!(test_neonf64_butterfly24, NeonF64Butterfly24, 24);
     test_butterfly_64_func!(test_neonf64_butterfly32, NeonF64Butterfly32, 32);
 
     #[test]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -413,7 +413,7 @@ impl<T: FftNum> FftPlannerScalar<T> {
         } else if factors.is_prime() {
             self.design_prime(len)
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
-            if len.is_power_of_two() {
+            if factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2 {
                 self.design_radix4(factors)
             } else {
                 let non_power_of_two = factors

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -127,7 +127,6 @@ impl<T: FftNum> FftPlanner<T> {
 const MIN_RADIX4_BITS: u32 = 5; // smallest size to consider radix 4 an option is 2^5 = 32
 const MIN_RADIX3_FACTORS: u32 = 4; // smallest number of factors of 3 to consider radix 4 an option is 3^4=81. any smaller and we want to use butterflies directly.
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
-const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
 /// It is used as a middle step in the planning process.
@@ -175,11 +174,13 @@ pub enum Recipe {
     Butterfly8,
     Butterfly9,
     Butterfly11,
+    Butterfly12,
     Butterfly13,
     Butterfly16,
     Butterfly17,
     Butterfly19,
     Butterfly23,
+    Butterfly24,
     Butterfly27,
     Butterfly29,
     Butterfly31,
@@ -201,11 +202,13 @@ impl Recipe {
             Recipe::Butterfly8 => 8,
             Recipe::Butterfly9 => 9,
             Recipe::Butterfly11 => 11,
+            Recipe::Butterfly12 => 12,
             Recipe::Butterfly13 => 13,
             Recipe::Butterfly16 => 16,
             Recipe::Butterfly17 => 17,
             Recipe::Butterfly19 => 19,
             Recipe::Butterfly23 => 23,
+            Recipe::Butterfly24 => 24,
             Recipe::Butterfly27 => 27,
             Recipe::Butterfly29 => 29,
             Recipe::Butterfly31 => 31,
@@ -350,11 +353,13 @@ impl<T: FftNum> FftPlannerScalar<T> {
             Recipe::Butterfly8 => Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly9 => Arc::new(Butterfly9::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly11 => Arc::new(Butterfly11::new(direction)) as Arc<dyn Fft<T>>,
+            Recipe::Butterfly12 => Arc::new(Butterfly12::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly13 => Arc::new(Butterfly13::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly16 => Arc::new(Butterfly16::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly17 => Arc::new(Butterfly17::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly19 => Arc::new(Butterfly19::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly23 => Arc::new(Butterfly23::new(direction)) as Arc<dyn Fft<T>>,
+            Recipe::Butterfly24 => Arc::new(Butterfly24::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly27 => Arc::new(Butterfly27::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly29 => Arc::new(Butterfly29::new(direction)) as Arc<dyn Fft<T>>,
             Recipe::Butterfly31 => Arc::new(Butterfly31::new(direction)) as Arc<dyn Fft<T>>,
@@ -409,7 +414,7 @@ impl<T: FftNum> FftPlannerScalar<T> {
             self.design_prime(len)
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
             if len.is_power_of_two() {
-                self.design_radix4(len)
+                self.design_radix4(factors)
             } else {
                 let non_power_of_two = factors
                     .remove_factors(PrimeFactor {
@@ -490,27 +495,54 @@ impl<T: FftNum> FftPlannerScalar<T> {
         })
     }
 
-    fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
-        // plan a step of radix4
-        let exponent = len.trailing_zeros();
-        let base_exponent = match exponent {
-            0 => 0,
-            1 => 1,
-            2 => 2,
-            _ => {
-                if exponent % 2 == 1 {
-                    3
-                } else {
-                    4
+    fn design_radix4(&mut self, factors: PrimeFactors) -> Arc<Recipe> {
+        // We can eventually relax this restriction -- it's not instrinsic to radix4, it's just that anything besides 2^n and 3*2^n hasn't been measured yet
+        assert!(factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2);
+
+        let p2 = factors.get_power_of_two();
+        let base_len: usize = if factors.get_power_of_three() == 0 {
+            // pure power of 2
+            match p2 {
+                // base cases. we shouldn't hit these but we might as well be ready for them
+                0 => 1,
+                1 => 2,
+                2 => 4,
+                // main case: if len is a power of 4, use a base of 16, otherwise use a base of 8
+                _ => {
+                    if p2 % 2 == 1 {
+                        8
+                    } else {
+                        16
+                    }
+                }
+            }
+        } else {
+            // we have a factor 3 that we're going to stick into the butterflies
+            match p2 {
+                // base cases. we shouldn't hit these but we might as well be ready for them
+                0 => 3,
+                1 => 6,
+                // main case: if len is 3*4^k, use a base of 12, otherwise use a base of 24
+                _ => {
+                    if p2 % 2 == 1 {
+                        24
+                    } else {
+                        12
+                    }
                 }
             }
         };
 
-        let base_fft = self.design_fft_for_len(1 << base_exponent);
-        Arc::new(Recipe::Radix4 {
-            k: (exponent - base_exponent) / 2,
-            base_fft,
-        })
+        // now that we know the base length, divide it out get what radix4 needs to compute
+        let cross_len = factors.get_product() / base_len;
+        assert!(cross_len.is_power_of_two());
+
+        let cross_bits = cross_len.trailing_zeros();
+        assert!(cross_bits % 2 == 0);
+        let k = cross_bits / 2;
+
+        let base_fft = self.design_fft_for_len(base_len);
+        Arc::new(Recipe::Radix4 { k, base_fft })
     }
 
     // Returns Some(instance) if we have a butterfly available for this size. Returns None if there is no butterfly available for this size
@@ -525,11 +557,13 @@ impl<T: FftNum> FftPlannerScalar<T> {
             8 => Some(Arc::new(Recipe::Butterfly8)),
             9 => Some(Arc::new(Recipe::Butterfly9)),
             11 => Some(Arc::new(Recipe::Butterfly11)),
+            12 => Some(Arc::new(Recipe::Butterfly12)),
             13 => Some(Arc::new(Recipe::Butterfly13)),
             16 => Some(Arc::new(Recipe::Butterfly16)),
             17 => Some(Arc::new(Recipe::Butterfly17)),
             19 => Some(Arc::new(Recipe::Butterfly19)),
             23 => Some(Arc::new(Recipe::Butterfly23)),
+            24 => Some(Arc::new(Recipe::Butterfly24)),
             27 => Some(Arc::new(Recipe::Butterfly27)),
             29 => Some(Arc::new(Recipe::Butterfly29)),
             31 => Some(Arc::new(Recipe::Butterfly31)),
@@ -547,17 +581,21 @@ impl<T: FftNum> FftPlannerScalar<T> {
             .iter()
             .any(|val| val.value > MAX_RADER_PRIME_FACTOR)
         {
-            let inner_fft_len_pow2 = (2 * len - 1).checked_next_power_of_two().unwrap();
-            // for long ffts a mixed radix inner fft is faster than a longer radix4
+            // we want to use bluestein's algorithm. we have a free choice of which inner FFT length to use
+            // the only restriction is that it has to be (2 * len - 1) or larger. So we want the fastest FFT we can compute at or above that size.
+
+            // the most obvious choice is the next-highest power of two, but there's one trick we can pull to get a smaller fft that we can be 100% certain will be faster
             let min_inner_len = 2 * len - 1;
-            let mixed_radix_len = 3 * inner_fft_len_pow2 / 4;
-            let inner_fft =
-                if mixed_radix_len >= min_inner_len && len >= MIN_BLUESTEIN_MIXED_RADIX_LEN {
-                    let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
-                    self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
-                } else {
-                    self.design_radix4(inner_fft_len_pow2)
-                };
+            let inner_len_pow2 = min_inner_len.checked_next_power_of_two().unwrap();
+            let inner_len_factor3 = inner_len_pow2 / 4 * 3;
+
+            let inner_len = if inner_len_factor3 >= min_inner_len {
+                inner_len_factor3
+            } else {
+                inner_len_pow2
+            };
+            let inner_fft = self.design_fft_for_len(inner_len);
+
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {
             let inner_fft = self.design_fft_with_factors(inner_fft_len_rader, raders_factors);
@@ -640,11 +678,13 @@ mod unit_tests {
         assert_eq!(*planner.design_fft_for_len(7), Recipe::Butterfly7);
         assert_eq!(*planner.design_fft_for_len(8), Recipe::Butterfly8);
         assert_eq!(*planner.design_fft_for_len(11), Recipe::Butterfly11);
+        assert_eq!(*planner.design_fft_for_len(12), Recipe::Butterfly12);
         assert_eq!(*planner.design_fft_for_len(13), Recipe::Butterfly13);
         assert_eq!(*planner.design_fft_for_len(16), Recipe::Butterfly16);
         assert_eq!(*planner.design_fft_for_len(17), Recipe::Butterfly17);
         assert_eq!(*planner.design_fft_for_len(19), Recipe::Butterfly19);
         assert_eq!(*planner.design_fft_for_len(23), Recipe::Butterfly23);
+        assert_eq!(*planner.design_fft_for_len(24), Recipe::Butterfly24);
         assert_eq!(*planner.design_fft_for_len(29), Recipe::Butterfly29);
         assert_eq!(*planner.design_fft_for_len(31), Recipe::Butterfly31);
         assert_eq!(*planner.design_fft_for_len(32), Recipe::Butterfly32);
@@ -689,7 +729,7 @@ mod unit_tests {
     #[test]
     fn test_plan_scalar_goodthomasbutterfly() {
         let mut planner = FftPlannerScalar::<f64>::new();
-        for len in [3 * 4, 3 * 5, 3 * 7, 5 * 7, 11 * 13].iter() {
+        for len in [3 * 5, 3 * 7, 5 * 7, 11 * 13].iter() {
             let plan = planner.design_fft_for_len(*len);
             assert!(
                 is_goodthomassmall(&plan),

--- a/src/sse/sse_butterflies.rs
+++ b/src/sse/sse_butterflies.rs
@@ -2600,7 +2600,6 @@ impl<T: FftNum> SseF64Butterfly16<T> {
     }
 }
 
-
 //    ___ _  _             _________  _     _ _
 //   |__ \ || |           |___ /___ \| |__ (_) |_
 //    __) ||| |_   _____    |_ \ __) | '_ \| | __|
@@ -2647,9 +2646,7 @@ impl<T: FftNum> SseF32Butterfly24<T> {
         let bf6 = SseF32Butterfly6::new(direction);
         let bf4 = SseF32Butterfly4::new(direction);
 
-        let pack = |a: Complex<f32>, b: Complex<f32>| {
-            unsafe { _mm_set_ps(b.im, b.re, a.im, a.re) }
-        };
+        let pack = |a: Complex<f32>, b: Complex<f32>| unsafe { _mm_set_ps(b.im, b.re, a.im, a.re) };
 
         let twiddle0 = Complex { re: 1.0, im: 0.0 };
         let twiddle1 = twiddles::compute_twiddle(1, 24, direction);
@@ -2694,7 +2691,8 @@ impl<T: FftNum> SseF32Butterfly24<T> {
 
     #[inline(always)]
     unsafe fn perform_fft_contiguous(&self, mut buffer: impl SseArrayMut<f32>) {
-        let input_packed = read_complex_to_array!(buffer, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22});
+        let input_packed =
+            read_complex_to_array!(buffer, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22});
 
         let out = self.perform_fft_direct(input_packed);
 
@@ -2705,11 +2703,13 @@ impl<T: FftNum> SseF32Butterfly24<T> {
     pub(crate) unsafe fn perform_parallel_fft_contiguous(&self, mut buffer: impl SseArrayMut<f32>) {
         let input_packed = read_complex_to_array!(buffer, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46});
 
-        let values = interleave_complex_f32!(input_packed, 12, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+        let values =
+            interleave_complex_f32!(input_packed, 12, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
 
         let out = self.perform_parallel_fft_direct(values);
 
-        let out_sorted = separate_interleaved_complex_f32!(out, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22});
+        let out_sorted =
+            separate_interleaved_complex_f32!(out, {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22});
 
         write_complex_to_array_strided!(out_sorted, buffer, 2, {0,1,2,3,4,5,6,7,8,9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 });
     }
@@ -2719,8 +2719,12 @@ impl<T: FftNum> SseF32Butterfly24<T> {
         // Algorithm: 6x4 mixedradix
 
         // Size-6 FFTs down the columns of our reordered array
-        let mut scratch0 = self.bf6.perform_parallel_fft_direct(values[0], values[2], values[4], values[6], values[8], values[10]);
-        let mut scratch1 = self.bf6.perform_parallel_fft_direct(values[1], values[3], values[5], values[7], values[9], values[11]);
+        let mut scratch0 = self.bf6.perform_parallel_fft_direct(
+            values[0], values[2], values[4], values[6], values[8], values[10],
+        );
+        let mut scratch1 = self.bf6.perform_parallel_fft_direct(
+            values[1], values[3], values[5], values[7], values[9], values[11],
+        );
 
         // twiddle factors
         scratch0[1] = SseVector::mul_complex(scratch0[1], self.twiddle01);
@@ -2751,18 +2755,18 @@ impl<T: FftNum> SseF32Butterfly24<T> {
 
         // Reorder and return
         [
-            extract_lo_lo_f32(out0[0], out1[0]),// 0 x
-            extract_lo_lo_f32(out2[0], out3[0]),// x x
-            extract_lo_lo_f32(out4[0], out5[0]),// 4 x
-            extract_hi_hi_f32(out0[0], out1[0]),// 6 x
-            extract_hi_hi_f32(out2[0], out3[0]),// x x
-            extract_hi_hi_f32(out4[0], out5[0]),// 10 11
-            extract_lo_lo_f32(out0[1], out1[1]),// 12 x
-            extract_lo_lo_f32(out2[1], out3[1]),// x x
-            extract_lo_lo_f32(out4[1], out5[1]),// 16 x
-            extract_hi_hi_f32(out0[1], out1[1]),// 18 19
-            extract_hi_hi_f32(out2[1], out3[1]),// x x
-            extract_hi_hi_f32(out4[1], out5[1]),// 22 x
+            extract_lo_lo_f32(out0[0], out1[0]), // 0 x
+            extract_lo_lo_f32(out2[0], out3[0]), // x x
+            extract_lo_lo_f32(out4[0], out5[0]), // 4 x
+            extract_hi_hi_f32(out0[0], out1[0]), // 6 x
+            extract_hi_hi_f32(out2[0], out3[0]), // x x
+            extract_hi_hi_f32(out4[0], out5[0]), // 10 11
+            extract_lo_lo_f32(out0[1], out1[1]), // 12 x
+            extract_lo_lo_f32(out2[1], out3[1]), // x x
+            extract_lo_lo_f32(out4[1], out5[1]), // 16 x
+            extract_hi_hi_f32(out0[1], out1[1]), // 18 19
+            extract_hi_hi_f32(out2[1], out3[1]), // x x
+            extract_hi_hi_f32(out4[1], out5[1]), // 22 x
         ]
     }
 
@@ -2771,10 +2775,18 @@ impl<T: FftNum> SseF32Butterfly24<T> {
         // Algorithm: 6x4 mixedradix
 
         // Size-6 FFTs down the columns of our reordered array
-        let scratch0     = self.bf6.perform_parallel_fft_direct(values[0], values[4], values[8], values[12], values[16], values[20]);
-        let mut scratch1 = self.bf6.perform_parallel_fft_direct(values[1], values[5], values[9], values[13], values[17], values[21]);
-        let mut scratch2 = self.bf6.perform_parallel_fft_direct(values[2], values[6], values[10], values[14], values[18], values[22]);
-        let mut scratch3 = self.bf6.perform_parallel_fft_direct(values[3], values[7], values[11], values[15], values[19], values[23]);
+        let scratch0 = self.bf6.perform_parallel_fft_direct(
+            values[0], values[4], values[8], values[12], values[16], values[20],
+        );
+        let mut scratch1 = self.bf6.perform_parallel_fft_direct(
+            values[1], values[5], values[9], values[13], values[17], values[21],
+        );
+        let mut scratch2 = self.bf6.perform_parallel_fft_direct(
+            values[2], values[6], values[10], values[14], values[18], values[22],
+        );
+        let mut scratch3 = self.bf6.perform_parallel_fft_direct(
+            values[3], values[7], values[11], values[15], values[19], values[23],
+        );
 
         // helper functions for our twiddle factors
         let rotate45 = |vec| {
@@ -2811,18 +2823,47 @@ impl<T: FftNum> SseF32Butterfly24<T> {
         scratch3[5] = rotate225(scratch3[5]);
 
         // step 4/5: Transpose the data and do size-4 FFTs down the columns
-        let out0 = self.bf4.perform_parallel_fft_direct(scratch0[0], scratch1[0], scratch2[0], scratch3[0]);
-        let out1 = self.bf4.perform_parallel_fft_direct(scratch0[1], scratch1[1], scratch2[1], scratch3[1]);
-        let out2 = self.bf4.perform_parallel_fft_direct(scratch0[2], scratch1[2], scratch2[2], scratch3[2]);
-        let out3 = self.bf4.perform_parallel_fft_direct(scratch0[3], scratch1[3], scratch2[3], scratch3[3]);
-        let out4 = self.bf4.perform_parallel_fft_direct(scratch0[4], scratch1[4], scratch2[4], scratch3[4]);
-        let out5 = self.bf4.perform_parallel_fft_direct(scratch0[5], scratch1[5], scratch2[5], scratch3[5]);
+        let out0 = self.bf4.perform_parallel_fft_direct(
+            scratch0[0],
+            scratch1[0],
+            scratch2[0],
+            scratch3[0],
+        );
+        let out1 = self.bf4.perform_parallel_fft_direct(
+            scratch0[1],
+            scratch1[1],
+            scratch2[1],
+            scratch3[1],
+        );
+        let out2 = self.bf4.perform_parallel_fft_direct(
+            scratch0[2],
+            scratch1[2],
+            scratch2[2],
+            scratch3[2],
+        );
+        let out3 = self.bf4.perform_parallel_fft_direct(
+            scratch0[3],
+            scratch1[3],
+            scratch2[3],
+            scratch3[3],
+        );
+        let out4 = self.bf4.perform_parallel_fft_direct(
+            scratch0[4],
+            scratch1[4],
+            scratch2[4],
+            scratch3[4],
+        );
+        let out5 = self.bf4.perform_parallel_fft_direct(
+            scratch0[5],
+            scratch1[5],
+            scratch2[5],
+            scratch3[5],
+        );
 
         // step 6: transpose to output
         [
-            out0[0], out1[0], out2[0], out3[0], out4[0], out5[0],
-            out0[1], out1[1], out2[1], out3[1], out4[1], out5[1],
-            out0[2], out1[2], out2[2], out3[2], out4[2], out5[2],
+            out0[0], out1[0], out2[0], out3[0], out4[0], out5[0], out0[1], out1[1], out2[1],
+            out3[1], out4[1], out5[1], out0[2], out1[2], out2[2], out3[2], out4[2], out5[2],
             out0[3], out1[3], out2[3], out3[3], out4[3], out5[3],
         ]
     }
@@ -2849,8 +2890,9 @@ pub struct SseF64Butterfly24<T> {
     rotation: Rotation90<__m128d>,
 }
 
-boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly24, 24, |this: &SseF64Butterfly24Mixed64<_>| this
-    .direction);
+boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly24, 24, |this: &SseF64Butterfly24Mixed64<
+    _,
+>| this.direction);
 boilerplate_fft_sse_common_butterfly!(SseF64Butterfly24, 24, |this: &SseF64Butterfly24<_>| this
     .direction);
 impl<T: FftNum> SseF64Butterfly24<T> {
@@ -2888,10 +2930,18 @@ impl<T: FftNum> SseF64Butterfly24<T> {
         // Algorithm: 6x4 mixedradix
 
         // Size-6 FFTs down the columns of our reordered array
-        let scratch0     = self.bf6.perform_fft_direct(values[0], values[4], values[8], values[12], values[16], values[20]);
-        let mut scratch1 = self.bf6.perform_fft_direct(values[1], values[5], values[9], values[13], values[17], values[21]);
-        let mut scratch2 = self.bf6.perform_fft_direct(values[2], values[6], values[10], values[14], values[18], values[22]);
-        let mut scratch3 = self.bf6.perform_fft_direct(values[3], values[7], values[11], values[15], values[19], values[23]);
+        let scratch0 = self.bf6.perform_fft_direct(
+            values[0], values[4], values[8], values[12], values[16], values[20],
+        );
+        let mut scratch1 = self.bf6.perform_fft_direct(
+            values[1], values[5], values[9], values[13], values[17], values[21],
+        );
+        let mut scratch2 = self.bf6.perform_fft_direct(
+            values[2], values[6], values[10], values[14], values[18], values[22],
+        );
+        let mut scratch3 = self.bf6.perform_fft_direct(
+            values[3], values[7], values[11], values[15], values[19], values[23],
+        );
 
         // helper functions for our twiddle factors
         let rotate45 = |vec| {
@@ -2928,18 +2978,29 @@ impl<T: FftNum> SseF64Butterfly24<T> {
         scratch3[5] = rotate225(scratch3[5]);
 
         // step 4/5: Transpose the data and do size-4 FFTs down the columns
-        let out0 = self.bf4.perform_fft_direct(scratch0[0], scratch1[0], scratch2[0], scratch3[0]);
-        let out1 = self.bf4.perform_fft_direct(scratch0[1], scratch1[1], scratch2[1], scratch3[1]);
-        let out2 = self.bf4.perform_fft_direct(scratch0[2], scratch1[2], scratch2[2], scratch3[2]);
-        let out3 = self.bf4.perform_fft_direct(scratch0[3], scratch1[3], scratch2[3], scratch3[3]);
-        let out4 = self.bf4.perform_fft_direct(scratch0[4], scratch1[4], scratch2[4], scratch3[4]);
-        let out5 = self.bf4.perform_fft_direct(scratch0[5], scratch1[5], scratch2[5], scratch3[5]);
+        let out0 = self
+            .bf4
+            .perform_fft_direct(scratch0[0], scratch1[0], scratch2[0], scratch3[0]);
+        let out1 = self
+            .bf4
+            .perform_fft_direct(scratch0[1], scratch1[1], scratch2[1], scratch3[1]);
+        let out2 = self
+            .bf4
+            .perform_fft_direct(scratch0[2], scratch1[2], scratch2[2], scratch3[2]);
+        let out3 = self
+            .bf4
+            .perform_fft_direct(scratch0[3], scratch1[3], scratch2[3], scratch3[3]);
+        let out4 = self
+            .bf4
+            .perform_fft_direct(scratch0[4], scratch1[4], scratch2[4], scratch3[4]);
+        let out5 = self
+            .bf4
+            .perform_fft_direct(scratch0[5], scratch1[5], scratch2[5], scratch3[5]);
 
         // step 6: transpose to output
         [
-            out0[0], out1[0], out2[0], out3[0], out4[0], out5[0],
-            out0[1], out1[1], out2[1], out3[1], out4[1], out5[1],
-            out0[2], out1[2], out2[2], out3[2], out4[2], out5[2],
+            out0[0], out1[0], out2[0], out3[0], out4[0], out5[0], out0[1], out1[1], out2[1],
+            out3[1], out4[1], out5[1], out0[2], out1[2], out2[2], out3[2], out4[2], out5[2],
             out0[3], out1[3], out2[3], out3[3], out4[3], out5[3],
         ]
     }

--- a/src/sse/sse_butterflies.rs
+++ b/src/sse/sse_butterflies.rs
@@ -2628,7 +2628,7 @@ pub struct SseF32Butterfly24<T> {
     twiddle5c: __m128,
 }
 
-boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly24, 24, |this: &SseF32Butterfly24Split<_>| {
+boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly24, 24, |this: &SseF32Butterfly24<_>| {
     this.direction
 });
 boilerplate_fft_sse_common_butterfly!(SseF32Butterfly24, 24, |this: &SseF32Butterfly24<_>| this
@@ -2888,7 +2888,7 @@ pub struct SseF64Butterfly24<T> {
     twiddle5c: __m128d,
 }
 
-boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly24, 24, |this: &SseF64Butterfly24Split<_>| {
+boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly24, 24, |this: &SseF64Butterfly24<_>| {
     this.direction
 });
 boilerplate_fft_sse_common_butterfly!(SseF64Butterfly24, 24, |this: &SseF64Butterfly24<_>| this

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -16,8 +16,7 @@ use crate::math_utils::{PrimeFactor, PrimeFactors};
 
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
-const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
-const RADIX4_USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
+const RADIX4_USE_BUTTERFLY32_FROM: u32 = 18; // Use length 32 butterfly starting from this power of 2
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
 /// It is used as a middle step in the planning process.
@@ -70,6 +69,7 @@ pub enum Recipe {
     Butterfly17,
     Butterfly19,
     Butterfly23,
+    Butterfly24,
     Butterfly29,
     Butterfly31,
     Butterfly32,
@@ -98,6 +98,7 @@ impl Recipe {
             Recipe::Butterfly17 => 17,
             Recipe::Butterfly19 => 19,
             Recipe::Butterfly23 => 23,
+            Recipe::Butterfly24 => 24,
             Recipe::Butterfly29 => 29,
             Recipe::Butterfly31 => 31,
             Recipe::Butterfly32 => 32,
@@ -425,6 +426,15 @@ impl<T: FftNum> FftPlannerSse<T> {
                     panic!("Not f32 or f64");
                 }
             }
+            Recipe::Butterfly24 => {
+                if id_t == id_f32 {
+                    Arc::new(SseF32Butterfly24::new(direction)) as Arc<dyn Fft<T>>
+                } else if id_t == id_f64 {
+                    Arc::new(SseF64Butterfly24::new(direction)) as Arc<dyn Fft<T>>
+                } else {
+                    panic!("Not f32 or f64");
+                }
+            }
             Recipe::Butterfly29 => {
                 if id_t == id_f32 {
                     Arc::new(SseF32Butterfly29::new(direction)) as Arc<dyn Fft<T>>
@@ -501,8 +511,8 @@ impl<T: FftNum> FftPlannerSse<T> {
         } else if factors.is_prime() {
             self.design_prime(len)
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
-            if len.is_power_of_two() {
-                self.design_radix4(len)
+            if factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2 {
+                self.design_radix4(factors)
             } else {
                 let non_power_of_two = factors
                     .remove_factors(PrimeFactor {
@@ -518,8 +528,8 @@ impl<T: FftNum> FftPlannerSse<T> {
             // Loop through and find all combinations
             // If more than one is found, keep the one where the factors are closer together.
             // For example length 20 where 10x2 and 5x4 are possible, we use 5x4.
-            let butterflies: [usize; 20] = [
-                2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 19, 23, 29, 31, 32,
+            let butterflies: [usize; 21] = [
+                2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 19, 23, 24, 29, 31, 32,
             ];
             let mut bf_left = 0;
             let mut bf_right = 0;
@@ -601,6 +611,7 @@ impl<T: FftNum> FftPlannerSse<T> {
             17 => Some(Arc::new(Recipe::Butterfly17)),
             19 => Some(Arc::new(Recipe::Butterfly19)),
             23 => Some(Arc::new(Recipe::Butterfly23)),
+            24 => Some(Arc::new(Recipe::Butterfly24)),
             29 => Some(Arc::new(Recipe::Butterfly29)),
             31 => Some(Arc::new(Recipe::Butterfly31)),
             32 => Some(Arc::new(Recipe::Butterfly32)),
@@ -617,17 +628,21 @@ impl<T: FftNum> FftPlannerSse<T> {
             .iter()
             .any(|val| val.value > MAX_RADER_PRIME_FACTOR)
         {
-            let inner_fft_len_pow2 = (2 * len - 1).checked_next_power_of_two().unwrap();
-            // for long ffts a mixed radix inner fft is faster than a longer radix4
+            // we want to use bluestein's algorithm. we have a free choice of which inner FFT length to use
+            // the only restriction is that it has to be (2 * len - 1) or larger. So we want the fastest FFT we can compute at or above that size.
+
+            // the most obvious choice is the next-highest power of two, but there's one trick we can pull to get a smaller fft that we can be 100% certain will be faster
             let min_inner_len = 2 * len - 1;
-            let mixed_radix_len = 3 * inner_fft_len_pow2 / 4;
-            let inner_fft =
-                if mixed_radix_len >= min_inner_len && len >= MIN_BLUESTEIN_MIXED_RADIX_LEN {
-                    let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
-                    self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
-                } else {
-                    self.design_radix4(inner_fft_len_pow2)
-                };
+            let inner_len_pow2 = min_inner_len.checked_next_power_of_two().unwrap();
+            let inner_len_factor3 = inner_len_pow2 / 4 * 3;
+
+            let inner_len = if inner_len_factor3 >= min_inner_len {
+                inner_len_factor3
+            } else {
+                inner_len_pow2
+            };
+            let inner_fft = self.design_fft_for_len(inner_len);
+
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {
             let inner_fft = self.design_fft_with_factors(inner_fft_len_rader, raders_factors);
@@ -635,31 +650,59 @@ impl<T: FftNum> FftPlannerSse<T> {
         }
     }
 
-    fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
-        // plan a step of radix4
-        let exponent = len.trailing_zeros();
-        let base_exponent = match exponent {
-            0 => 0,
-            1 => 1,
-            2 => 2,
-            _ => {
-                if exponent % 2 == 1 {
-                    if len < RADIX4_USE_BUTTERFLY32_FROM {
-                        3
+    fn design_radix4(&mut self, factors: PrimeFactors) -> Arc<Recipe> {
+        // We can eventually relax this restriction -- it's not instrinsic to radix4, it's just that anything besides 2^n and 3*2^n hasn't been measured yet
+        assert!(factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2);
+
+        let p2 = factors.get_power_of_two();
+        let base_len: usize = if factors.get_power_of_three() == 0 {
+            // pure power of 2
+            match p2 {
+                // base cases. we shouldn't hit these but we might as well be ready for them
+                0 => 1,
+                1 => 2,
+                2 => 4,
+                3 => 8,
+                // main case: if len is a power of 4, use a base of 16, otherwise use a base of 8
+                _ => {
+                    if p2 % 2 == 1 {
+                        if p2 >= RADIX4_USE_BUTTERFLY32_FROM {
+                            32
+                        } else {
+                            8
+                        }
                     } else {
-                        5
+                        16
                     }
-                } else {
-                    4
+                }
+            }
+        } else {
+            // we have a factor 3 that we're going to stick into the butterflies
+            match p2 {
+                // base cases. we shouldn't hit these but we might as well be ready for them
+                0 => 3,
+                1 => 6,
+                // main case: if len is 3*4^k, use a base of 12, otherwise use a base of 24
+                _ => {
+                    if p2 % 2 == 1 {
+                        24
+                    } else {
+                        12
+                    }
                 }
             }
         };
 
-        let base_fft = self.design_fft_for_len(1 << base_exponent);
-        Arc::new(Recipe::Radix4 {
-            k: (exponent - base_exponent) / 2,
-            base_fft,
-        })
+        // now that we know the base length, divide it out get what radix4 needs to compute
+        let cross_len = factors.get_product() / base_len;
+        assert!(cross_len.is_power_of_two());
+
+        let cross_bits = cross_len.trailing_zeros();
+        assert!(cross_bits % 2 == 0);
+        let k = cross_bits / 2;
+
+        let base_fft = self.design_fft_for_len(base_len);
+        Arc::new(Recipe::Radix4 { k, base_fft })
     }
 }
 
@@ -746,6 +789,7 @@ mod unit_tests {
         assert_eq!(*planner.design_fft_for_len(17), Recipe::Butterfly17);
         assert_eq!(*planner.design_fft_for_len(19), Recipe::Butterfly19);
         assert_eq!(*planner.design_fft_for_len(23), Recipe::Butterfly23);
+        assert_eq!(*planner.design_fft_for_len(24), Recipe::Butterfly24);
         assert_eq!(*planner.design_fft_for_len(29), Recipe::Butterfly29);
         assert_eq!(*planner.design_fft_for_len(31), Recipe::Butterfly31);
         assert_eq!(*planner.design_fft_for_len(32), Recipe::Butterfly32);

--- a/src/sse/sse_radix4.rs
+++ b/src/sse/sse_radix4.rs
@@ -51,6 +51,7 @@ impl<S: SseNum, T: FftNum> SseRadix4<S, T> {
         let direction = base_fft.fft_direction();
         let base_len = base_fft.len();
 
+        // note that we can eventually release this restriction - we just need to update the rest of the code in here to handle remainders
         assert!(base_len % (2 * S::VectorType::COMPLEX_PER_VECTOR) == 0 && base_len > 0);
 
         let len = base_len * (1 << (k * 2));

--- a/src/sse/sse_radix4.rs
+++ b/src/sse/sse_radix4.rs
@@ -51,7 +51,7 @@ impl<S: SseNum, T: FftNum> SseRadix4<S, T> {
         let direction = base_fft.fft_direction();
         let base_len = base_fft.len();
 
-        assert!(base_len.is_power_of_two() && base_len >= 2 * S::VectorType::COMPLEX_PER_VECTOR);
+        assert!(base_len % (2 * S::VectorType::COMPLEX_PER_VECTOR) == 0 && base_len > 0);
 
         let len = base_len * (1 << (k * 2));
 
@@ -195,7 +195,7 @@ mod unit_tests {
 
     #[test]
     fn test_sse_radix4_64() {
-        for base in [2, 4, 8, 16] {
+        for base in [2, 4, 6, 8, 12, 16] {
             let base_forward = construct_base(base, FftDirection::Forward);
             let base_inverse = construct_base(base, FftDirection::Inverse);
             for k in 0..4 {
@@ -214,7 +214,7 @@ mod unit_tests {
 
     #[test]
     fn test_sse_radix4_32() {
-        for base in [4, 8, 16] {
+        for base in [4, 8, 12, 16] {
             let base_forward = construct_base(base, FftDirection::Forward);
             let base_inverse = construct_base(base, FftDirection::Inverse);
             for k in 0..4 {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,8 +7,8 @@ use rand::distributions::{uniform::SampleUniform, Distribution, Uniform};
 use rand::{rngs::StdRng, SeedableRng};
 
 use crate::algorithm::butterflies::{
-    Butterfly1, Butterfly16, Butterfly2, Butterfly3, Butterfly4, Butterfly5, Butterfly6,
-    Butterfly7, Butterfly8, Butterfly9,
+    Butterfly1, Butterfly12, Butterfly16, Butterfly2, Butterfly3, Butterfly4, Butterfly5,
+    Butterfly6, Butterfly7, Butterfly8, Butterfly9,
 };
 use crate::{algorithm::Dft, Direction, FftNum, Length};
 use crate::{Fft, FftDirection};
@@ -225,6 +225,7 @@ pub fn construct_base<T: FftNum>(n: usize, direction: FftDirection) -> Arc<dyn F
         7 => Arc::new(Butterfly7::new(direction)) as Arc<dyn Fft<T>>,
         8 => Arc::new(Butterfly8::new(direction)) as Arc<dyn Fft<T>>,
         9 => Arc::new(Butterfly9::new(direction)) as Arc<dyn Fft<T>>,
+        12 => Arc::new(Butterfly12::new(direction)) as Arc<dyn Fft<T>>,
         16 => Arc::new(Butterfly16::new(direction)) as Arc<dyn Fft<T>>,
         _ => unimplemented!(),
     }

--- a/src/wasm_simd/wasm_simd_butterflies.rs
+++ b/src/wasm_simd/wasm_simd_butterflies.rs
@@ -18,6 +18,7 @@ use super::wasm_simd_vector::WasmSimdArrayMut;
 unsafe fn pack32(a: Complex<f32>, b: Complex<f32>) -> v128 {
     f32x4(a.re, a.im, b.re, b.im)
 }
+#[inline(always)]
 unsafe fn pack64(a: Complex<f64>) -> v128 {
     f64x2(a.re, a.im)
 }

--- a/src/wasm_simd/wasm_simd_planner.rs
+++ b/src/wasm_simd/wasm_simd_planner.rs
@@ -11,8 +11,7 @@ use std::{any::TypeId, collections::HashMap, sync::Arc};
 
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
-const MIN_BLUESTEIN_MIXED_RADIX_LEN: usize = 90; // only use mixed radix for the inner fft of Bluestein if length is larger than this
-const RADIX4_USE_BUTTERFLY32_FROM: usize = 262144; // Use length 32 butterfly starting from this length
+const RADIX4_USE_BUTTERFLY32_FROM: u32 = 18; // Use length 32 butterfly starting from this power of 2
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
 /// It is used as a middle step in the planning process.
@@ -65,6 +64,7 @@ pub enum Recipe {
     Butterfly17,
     Butterfly19,
     Butterfly23,
+    Butterfly24,
     Butterfly29,
     Butterfly31,
     Butterfly32,
@@ -93,6 +93,7 @@ impl Recipe {
             Recipe::Butterfly17 => 17,
             Recipe::Butterfly19 => 19,
             Recipe::Butterfly23 => 23,
+            Recipe::Butterfly24 => 24,
             Recipe::Butterfly29 => 29,
             Recipe::Butterfly31 => 31,
             Recipe::Butterfly32 => 32,
@@ -398,6 +399,15 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
                     panic!("Not f32 or f64");
                 }
             }
+            Recipe::Butterfly24 => {
+                if id_t == id_f32 {
+                    Arc::new(WasmSimdF32Butterfly24::new(direction)) as Arc<dyn Fft<T>>
+                } else if id_t == id_f64 {
+                    Arc::new(WasmSimdF64Butterfly24::new(direction)) as Arc<dyn Fft<T>>
+                } else {
+                    panic!("Not f32 or f64");
+                }
+            }
             Recipe::Butterfly29 => {
                 if id_t == id_f32 {
                     Arc::new(WasmSimdF32Butterfly29::new(direction)) as Arc<dyn Fft<T>>
@@ -474,8 +484,8 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
         } else if factors.is_prime() {
             self.design_prime(len)
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
-            if len.is_power_of_two() {
-                self.design_radix4(len)
+            if factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2 {
+                self.design_radix4(factors)
             } else {
                 let non_power_of_two = factors
                     .remove_factors(PrimeFactor {
@@ -491,8 +501,8 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
             // Loop through and find all combinations
             // If more than one is found, keep the one where the factors are closer together.
             // For example length 20 where 10x2 and 5x4 are possible, we use 5x4.
-            let butterflies: [usize; 20] = [
-                2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 19, 23, 29, 31, 32,
+            let butterflies: [usize; 21] = [
+                2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 19, 23, 24, 29, 31, 32,
             ];
             let mut bf_left = 0;
             let mut bf_right = 0;
@@ -573,6 +583,7 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
             17 => Some(Arc::new(Recipe::Butterfly17)),
             19 => Some(Arc::new(Recipe::Butterfly19)),
             23 => Some(Arc::new(Recipe::Butterfly23)),
+            24 => Some(Arc::new(Recipe::Butterfly24)),
             29 => Some(Arc::new(Recipe::Butterfly29)),
             31 => Some(Arc::new(Recipe::Butterfly31)),
             32 => Some(Arc::new(Recipe::Butterfly32)),
@@ -589,17 +600,21 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
             .iter()
             .any(|val| val.value > MAX_RADER_PRIME_FACTOR)
         {
-            let inner_fft_len_pow2 = (2 * len - 1).checked_next_power_of_two().unwrap();
-            // for long ffts a mixed radix inner fft is faster than a longer radix4
+            // we want to use bluestein's algorithm. we have a free choice of which inner FFT length to use
+            // the only restriction is that it has to be (2 * len - 1) or larger. So we want the fastest FFT we can compute at or above that size.
+
+            // the most obvious choice is the next-highest power of two, but there's one trick we can pull to get a smaller fft that we can be 100% certain will be faster
             let min_inner_len = 2 * len - 1;
-            let mixed_radix_len = 3 * inner_fft_len_pow2 / 4;
-            let inner_fft =
-                if mixed_radix_len >= min_inner_len && len >= MIN_BLUESTEIN_MIXED_RADIX_LEN {
-                    let mixed_radix_factors = PrimeFactors::compute(mixed_radix_len);
-                    self.design_fft_with_factors(mixed_radix_len, mixed_radix_factors)
-                } else {
-                    self.design_radix4(inner_fft_len_pow2)
-                };
+            let inner_len_pow2 = min_inner_len.checked_next_power_of_two().unwrap();
+            let inner_len_factor3 = inner_len_pow2 / 4 * 3;
+
+            let inner_len = if inner_len_factor3 >= min_inner_len {
+                inner_len_factor3
+            } else {
+                inner_len_pow2
+            };
+            let inner_fft = self.design_fft_for_len(inner_len);
+
             Arc::new(Recipe::BluesteinsAlgorithm { len, inner_fft })
         } else {
             let inner_fft = self.design_fft_with_factors(inner_fft_len_rader, raders_factors);
@@ -607,31 +622,59 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
         }
     }
 
-    fn design_radix4(&mut self, len: usize) -> Arc<Recipe> {
-        // plan a step of radix4
-        let exponent = len.trailing_zeros();
-        let base_exponent = match exponent {
-            0 => 0,
-            1 => 1,
-            2 => 2,
-            _ => {
-                if exponent % 2 == 1 {
-                    if len < RADIX4_USE_BUTTERFLY32_FROM {
-                        3
+    fn design_radix4(&mut self, factors: PrimeFactors) -> Arc<Recipe> {
+        // We can eventually relax this restriction -- it's not instrinsic to radix4, it's just that anything besides 2^n and 3*2^n hasn't been measured yet
+        assert!(factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2);
+
+        let p2 = factors.get_power_of_two();
+        let base_len: usize = if factors.get_power_of_three() == 0 {
+            // pure power of 2
+            match p2 {
+                // base cases. we shouldn't hit these but we might as well be ready for them
+                0 => 1,
+                1 => 2,
+                2 => 4,
+                3 => 8,
+                // main case: if len is a power of 4, use a base of 16, otherwise use a base of 8
+                _ => {
+                    if p2 % 2 == 1 {
+                        if p2 >= RADIX4_USE_BUTTERFLY32_FROM {
+                            32
+                        } else {
+                            8
+                        }
                     } else {
-                        5
+                        16
                     }
-                } else {
-                    4
+                }
+            }
+        } else {
+            // we have a factor 3 that we're going to stick into the butterflies
+            match p2 {
+                // base cases. we shouldn't hit these but we might as well be ready for them
+                0 => 3,
+                1 => 6,
+                // main case: if len is 3*4^k, use a base of 12, otherwise use a base of 24
+                _ => {
+                    if p2 % 2 == 1 {
+                        24
+                    } else {
+                        12
+                    }
                 }
             }
         };
 
-        let base_fft = self.design_fft_for_len(1 << base_exponent);
-        Arc::new(Recipe::Radix4 {
-            k: (exponent - base_exponent) / 2,
-            base_fft,
-        })
+        // now that we know the base length, divide it out get what radix4 needs to compute
+        let cross_len = factors.get_product() / base_len;
+        assert!(cross_len.is_power_of_two());
+
+        let cross_bits = cross_len.trailing_zeros();
+        assert!(cross_bits % 2 == 0);
+        let k = cross_bits / 2;
+
+        let base_fft = self.design_fft_for_len(base_len);
+        Arc::new(Recipe::Radix4 { k, base_fft })
     }
 }
 
@@ -719,6 +762,7 @@ mod unit_tests {
         assert_eq!(*planner.design_fft_for_len(17), Recipe::Butterfly17);
         assert_eq!(*planner.design_fft_for_len(19), Recipe::Butterfly19);
         assert_eq!(*planner.design_fft_for_len(23), Recipe::Butterfly23);
+        assert_eq!(*planner.design_fft_for_len(24), Recipe::Butterfly24);
         assert_eq!(*planner.design_fft_for_len(29), Recipe::Butterfly29);
         assert_eq!(*planner.design_fft_for_len(31), Recipe::Butterfly31);
         assert_eq!(*planner.design_fft_for_len(32), Recipe::Butterfly32);

--- a/src/wasm_simd/wasm_simd_radix4.rs
+++ b/src/wasm_simd/wasm_simd_radix4.rs
@@ -39,7 +39,8 @@ impl<S: WasmNum, T: FftNum> WasmSimdRadix4<S, T> {
         let direction = base_fft.fft_direction();
         let base_len = base_fft.len();
 
-        assert!(base_len.is_power_of_two() && base_len >= 2 * S::VectorType::COMPLEX_PER_VECTOR);
+        // note that we can eventually release this restriction - we just need to update the rest of the code in here to handle remainders
+        assert!(base_len % (2 * S::VectorType::COMPLEX_PER_VECTOR) == 0 && base_len > 0);
 
         let len = base_len * (1 << (k * 2));
 
@@ -182,10 +183,11 @@ unsafe fn butterfly_4<S: WasmNum, T: FftNum>(
 mod unit_tests {
     use super::*;
     use crate::test_utils::{check_fft_algorithm, construct_base};
+    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[test]
+    #[wasm_bindgen_test]
     fn test_wasm_simd_radix4_64() {
-        for base in [2, 4, 8, 16] {
+        for base in [2, 4, 6, 8, 12, 16] {
             let base_forward = construct_base(base, FftDirection::Forward);
             let base_inverse = construct_base(base, FftDirection::Inverse);
             for k in 0..4 {
@@ -202,9 +204,9 @@ mod unit_tests {
         check_fft_algorithm::<f64>(&fft, len, direction);
     }
 
-    #[test]
+    #[wasm_bindgen_test]
     fn test_wasm_simd_radix4_32() {
-        for base in [4, 8, 16] {
+        for base in [4, 8, 12, 16] {
             let base_forward = construct_base(base, FftDirection::Forward);
             let base_inverse = construct_base(base, FftDirection::Inverse);
             for k in 0..4 {

--- a/src/wasm_simd/wasm_simd_radix4.rs
+++ b/src/wasm_simd/wasm_simd_radix4.rs
@@ -12,7 +12,7 @@ use super::WasmNum;
 
 use super::wasm_simd_vector::{Rotation90, WasmSimdArray, WasmSimdArrayMut, WasmVector};
 
-/// FFT algorithm optimized for power-of-two sizes, SSE accelerated version.
+/// FFT algorithm optimized for power-of-two sizes, Wasm SIMD accelerated version.
 /// This is designed to be used via a Planner, and not created directly.
 
 pub struct WasmSimdRadix4<S: WasmNum, T> {


### PR DESCRIPTION
This PR relaxes the restriction for all 4 Radix4 implementations that the base FFT length must be a power of 2. For scalar, there's no longer any restriction, and for SIMD, it's restricted to a multiple of COMPLEX_PER_VECTOR * 2 to account for SIMD radix4's unrolling.

So far, we only take advantage of this relaxation in the planner when planning Bluestein's Algorithm. Before, we would attempt to plan a Mixed Radix step with a butterfly3 on one side, and a radix4 on the other side. This carried a lot of overhead, so it wasn't too much faster. Now, we use size-12 and size-24 butterflies instead of radix4's usual size-16 and size-32, so the factor of 3 gets absorbed into the base.

I benchmarked scalar and all of the SIMD implementations' performance of these strategies:

![scalar_factor3](https://github.com/ejmahler/RustFFT/assets/1156730/b6ba11c6-abf3-4293-b79a-c338d84a5726)

I won't bother sharing the SIMD benchmarks because they all look identical. There's two major takeaways from this chart. The first is that the new strategy ("factor 3 base") is strictly faster than the old mixed radix strategy. The second is that element-for-element, the factor 3 base FFTs are just as fast, or maybe even faster, than the strictly power of two FFTs. 

This matches what I found when doing AVX benchmarking - size 3, 6, and 12 FFTs seems to be very, very competitive. On intel processors at least, my theory has been that size 6 and 12 hit a sweet spot of register utilization that 4, 8, and 16 can't quite reach.

This suggests to me that we could benefit from trying more RadixN algorithms than just 4. I bet a Radix6 algorithm would be very competitive, for example. I intend to tackle that soon.