### PR TITLE
Require `Float` trait for `FftNum` supertrait

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,10 @@
-use num_traits::{FromPrimitive, Signed};
+use num_traits::{Float, FromPrimitive, Signed};
 use std::fmt::Debug;
 
 /// Generic floating point number, implemented for f32 and f64
-pub trait FftNum: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
+pub trait FftNum: Float + Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
 
-impl<T> FftNum for T where T: Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
+impl<T> FftNum for T where T: Float + Copy + FromPrimitive + Signed + Sync + Send + Debug + 'static {}
 
 // Prints an error raised by an in-place FFT algorithm's `process_inplace` method
 // Marked cold and inline never to keep all formatting code out of the many monomorphized process_inplace methods


### PR DESCRIPTION
Based on [its doc comment](https://docs.rs/rustfft/latest/rustfft/trait.FftNum.html), `FftNum` was intended to only work with `f32`s and `f64`s. As a side note, is this comment correct in that other forms of `Float` (like `f128`) aren't implemented?

I'm hardly an expert on FFTs, so maybe there's some use case for this that I'm not aware of, but the values left after processing an FFT with integer types seem to be just garbage. This PR is intended to prevent users inexperienced with DFTs (like me) from doing something nonsensical.

This PR prevents the following code from compiling:
```rust
use rustfft::{FftPlanner, num_complex::Complex};

let mut planner = FftPlanner::<i32>::new();
let fft = planner.plan_fft_forward(1234);

let mut buffer = vec![Complex{ re: 0, im: 0 }; 1234];
```

I would add a test to ensure that the above code fails to compile, but [`compile_fail`](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html?highlight=compile_fail#attributes) seems to be the only option, and I wasn't sure where a doc comment like that should live within this crate.