### PR TITLE
RadixN: Like Radix4, but supports size 2,3,4,5,6, and 7 cross-FFTs all in the same instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "compression", "multimedia::encoding", "science"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = []
+default = ["avx", "sse", "neon"]
 
 # On x86_64, the "avx" feature enables compilation of AVX-acclerated code. 
 # Similarly, the "sse" feature enables compilation of SSE-accelerated code. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "compression", "multimedia::encoding", "science"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["avx", "sse", "neon"]
+default = []
 
 # On x86_64, the "avx" feature enables compilation of AVX-acclerated code. 
 # Similarly, the "sse" feature enables compilation of SSE-accelerated code. 

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -38,6 +38,13 @@ impl<T: FftNum> Dft<T> {
         }
     }
 
+    fn inplace_scratch_len(&self) -> usize {
+        self.len()
+    }
+    fn outofplace_scratch_len(&self) -> usize {
+        0
+    }
+
     fn perform_fft_out_of_place(
         &self,
         signal: &[Complex<T>],

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -5,6 +5,7 @@ mod mixed_radix;
 mod raders_algorithm;
 mod radix3;
 mod radix4;
+mod radixn;
 
 /// Hardcoded size-specfic FFT algorithms
 pub mod butterflies;
@@ -16,3 +17,4 @@ pub use self::mixed_radix::{MixedRadix, MixedRadixSmall};
 pub use self::raders_algorithm::RadersAlgorithm;
 pub use self::radix3::Radix3;
 pub use self::radix4::Radix4;
+pub use self::radixn::RadixN;

--- a/src/algorithm/radix3.rs
+++ b/src/algorithm/radix3.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use num_complex::Complex;
-use num_traits::Zero;
 
 use crate::algorithm::butterflies::{Butterfly1, Butterfly27, Butterfly3, Butterfly9};
+use crate::algorithm::radixn::butterfly_3;
 use crate::array_utils::{self, bitreversed_transpose, compute_logarithm};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles, FftDirection};
@@ -32,6 +32,8 @@ pub struct Radix3<T> {
 
     len: usize,
     direction: FftDirection,
+    inplace_scratch_len: usize,
+    outofplace_scratch_len: usize,
 }
 
 impl<T: FftNum> Radix3<T> {
@@ -68,10 +70,11 @@ impl<T: FftNum> Radix3<T> {
         // but mixed radix only does one step and then calls itself recusrively, and this algorithm does every layer all the way down
         // so we're going to pack all the "layers" of twiddle factors into a single array, starting with the bottom layer and going up
         const ROW_COUNT: usize = 3;
-        let mut cross_fft_len = base_len * ROW_COUNT;
+        let mut cross_fft_len = base_len;
         let mut twiddle_factors = Vec::with_capacity(len * 2);
-        while cross_fft_len <= len {
-            let num_columns = cross_fft_len / ROW_COUNT;
+        while cross_fft_len < len {
+            let num_columns = cross_fft_len;
+            cross_fft_len *= ROW_COUNT;
 
             for i in 0..num_columns {
                 for k in 1..ROW_COUNT {
@@ -79,8 +82,15 @@ impl<T: FftNum> Radix3<T> {
                     twiddle_factors.push(twiddle);
                 }
             }
-            cross_fft_len *= ROW_COUNT;
         }
+
+        let base_inplace_scratch = base_fft.get_inplace_scratch_len();
+        let inplace_scratch_len = if base_inplace_scratch > cross_fft_len {
+            cross_fft_len + base_inplace_scratch
+        } else {
+            cross_fft_len
+        };
+        let outofplace_scratch_len = base_inplace_scratch;
 
         Self {
             twiddles: twiddle_factors.into_boxed_slice(),
@@ -91,7 +101,17 @@ impl<T: FftNum> Radix3<T> {
 
             len,
             direction,
+
+            inplace_scratch_len,
+            outofplace_scratch_len,
         }
+    }
+
+    fn inplace_scratch_len(&self) -> usize {
+        self.inplace_scratch_len
+    }
+    fn outofplace_scratch_len(&self) -> usize {
+        self.outofplace_scratch_len
     }
 
     fn perform_fft_out_of_place(
@@ -112,58 +132,24 @@ impl<T: FftNum> Radix3<T> {
 
         // cross-FFTs
         const ROW_COUNT: usize = 3;
-        let mut cross_fft_len = self.base_len * ROW_COUNT;
+        let mut cross_fft_len = self.base_len;
         let mut layer_twiddles: &[Complex<T>] = &self.twiddles;
 
-        while cross_fft_len <= input.len() {
-            let num_rows = input.len() / cross_fft_len;
-            let num_columns = cross_fft_len / ROW_COUNT;
+        while cross_fft_len < input.len() {
+            let num_columns = cross_fft_len;
+            cross_fft_len *= ROW_COUNT;
 
-            for i in 0..num_rows {
-                unsafe {
-                    butterfly_3(
-                        &mut output[i * cross_fft_len..],
-                        layer_twiddles,
-                        num_columns,
-                        &self.butterfly3,
-                    )
-                }
+            for data in output.chunks_exact_mut(cross_fft_len) {
+                unsafe { butterfly_3(data, layer_twiddles, num_columns, &self.butterfly3) }
             }
 
             // skip past all the twiddle factors used in this layer
             let twiddle_offset = num_columns * (ROW_COUNT - 1);
             layer_twiddles = &layer_twiddles[twiddle_offset..];
-
-            cross_fft_len *= ROW_COUNT;
         }
     }
 }
 boilerplate_fft_oop!(Radix3, |this: &Radix3<_>| this.len);
-
-unsafe fn butterfly_3<T: FftNum>(
-    data: &mut [Complex<T>],
-    twiddles: &[Complex<T>],
-    num_ffts: usize,
-    butterfly3: &Butterfly3<T>,
-) {
-    let mut idx = 0usize;
-    let mut tw_idx = 0usize;
-    let mut scratch = [Zero::zero(); 3];
-    for _ in 0..num_ffts {
-        scratch[0] = *data.get_unchecked(idx);
-        scratch[1] = *data.get_unchecked(idx + 1 * num_ffts) * twiddles[tw_idx];
-        scratch[2] = *data.get_unchecked(idx + 2 * num_ffts) * twiddles[tw_idx + 1];
-
-        butterfly3.perform_fft_butterfly(&mut scratch);
-
-        *data.get_unchecked_mut(idx) = scratch[0];
-        *data.get_unchecked_mut(idx + 1 * num_ffts) = scratch[1];
-        *data.get_unchecked_mut(idx + 2 * num_ffts) = scratch[2];
-
-        tw_idx += 2;
-        idx += 1;
-    }
-}
 
 #[cfg(test)]
 mod unit_tests {

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use num_complex::Complex;
-use num_traits::Zero;
 
 use crate::algorithm::butterflies::{
     Butterfly1, Butterfly16, Butterfly2, Butterfly32, Butterfly4, Butterfly8,
 };
+use crate::algorithm::radixn::butterfly_4;
 use crate::array_utils::{self, bitreversed_transpose};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles, FftDirection};
@@ -33,6 +33,8 @@ pub struct Radix4<T> {
 
     len: usize,
     direction: FftDirection,
+    inplace_scratch_len: usize,
+    outofplace_scratch_len: usize,
 }
 
 impl<T: FftNum> Radix4<T> {
@@ -75,10 +77,11 @@ impl<T: FftNum> Radix4<T> {
         // but mixed radix only does one step and then calls itself recusrively, and this algorithm does every layer all the way down
         // so we're going to pack all the "layers" of twiddle factors into a single array, starting with the bottom layer and going up
         const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = base_len * ROW_COUNT;
+        let mut cross_fft_len = base_len;
         let mut twiddle_factors = Vec::with_capacity(len * 2);
-        while cross_fft_len <= len {
-            let num_columns = cross_fft_len / ROW_COUNT;
+        while cross_fft_len < len {
+            let num_columns = cross_fft_len;
+            cross_fft_len *= ROW_COUNT;
 
             for i in 0..num_columns {
                 for k in 1..ROW_COUNT {
@@ -86,8 +89,15 @@ impl<T: FftNum> Radix4<T> {
                     twiddle_factors.push(twiddle);
                 }
             }
-            cross_fft_len *= ROW_COUNT;
         }
+
+        let base_inplace_scratch = base_fft.get_inplace_scratch_len();
+        let inplace_scratch_len = if base_inplace_scratch > cross_fft_len {
+            cross_fft_len + base_inplace_scratch
+        } else {
+            cross_fft_len
+        };
+        let outofplace_scratch_len = base_inplace_scratch;
 
         Self {
             twiddles: twiddle_factors.into_boxed_slice(),
@@ -97,14 +107,24 @@ impl<T: FftNum> Radix4<T> {
 
             len,
             direction,
+
+            inplace_scratch_len,
+            outofplace_scratch_len,
         }
+    }
+
+    fn inplace_scratch_len(&self) -> usize {
+        self.inplace_scratch_len
+    }
+    fn outofplace_scratch_len(&self) -> usize {
+        self.outofplace_scratch_len
     }
 
     fn perform_fft_out_of_place(
         &self,
-        input: &[Complex<T>],
+        input: &mut [Complex<T>],
         output: &mut [Complex<T>],
-        _scratch: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
     ) {
         // copy the data into the output vector
         if self.len() == self.base_len {
@@ -114,66 +134,31 @@ impl<T: FftNum> Radix4<T> {
         }
 
         // Base-level FFTs
-        self.base_fft.process_with_scratch(output, &mut []);
+        let base_scratch = if scratch.len() > 0 { scratch } else { input };
+        self.base_fft.process_with_scratch(output, base_scratch);
 
         // cross-FFTs
         const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = self.base_len * ROW_COUNT;
+        let mut cross_fft_len = self.base_len;
         let mut layer_twiddles: &[Complex<T>] = &self.twiddles;
 
-        while cross_fft_len <= input.len() {
-            let num_rows = input.len() / cross_fft_len;
-            let num_columns = cross_fft_len / ROW_COUNT;
+        let butterfly4 = Butterfly4::new(self.direction);
 
-            for i in 0..num_rows {
-                unsafe {
-                    butterfly_4(
-                        &mut output[i * cross_fft_len..],
-                        layer_twiddles,
-                        num_columns,
-                        self.direction,
-                    )
-                }
+        while cross_fft_len < output.len() {
+            let num_columns = cross_fft_len;
+            cross_fft_len *= ROW_COUNT;
+
+            for data in output.chunks_exact_mut(cross_fft_len) {
+                unsafe { butterfly_4(data, layer_twiddles, num_columns, &butterfly4) }
             }
 
             // skip past all the twiddle factors used in this layer
             let twiddle_offset = num_columns * (ROW_COUNT - 1);
             layer_twiddles = &layer_twiddles[twiddle_offset..];
-
-            cross_fft_len *= ROW_COUNT;
         }
     }
 }
 boilerplate_fft_oop!(Radix4, |this: &Radix4<_>| this.len);
-
-unsafe fn butterfly_4<T: FftNum>(
-    data: &mut [Complex<T>],
-    twiddles: &[Complex<T>],
-    num_ffts: usize,
-    direction: FftDirection,
-) {
-    let butterfly4 = Butterfly4::new(direction);
-
-    let mut idx = 0usize;
-    let mut tw_idx = 0usize;
-    let mut scratch = [Zero::zero(); 4];
-    for _ in 0..num_ffts {
-        scratch[0] = *data.get_unchecked(idx);
-        scratch[1] = *data.get_unchecked(idx + 1 * num_ffts) * twiddles[tw_idx];
-        scratch[2] = *data.get_unchecked(idx + 2 * num_ffts) * twiddles[tw_idx + 1];
-        scratch[3] = *data.get_unchecked(idx + 3 * num_ffts) * twiddles[tw_idx + 2];
-
-        butterfly4.perform_fft_butterfly(&mut scratch);
-
-        *data.get_unchecked_mut(idx) = scratch[0];
-        *data.get_unchecked_mut(idx + 1 * num_ffts) = scratch[1];
-        *data.get_unchecked_mut(idx + 2 * num_ffts) = scratch[2];
-        *data.get_unchecked_mut(idx + 3 * num_ffts) = scratch[3];
-
-        tw_idx += 3;
-        idx += 1;
-    }
-}
 
 #[cfg(test)]
 mod unit_tests {

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -97,7 +97,11 @@ impl<T: FftNum> Radix4<T> {
         } else {
             cross_fft_len
         };
-        let outofplace_scratch_len = base_inplace_scratch;
+        let outofplace_scratch_len = if base_inplace_scratch > len {
+            base_inplace_scratch
+        } else {
+            0
+        };
 
         Self {
             twiddles: twiddle_factors.into_boxed_slice(),

--- a/src/algorithm/radixn.rs
+++ b/src/algorithm/radixn.rs
@@ -138,7 +138,6 @@ impl<T: FftNum> RadixN<T> {
             base_len,
 
             factors: transpose_factors.into_boxed_slice(),
-            //transpose_lookup_table,
             butterflies: butterflies.into_boxed_slice(),
 
             len: cross_fft_len,

--- a/src/algorithm/radixn.rs
+++ b/src/algorithm/radixn.rs
@@ -1,0 +1,450 @@
+use std::sync::Arc;
+
+use num_complex::Complex;
+
+use crate::array_utils::{self, factor_transpose, Load, LoadStore, TransposeFactor};
+use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::{common::FftNum, twiddles, FftDirection};
+use crate::{Direction, Fft, Length, RadixFactor};
+
+use super::butterflies::{Butterfly2, Butterfly3, Butterfly4, Butterfly5, Butterfly6, Butterfly7};
+
+/// FFT algorithm which efficiently computes FFTs with small prime factors.
+///
+/// ~~~
+/// // Computes a forward FFT of size 4096
+/// use rustfft::algorithm::Radix4;
+/// use rustfft::{Fft, FftDirection};
+/// use rustfft::num_complex::Complex;
+///
+/// let mut buffer = vec![Complex{ re: 0.0f32, im: 0.0f32 }; 4096];
+///
+/// let fft = Radix4::new(4096, FftDirection::Forward);
+/// fft.process(&mut buffer);
+/// ~~~
+
+#[repr(u8)]
+enum InternalRadixFactor<T> {
+    Factor2(Butterfly2<T>) = 2,
+    Factor3(Butterfly3<T>) = 3,
+    Factor4(Butterfly4<T>) = 4,
+    Factor5(Butterfly5<T>) = 5,
+    Factor6(Butterfly6<T>) = 6,
+    Factor7(Butterfly7<T>) = 7,
+}
+impl<T> InternalRadixFactor<T> {
+    pub const fn radix(&self) -> usize {
+        unsafe { *(self as *const Self as *const u8) as usize }
+    }
+}
+
+pub struct RadixN<T> {
+    twiddles: Box<[Complex<T>]>,
+
+    base_fft: Arc<dyn Fft<T>>,
+    base_len: usize,
+
+    factors: Box<[TransposeFactor]>,
+    butterflies: Box<[InternalRadixFactor<T>]>,
+
+    len: usize,
+    direction: FftDirection,
+    inplace_scratch_len: usize,
+    outofplace_scratch_len: usize,
+}
+
+impl<T: FftNum> RadixN<T> {
+    /// Constructs a Radix4 instance which computes FFTs of length `factor_product * base_fft.len()`
+    pub fn new(factors: &[RadixFactor], base_fft: Arc<dyn Fft<T>>) -> Self {
+        let base_len = base_fft.len();
+        let direction = base_fft.fft_direction();
+
+        // set up our cross FFT butterfly instances. simultaneously, compute the number of twiddle factors
+        let mut butterflies = Vec::with_capacity(factors.len());
+        let mut cross_fft_len = base_len;
+        let mut twiddle_count = 0;
+
+        for factor in factors {
+            // compute how many twiddles this cross-FFT needs
+            let cross_fft_rows = factor.radix();
+            let cross_fft_columns = cross_fft_len;
+            cross_fft_len *= cross_fft_rows;
+
+            twiddle_count += cross_fft_columns * (cross_fft_rows - 1);
+
+            // set up the butterfly for this cross-FFT
+            let butterfly = match factor {
+                RadixFactor::Factor2 => InternalRadixFactor::Factor2(Butterfly2::new(direction)),
+                RadixFactor::Factor3 => InternalRadixFactor::Factor3(Butterfly3::new(direction)),
+                RadixFactor::Factor4 => InternalRadixFactor::Factor4(Butterfly4::new(direction)),
+                RadixFactor::Factor5 => InternalRadixFactor::Factor5(Butterfly5::new(direction)),
+                RadixFactor::Factor6 => InternalRadixFactor::Factor6(Butterfly6::new(direction)),
+                RadixFactor::Factor7 => InternalRadixFactor::Factor7(Butterfly7::new(direction)),
+            };
+            butterflies.push(butterfly);
+        }
+
+        // set up our list of transpose factors - it's the same list but reversed, and we want to collapse duplicates
+        let mut transpose_factors: Vec<TransposeFactor> = Vec::with_capacity(factors.len());
+        for f in factors.iter().rev() {
+            // I really want let chains for this!
+            let mut push_new = true;
+            if let Some(last) = transpose_factors.last_mut() {
+                if last.factor == *f {
+                    last.count += 1;
+                    push_new = false;
+                }
+            }
+            if push_new {
+                transpose_factors.push(TransposeFactor {
+                    factor: *f,
+                    count: 1,
+                });
+            }
+        }
+
+        // precompute the twiddle factors this algorithm will use.
+        // we're doing the same precomputation of twiddle factors as the mixed radix algorithm where width=factor.radix() and height=len/factor.radix()
+        // but mixed radix only does one step and then calls itself recusrively, and this algorithm does every layer all the way down
+        // so we're going to pack all the "layers" of twiddle factors into a single array, starting with the bottom layer and going up
+        let mut cross_fft_len = base_len;
+        let mut twiddle_factors = Vec::with_capacity(twiddle_count);
+
+        for factor in factors {
+            // Compute the twiddle factors for the cross FFT
+            let cross_fft_columns = cross_fft_len;
+            cross_fft_len *= factor.radix();
+
+            for i in 0..cross_fft_columns {
+                for k in 1..factor.radix() {
+                    let twiddle = twiddles::compute_twiddle(i * k, cross_fft_len, direction);
+                    twiddle_factors.push(twiddle);
+                }
+            }
+        }
+
+        let base_inplace_scratch = base_fft.get_inplace_scratch_len();
+        let inplace_scratch_len = if base_inplace_scratch > cross_fft_len {
+            cross_fft_len + base_inplace_scratch
+        } else {
+            cross_fft_len
+        };
+        let outofplace_scratch_len = base_inplace_scratch;
+
+        Self {
+            twiddles: twiddle_factors.into_boxed_slice(),
+
+            base_fft,
+            base_len,
+
+            factors: transpose_factors.into_boxed_slice(),
+            //transpose_lookup_table,
+            butterflies: butterflies.into_boxed_slice(),
+
+            len: cross_fft_len,
+            direction,
+
+            inplace_scratch_len,
+            outofplace_scratch_len,
+        }
+    }
+
+    fn inplace_scratch_len(&self) -> usize {
+        self.inplace_scratch_len
+    }
+    fn outofplace_scratch_len(&self) -> usize {
+        self.outofplace_scratch_len
+    }
+
+    fn perform_fft_out_of_place(
+        &self,
+        input: &mut [Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        if let Some(unroll_factor) = self.factors.first() {
+            // for performance, we really, really want to unroll the transpose, but we need to make sure the output length is divisible by the unroll amount
+            // choosing the first factor seems to reliably perform well
+            match unroll_factor.factor {
+                RadixFactor::Factor2 => {
+                    factor_transpose::<Complex<T>, 2>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor3 => {
+                    factor_transpose::<Complex<T>, 3>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor4 => {
+                    factor_transpose::<Complex<T>, 4>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor5 => {
+                    factor_transpose::<Complex<T>, 5>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor6 => {
+                    factor_transpose::<Complex<T>, 6>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor7 => {
+                    factor_transpose::<Complex<T>, 7>(self.base_len, input, output, &self.factors)
+                }
+            }
+        } else {
+            // no factors, so just pass data straight to our base
+            output.copy_from_slice(input);
+        }
+
+        // Base-level FFTs
+        let base_scratch = if scratch.len() > 0 { scratch } else { input };
+        self.base_fft.process_with_scratch(output, base_scratch);
+
+        // cross-FFTs
+        let mut cross_fft_len = self.base_len;
+        let mut layer_twiddles: &[Complex<T>] = &self.twiddles;
+
+        for factor in self.butterflies.iter() {
+            let cross_fft_columns = cross_fft_len;
+            cross_fft_len *= factor.radix();
+
+            match factor {
+                InternalRadixFactor::Factor2(butterfly2) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_2(data, layer_twiddles, cross_fft_columns, butterfly2) }
+                    }
+                }
+                InternalRadixFactor::Factor3(butterfly3) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_3(data, layer_twiddles, cross_fft_columns, butterfly3) }
+                    }
+                }
+                InternalRadixFactor::Factor4(butterfly4) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_4(data, layer_twiddles, cross_fft_columns, butterfly4) }
+                    }
+                }
+                InternalRadixFactor::Factor5(butterfly5) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_5(data, layer_twiddles, cross_fft_columns, butterfly5) }
+                    }
+                }
+                InternalRadixFactor::Factor6(butterfly6) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_6(data, layer_twiddles, cross_fft_columns, butterfly6) }
+                    }
+                }
+                InternalRadixFactor::Factor7(butterfly7) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_7(data, layer_twiddles, cross_fft_columns, butterfly7) }
+                    }
+                }
+            }
+
+            // skip past all the twiddle factors used in this layer
+            let twiddle_offset = cross_fft_columns * (factor.radix() - 1);
+            layer_twiddles = &layer_twiddles[twiddle_offset..];
+        }
+    }
+}
+boilerplate_fft_oop!(RadixN, |this: &RadixN<_>| this.len);
+
+#[inline(never)]
+pub(crate) unsafe fn butterfly_2<T: FftNum>(
+    mut data: impl LoadStore<T>,
+    twiddles: impl Load<T>,
+    num_columns: usize,
+    butterfly2: &Butterfly2<T>,
+) {
+    for idx in 0..num_columns {
+        let mut scratch0 = [
+            data.load(idx + 0 * num_columns),
+            data.load(idx + 1 * num_columns) * twiddles.load(idx),
+        ];
+
+        butterfly2.perform_fft_butterfly(&mut scratch0);
+
+        data.store(scratch0[0], idx + num_columns * 0);
+        data.store(scratch0[1], idx + num_columns * 1);
+    }
+}
+
+#[inline(never)]
+pub(crate) unsafe fn butterfly_3<T: FftNum>(
+    mut data: impl LoadStore<T>,
+    twiddles: impl Load<T>,
+    num_columns: usize,
+    butterfly3: &Butterfly3<T>,
+) {
+    for idx in 0..num_columns {
+        let tw_idx = idx * 2;
+        let mut scratch = [
+            data.load(idx + 0 * num_columns),
+            data.load(idx + 1 * num_columns) * twiddles.load(tw_idx + 0),
+            data.load(idx + 2 * num_columns) * twiddles.load(tw_idx + 1),
+        ];
+
+        butterfly3.perform_fft_butterfly(&mut scratch);
+
+        data.store(scratch[0], idx + 0 * num_columns);
+        data.store(scratch[1], idx + 1 * num_columns);
+        data.store(scratch[2], idx + 2 * num_columns);
+    }
+}
+
+#[inline(never)]
+pub(crate) unsafe fn butterfly_4<T: FftNum>(
+    mut data: impl LoadStore<T>,
+    twiddles: impl Load<T>,
+    num_columns: usize,
+    butterfly4: &Butterfly4<T>,
+) {
+    for idx in 0..num_columns {
+        let tw_idx = idx * 3;
+        let mut scratch = [
+            data.load(idx + 0 * num_columns),
+            data.load(idx + 1 * num_columns) * twiddles.load(tw_idx + 0),
+            data.load(idx + 2 * num_columns) * twiddles.load(tw_idx + 1),
+            data.load(idx + 3 * num_columns) * twiddles.load(tw_idx + 2),
+        ];
+
+        butterfly4.perform_fft_butterfly(&mut scratch);
+
+        data.store(scratch[0], idx + 0 * num_columns);
+        data.store(scratch[1], idx + 1 * num_columns);
+        data.store(scratch[2], idx + 2 * num_columns);
+        data.store(scratch[3], idx + 3 * num_columns);
+    }
+}
+
+#[inline(never)]
+pub(crate) unsafe fn butterfly_5<T: FftNum>(
+    mut data: impl LoadStore<T>,
+    twiddles: impl Load<T>,
+    num_columns: usize,
+    butterfly5: &Butterfly5<T>,
+) {
+    for idx in 0..num_columns {
+        let tw_idx = idx * 4;
+        let mut scratch = [
+            data.load(idx + 0 * num_columns),
+            data.load(idx + 1 * num_columns) * twiddles.load(tw_idx + 0),
+            data.load(idx + 2 * num_columns) * twiddles.load(tw_idx + 1),
+            data.load(idx + 3 * num_columns) * twiddles.load(tw_idx + 2),
+            data.load(idx + 4 * num_columns) * twiddles.load(tw_idx + 3),
+        ];
+
+        butterfly5.perform_fft_butterfly(&mut scratch);
+
+        data.store(scratch[0], idx + 0 * num_columns);
+        data.store(scratch[1], idx + 1 * num_columns);
+        data.store(scratch[2], idx + 2 * num_columns);
+        data.store(scratch[3], idx + 3 * num_columns);
+        data.store(scratch[4], idx + 4 * num_columns);
+    }
+}
+
+#[inline(never)]
+pub(crate) unsafe fn butterfly_6<T: FftNum>(
+    mut data: impl LoadStore<T>,
+    twiddles: impl Load<T>,
+    num_columns: usize,
+    butterfly6: &Butterfly6<T>,
+) {
+    for idx in 0..num_columns {
+        let tw_idx = idx * 5;
+        let mut scratch = [
+            data.load(idx + 0 * num_columns),
+            data.load(idx + 1 * num_columns) * twiddles.load(tw_idx + 0),
+            data.load(idx + 2 * num_columns) * twiddles.load(tw_idx + 1),
+            data.load(idx + 3 * num_columns) * twiddles.load(tw_idx + 2),
+            data.load(idx + 4 * num_columns) * twiddles.load(tw_idx + 3),
+            data.load(idx + 5 * num_columns) * twiddles.load(tw_idx + 4),
+        ];
+
+        butterfly6.perform_fft_butterfly(&mut scratch);
+
+        data.store(scratch[0], idx + 0 * num_columns);
+        data.store(scratch[1], idx + 1 * num_columns);
+        data.store(scratch[2], idx + 2 * num_columns);
+        data.store(scratch[3], idx + 3 * num_columns);
+        data.store(scratch[4], idx + 4 * num_columns);
+        data.store(scratch[5], idx + 5 * num_columns);
+    }
+}
+
+#[inline(never)]
+pub(crate) unsafe fn butterfly_7<T: FftNum>(
+    mut data: impl LoadStore<T>,
+    twiddles: impl Load<T>,
+    num_columns: usize,
+    butterfly7: &Butterfly7<T>,
+) {
+    for idx in 0..num_columns {
+        let tw_idx = idx * 6;
+        let mut scratch = [
+            data.load(idx + 0 * num_columns),
+            data.load(idx + 1 * num_columns) * twiddles.load(tw_idx + 0),
+            data.load(idx + 2 * num_columns) * twiddles.load(tw_idx + 1),
+            data.load(idx + 3 * num_columns) * twiddles.load(tw_idx + 2),
+            data.load(idx + 4 * num_columns) * twiddles.load(tw_idx + 3),
+            data.load(idx + 5 * num_columns) * twiddles.load(tw_idx + 4),
+            data.load(idx + 6 * num_columns) * twiddles.load(tw_idx + 5),
+        ];
+
+        butterfly7.perform_fft_butterfly(&mut scratch);
+
+        data.store(scratch[0], idx + 0 * num_columns);
+        data.store(scratch[1], idx + 1 * num_columns);
+        data.store(scratch[2], idx + 2 * num_columns);
+        data.store(scratch[3], idx + 3 * num_columns);
+        data.store(scratch[4], idx + 4 * num_columns);
+        data.store(scratch[5], idx + 5 * num_columns);
+        data.store(scratch[6], idx + 6 * num_columns);
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::test_utils::{check_fft_algorithm, construct_base};
+
+    #[test]
+    fn test_scalar_radixn() {
+        let factor_list = &[
+            RadixFactor::Factor2,
+            RadixFactor::Factor3,
+            RadixFactor::Factor4,
+            RadixFactor::Factor5,
+            RadixFactor::Factor6,
+            RadixFactor::Factor7,
+        ];
+
+        for base in 1..7 {
+            let base_forward = construct_base(base, FftDirection::Forward);
+            let base_inverse = construct_base(base, FftDirection::Inverse);
+
+            // test just the base with no factors
+            test_radixn(&[], Arc::clone(&base_forward));
+            test_radixn(&[], Arc::clone(&base_inverse));
+
+            // test one factor
+            for factor_a in factor_list {
+                let factors = &[*factor_a];
+                test_radixn(factors, Arc::clone(&base_forward));
+                test_radixn(factors, Arc::clone(&base_inverse));
+            }
+
+            // test two factors
+            for factor_a in factor_list {
+                for factor_b in factor_list {
+                    let factors = &[*factor_a, *factor_b];
+                    test_radixn(factors, Arc::clone(&base_forward));
+                    test_radixn(factors, Arc::clone(&base_inverse));
+                }
+            }
+        }
+    }
+
+    fn test_radixn(factors: &[RadixFactor], base_fft: Arc<dyn Fft<f64>>) {
+        let len = base_fft.len() * factors.iter().map(|f| f.radix()).product::<usize>();
+        let direction = base_fft.fft_direction();
+        let fft = RadixN::new(factors, base_fft);
+
+        check_fft_algorithm::<f64>(&fft, len, direction);
+    }
+}

--- a/src/algorithm/radixn.rs
+++ b/src/algorithm/radixn.rs
@@ -25,16 +25,24 @@ use super::butterflies::{Butterfly2, Butterfly3, Butterfly4, Butterfly5, Butterf
 
 #[repr(u8)]
 enum InternalRadixFactor<T> {
-    Factor2(Butterfly2<T>) = 2,
-    Factor3(Butterfly3<T>) = 3,
-    Factor4(Butterfly4<T>) = 4,
-    Factor5(Butterfly5<T>) = 5,
-    Factor6(Butterfly6<T>) = 6,
-    Factor7(Butterfly7<T>) = 7,
+    Factor2(Butterfly2<T>),
+    Factor3(Butterfly3<T>),
+    Factor4(Butterfly4<T>),
+    Factor5(Butterfly5<T>),
+    Factor6(Butterfly6<T>),
+    Factor7(Butterfly7<T>),
 }
 impl<T> InternalRadixFactor<T> {
     pub const fn radix(&self) -> usize {
-        unsafe { *(self as *const Self as *const u8) as usize }
+        // note: if we had rustc 1.66, we could just turn these values explicit discriminators on the enum
+        match self {
+            InternalRadixFactor::Factor2(_) => 2,
+            InternalRadixFactor::Factor3(_) => 3,
+            InternalRadixFactor::Factor4(_) => 4,
+            InternalRadixFactor::Factor5(_) => 5,
+            InternalRadixFactor::Factor6(_) => 6,
+            InternalRadixFactor::Factor7(_) => 7,
+        }
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -284,15 +284,23 @@ macro_rules! boilerplate_fft {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RadixFactor {
-    Factor2 = 2,
-    Factor3 = 3,
-    Factor4 = 4,
-    Factor5 = 5,
-    Factor6 = 6,
-    Factor7 = 7,
+    Factor2,
+    Factor3,
+    Factor4,
+    Factor5,
+    Factor6,
+    Factor7,
 }
 impl RadixFactor {
     pub const fn radix(&self) -> usize {
-        unsafe { *(self as *const Self as *const u8) as usize }
+        // note: if we had rustc 1.66, we could just turn these values explicit discriminators on the enum
+        match self {
+            RadixFactor::Factor2 => 2,
+            RadixFactor::Factor3 => 3,
+            RadixFactor::Factor4 => 4,
+            RadixFactor::Factor5 => 5,
+            RadixFactor::Factor6 => 6,
+            RadixFactor::Factor7 => 7,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ mod twiddles;
 use num_complex::Complex;
 use num_traits::Zero;
 
-pub use crate::common::FftNum;
+pub use crate::common::{FftNum, RadixFactor};
 pub use crate::plan::{FftPlanner, FftPlannerScalar};
 
 /// A trait that allows FFT algorithms to report their expected input/output size

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -190,6 +190,52 @@ impl PrimeFactors {
         self.power_three > 0 && self.power_two == 0 && self.other_factors.len() == 0
     }
 
+    // Divides the number by the given prime factor. Returns None if the resulting number is one.
+    #[allow(unused)]
+    pub fn remove_factors(mut self, factor: PrimeFactor) -> Option<Self> {
+        if factor.count == 0 {
+            return Some(self);
+        }
+        if factor.value == 2 {
+            self.power_two = self.power_two.checked_sub(factor.count).unwrap();
+            self.n >>= factor.count;
+            self.total_factor_count -= factor.count;
+            if self.power_two == 0 {
+                self.distinct_factor_count -= 1;
+            }
+            if self.n > 1 {
+                return Some(self);
+            }
+        } else if factor.value == 3 {
+            self.power_three = self.power_three.checked_sub(factor.count).unwrap();
+            self.n /= 3.pow(factor.count);
+            self.total_factor_count -= factor.count;
+            if self.power_two == 0 {
+                self.distinct_factor_count -= 1;
+            }
+            if self.n > 1 {
+                return Some(self);
+            }
+        } else {
+            let found_factor = self
+                .other_factors
+                .iter_mut()
+                .find(|item| item.value == factor.value)
+                .unwrap();
+            found_factor.count = found_factor.count.checked_sub(factor.count).unwrap();
+            self.n /= factor.value.pow(factor.count);
+            self.total_factor_count -= factor.count;
+            if found_factor.count == 0 {
+                self.distinct_factor_count -= 1;
+                self.other_factors.retain(|item| item.value != factor.value);
+            }
+            if self.n > 1 {
+                return Some(self);
+            }
+        }
+        None
+    }
+
     // returns true if we have any factors whose value is less than or equal to the provided factor
     pub fn has_factors_leq(&self, factor: usize) -> bool {
         self.power_two > 0
@@ -649,6 +695,28 @@ mod unit_tests {
 
                 assert_internally_consistent(&left_factors);
                 assert_internally_consistent(&right_factors);
+            }
+        }
+    }
+
+    #[test]
+    fn test_remove_factors() {
+        // For every possible factor of a bunch of factors, they removing each and making sure the result is internally consistent
+        for n in 2..200 {
+            let factors = PrimeFactors::compute(n);
+
+            for i in 0..=factors.get_power_of_two() {
+                if let Some(removed_factors) = factors
+                    .clone()
+                    .remove_factors(PrimeFactor { value: 2, count: i })
+                {
+                    assert_eq!(removed_factors.get_product(), factors.get_product() >> i);
+                    assert_internally_consistent(&removed_factors);
+                } else {
+                    // If the method returned None, this must be a power of two and i must be equal to the product
+                    assert!(n.is_power_of_two());
+                    assert!(i == factors.get_power_of_two());
+                }
             }
         }
     }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -510,12 +510,12 @@ impl<T: FftNum> FftPlannerScalar<T> {
         let p5 = factors
             .get_other_factors()
             .iter()
-            .find_map(|f| (f.value == 5).then_some(f.count))
+            .find_map(|f| if f.value == 5 { Some(f.count) } else { None }) // if we had rustc 1.62, we could use (f.value == 5).then_some(f.count)
             .unwrap_or(0);
         let p7 = factors
             .get_other_factors()
             .iter()
-            .find_map(|f| (f.value == 7).then_some(f.count))
+            .find_map(|f| if f.value == 7 { Some(f.count) } else { None })
             .unwrap_or(0);
 
         let base_len: usize = if factors.has_factors_gt(MAX_RADIXN_FACTOR) {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -6,8 +6,8 @@ use crate::wasm_simd::wasm_simd_planner::FftPlannerWasmSimd;
 use crate::{common::FftNum, fft_cache::FftCache, FftDirection};
 
 use crate::algorithm::butterflies::*;
-use crate::Fft;
-use crate::{algorithm::*, RadixFactor};
+use crate::algorithm::*;
+use crate::{Fft, RadixFactor};
 
 use crate::FftPlannerAvx;
 use crate::FftPlannerNeon;

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -17,10 +17,6 @@ use std::arch::x86_64::__m128d;
 
 use crate::FftNum;
 
-pub use self::sse_butterflies::*;
-pub use self::sse_prime_butterflies::*;
-pub use self::sse_radix4::*;
-
 use sse_vector::SseVector;
 
 pub trait SseNum: FftNum {

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -113,7 +113,7 @@ fn test_planned_fft_forward_f32() {
     let direction = FftDirection::Forward;
     let cache: ControlCache<f32> = ControlCache::new(TEST_MAX, direction);
 
-    for len in 118..TEST_MAX {
+    for len in 1..TEST_MAX {
         println!("len: {len}");
         let control = cache.plan_fft(len);
         assert_eq!(control.len(), len);

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -113,7 +113,8 @@ fn test_planned_fft_forward_f32() {
     let direction = FftDirection::Forward;
     let cache: ControlCache<f32> = ControlCache::new(TEST_MAX, direction);
 
-    for len in 1..TEST_MAX {
+    for len in 118..TEST_MAX {
+        println!("len: {len}");
         let control = cache.plan_fft(len);
         assert_eq!(control.len(), len);
         assert_eq!(control.fft_direction(), direction);


### PR DESCRIPTION
This PR implements a new FFT algorithm called RadixN, and integrates it into the planner. It efficiently handles FFT sizes containing small prime factors. So far, it's scalar-only, but I intend to port it over to the SIMD implementations next.

The key insight here is that even though we use the same cross-FFT size at every "level" of Radix4, there's no intrinsic limitation that forces us to do so - that's just what we need for powers of four, so that's what radix4 does.

RadixN removes this restriction, allowing every cross-FFT to have a different butterfly size. I picked 2,3,4,5,6, and 7 as the initial butterflies, but if it improves performance to add 9 or 10 or 11 for example, I'm open to adding it. If we add a lot of composite sizes, I suspect there will be a combinatoric explosion of complexity of which overlapping sets of factors to choose from (Ie, if we have 2 * 3 * 5, we could collapse that to 3 * 10, or 6 * 5, or 2 * 15, which is fastest? it gets messy really fast, so if we start adding more composites than we have now i'd like it to come with an architecture for managing that complexity.

RadixN can handle factors larger than its largest butterfly length, by using those larger factors as its base FFT length. For example, RadixN can gracefully handle something like 4 * 9 * 5 * 7 * 101, by processing the 4 * 9 * 5 * 7 internally, and using 101 as the base FFT size.

Benchmarking shows that RadixN is marginally worse than Radix4 at power of two sizes, as you might expect given that it has more branches, etc. So the planner still uses Radix4 when computing 4*k * base, and still tries to maneuver the base to make 4^k happen.

Where the performance of RadixN really shines is in collections of small factors - For 44100 (2^2 * 3^2 * 5^2 * 7^2), we get a 60% improvement:
```
test bench_radixn_44100_planned                      ... bench:     741,795 ns/iter (+/- 38,680)
test bench_radixn_44100_radixn                       ... bench:     453,662 ns/iter (+/- 12,686)
```

For 48000 (2^7 * 3 * 5^3) we get a 45% improvement:
```
test bench_radixn_48000_planned                      ... bench:     685,025 ns/iter (+/- 28,818)
test bench_radixn_48000_radixn                       ... bench:     469,620 ns/iter (+/- 11,005)
```

These improvements come from eliminating the overhead associated with the multiple transposes that MixedRadix does. I was inspired by a comment from #65 - "With this shuffler, there is no need to use mixer radix for long ffts, since radix4 is now the fastest also there." I remembered this quote, and wondered - if it's true for powers of two, why wouldn't it also be true for non powers of two?

I plan to do one more pass of cleanup and clarity before submitting, and then like I said I'll port it over to the SIMD implementations.