### PR TITLE
Fix the `FftPlanner` not being `Sync`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,9 @@ bumpalo = "=3.14.0"
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 libc = "=0.2.163"
 
+# we don't need once_cell directly, but a dependency does, and version 1.21+ requires rustc 1.66+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+once_cell = "=1.20.2"
+
 [build-dependencies]
 version_check = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,9 @@ wasm-bindgen-test = "^0.3.36"
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 bumpalo = "=3.14.0"
 
+# we don't need libc directly, but a dependency does, and version 0.2.164+ requires rustc 1.63+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+libc = "=0.2.163"
+
 [build-dependencies]
 version_check = "0.9"

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -7,7 +7,11 @@ use rustfft::num_complex::Complex32;
 use rustfft::FftPlanner;
 
 fn main() {
-    let mut planner = FftPlanner::new();
+    // Verify that the planner is sync + send
+    fn test_sync<T: Sync + Send>(val: T) -> T {
+        val
+    }
+    let mut planner = test_sync(FftPlanner::new());
     let fft = planner.plan_fft_forward(100);
 
     let threads: Vec<thread::JoinHandle<_>> = (0..2)

--- a/src/avx/avx_planner.rs
+++ b/src/avx/avx_planner.rs
@@ -191,7 +191,7 @@ impl<T: FftNum> FftPlannerAvx<T> {
     }
 }
 
-trait AvxPlannerInternalAPI<T: FftNum>: Send {
+trait AvxPlannerInternalAPI<T: FftNum>: Send + Sync {
     fn plan_and_construct_fft(&mut self, len: usize, direction: FftDirection) -> Arc<dyn Fft<T>>;
     fn debug_plan_fft(&self, len: usize, direction: FftDirection) -> MixedRadixPlan;
 }


### PR DESCRIPTION
Added `Sync` to the supertraits of `AvxPlannerInternalAPI`, and added code in our tests that won't compile if the `FftPlanner` isn't `Sync`, so that we catch this immediately if it happens again.