### PR TITLE
Adding process_immutable_with_scratch method

### DIFF
--- a/benches/bench_rustfft.rs
+++ b/benches/bench_rustfft.rs
@@ -23,6 +23,13 @@ impl<T: FftNum> Fft<T> for Noop {
     fn process_outofplace_with_scratch(&self, _input: &mut [Complex<T>], _output: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {}
     fn get_inplace_scratch_len(&self) -> usize { self.len }
     fn get_outofplace_scratch_len(&self) -> usize { 0 }
+    fn process_immutable_with_scratch(
+        &self,
+        _input: &[Complex<T>],
+        _output: &mut [Complex<T>],
+        _scratch: &mut [Complex<T>],
+    ) {}
+    fn get_immutable_scratch_len(&self) -> usize { 0 }
 }
 impl Length for Noop {
     fn len(&self) -> usize { self.len }

--- a/benches/bench_rustfft_scalar.rs
+++ b/benches/bench_rustfft_scalar.rs
@@ -33,6 +33,16 @@ impl<T: FftNum> Fft<T> for Noop {
     fn get_outofplace_scratch_len(&self) -> usize {
         0
     }
+    
+    fn process_immutable_with_scratch(
+        &self,
+        _input: &[Complex<T>],
+        _output: &mut [Complex<T>],
+        _scratch: &mut [Complex<T>],
+    ) {
+    }
+    
+    fn get_immutable_scratch_len(&self) -> usize { 0 }
 }
 impl Length for Noop {
     fn len(&self) -> usize {

--- a/src/algorithm/bluesteins_algorithm.rs
+++ b/src/algorithm/bluesteins_algorithm.rs
@@ -137,9 +137,10 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
         }
     }
 
-    fn perform_fft_out_of_place(
+    #[inline]
+    fn perform_fft_immut(
         &self,
-        input: &mut [Complex<T>],
+        input: &[Complex<T>],
         output: &mut [Complex<T>],
         scratch: &mut [Complex<T>],
     ) {
@@ -179,6 +180,15 @@ impl<T: FftNum> BluesteinsAlgorithm<T> {
             *buffer_entry = inner_entry.conj() * twiddle;
         }
     }
+
+    fn perform_fft_out_of_place(
+        &self,
+        input: &mut [Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        self.perform_fft_immut(input, output, scratch);
+    }
 }
 boilerplate_fft!(
     BluesteinsAlgorithm,
@@ -186,7 +196,9 @@ boilerplate_fft!(
     |this: &BluesteinsAlgorithm<_>| this.inner_fft_multiplier.len()
         + this.inner_fft.get_inplace_scratch_len(), // in-place scratch len
     |this: &BluesteinsAlgorithm<_>| this.inner_fft_multiplier.len()
-        + this.inner_fft.get_inplace_scratch_len()  // out of place scratch len
+        + this.inner_fft.get_inplace_scratch_len(), // out of place scratch len
+    |this: &BluesteinsAlgorithm<_>| this.inner_fft_multiplier.len()
+        + this.inner_fft.get_inplace_scratch_len()  // immut scratch len
 );
 
 #[cfg(test)]

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -3,7 +3,7 @@ use num_complex::Complex;
 use crate::{common::FftNum, FftDirection};
 
 use crate::array_utils::{self, DoubleBuf, LoadStore};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::common::{fft_error_inplace, fft_error_outofplace, fft_error_immut};
 use crate::twiddles;
 use crate::{Direction, Fft, Length};
 
@@ -26,8 +26,8 @@ macro_rules! boilerplate_fft_butterfly {
             ) {
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let result = array_utils::iter_chunks_zipped(

--- a/src/algorithm/butterflies.rs
+++ b/src/algorithm/butterflies.rs
@@ -3,7 +3,7 @@ use num_complex::Complex;
 use crate::{common::FftNum, FftDirection};
 
 use crate::array_utils::{self, DoubleBuf, LoadStore};
-use crate::common::{fft_error_inplace, fft_error_outofplace, fft_error_immut};
+use crate::common::{fft_error_immut, fft_error_inplace, fft_error_outofplace};
 use crate::twiddles;
 use crate::{Direction, Fft, Length};
 

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -51,15 +51,6 @@ impl<T: FftNum> Dft<T> {
         spectrum: &mut [Complex<T>],
         _scratch: &mut [Complex<T>],
     ) {
-        self.perform_fft_out_of_place(signal, spectrum, _scratch);
-    }
-
-    fn perform_fft_out_of_place(
-        &self,
-        signal: &[Complex<T>],
-        spectrum: &mut [Complex<T>],
-        _scratch: &mut [Complex<T>],
-    ) {
         for k in 0..spectrum.len() {
             let output_cell = spectrum.get_mut(k).unwrap();
 
@@ -76,6 +67,15 @@ impl<T: FftNum> Dft<T> {
                 }
             }
         }
+    }
+
+    fn perform_fft_out_of_place(
+        &self,
+        signal: &[Complex<T>],
+        spectrum: &mut [Complex<T>],
+        _scratch: &mut [Complex<T>],
+    ) {
+        self.perform_fft_immut(signal, spectrum, _scratch);
     }
 }
 boilerplate_fft_oop!(Dft, |this: &Dft<_>| this.twiddles.len());

--- a/src/algorithm/dft.rs
+++ b/src/algorithm/dft.rs
@@ -45,6 +45,15 @@ impl<T: FftNum> Dft<T> {
         0
     }
 
+    fn perform_fft_immut(
+        &self,
+        signal: &[Complex<T>],
+        spectrum: &mut [Complex<T>],
+        _scratch: &mut [Complex<T>],
+    ) {
+        self.perform_fft_out_of_place(signal, spectrum, _scratch);
+    }
+
     fn perform_fft_out_of_place(
         &self,
         signal: &[Complex<T>],

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -50,6 +50,7 @@ pub struct GoodThomasAlgorithm<T> {
 
     inplace_scratch_len: usize,
     outofplace_scratch_len: usize,
+    immut_scratch_len: usize,
 
     len: usize,
     direction: FftDirection,
@@ -116,6 +117,13 @@ impl<T: FftNum> GoodThomasAlgorithm<T> {
                 },
                 height_outofplace_scratch,
             );
+        let height_fft_immut = height_fft.get_immutable_scratch_len();
+        let width_fft_immut = width_fft.get_immutable_scratch_len();
+
+        let immut_scratch_len = 2 * max(
+            max(height_fft_immut, width_fft_immut),
+            max(outofplace_scratch_len, inplace_scratch_len),
+        );
 
         Self {
             width,
@@ -129,6 +137,7 @@ impl<T: FftNum> GoodThomasAlgorithm<T> {
 
             inplace_scratch_len,
             outofplace_scratch_len,
+            immut_scratch_len,
 
             len,
             direction,
@@ -241,6 +250,30 @@ impl<T: FftNum> GoodThomasAlgorithm<T> {
         self.reindex_output(scratch, buffer);
     }
 
+    fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        let (scratch, scratch2) = scratch.split_at_mut(scratch.len() / 2);
+        // Re-index the input, copying from the input to the output in the process
+        self.reindex_input(input, output);
+
+        // run FFTs of size `width`
+        self.width_size_fft.process_with_scratch(output, scratch);
+
+        let scratch = &mut scratch[..output.len()];
+        // transpose
+        transpose::transpose(output, scratch, self.width, self.height);
+
+        // run FFTs of size 'height'
+        self.height_size_fft.process_with_scratch(scratch, scratch2);
+
+        // Re-index the output, copying from the input to the output in the process
+        self.reindex_output(scratch, output);
+    }
+
     fn perform_fft_out_of_place(
         &self,
         input: &mut [Complex<T>],
@@ -279,7 +312,8 @@ boilerplate_fft!(
     GoodThomasAlgorithm,
     |this: &GoodThomasAlgorithm<_>| this.len,
     |this: &GoodThomasAlgorithm<_>| this.inplace_scratch_len,
-    |this: &GoodThomasAlgorithm<_>| this.outofplace_scratch_len
+    |this: &GoodThomasAlgorithm<_>| this.outofplace_scratch_len,
+    |this: &GoodThomasAlgorithm<_>| this.immut_scratch_len
 );
 
 /// Implementation of the Good-Thomas Algorithm, specialized for smaller input sizes
@@ -384,6 +418,38 @@ impl<T: FftNum> GoodThomasAlgorithmSmall<T> {
         }
     }
 
+    fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        // These asserts are for the unsafe blocks down below. we're relying on the optimizer to get rid of this assert
+        assert_eq!(self.len(), input.len());
+        assert_eq!(self.len(), output.len());
+
+        let (input_map, output_map) = self.input_output_map.split_at(self.len());
+
+        // copy the input using our reordering mapping
+        for (output_element, &input_index) in output.iter_mut().zip(input_map.iter()) {
+            *output_element = input[input_index];
+        }
+
+        // run FFTs of size `width`
+        self.width_size_fft.process_with_scratch(output, scratch);
+
+        // transpose
+        unsafe { array_utils::transpose_small(self.width, self.height, output, scratch) };
+
+        // run FFTs of size 'height'
+        self.height_size_fft.process_with_scratch(scratch, output);
+
+        // copy to the output, using our output redordeing mapping
+        for (input_element, &output_index) in scratch.iter().zip(output_map.iter()) {
+            output[output_index] = *input_element;
+        }
+    }
+
     fn perform_fft_out_of_place(
         &self,
         input: &mut [Complex<T>],
@@ -448,7 +514,8 @@ boilerplate_fft!(
     GoodThomasAlgorithmSmall,
     |this: &GoodThomasAlgorithmSmall<_>| this.width * this.height,
     |this: &GoodThomasAlgorithmSmall<_>| this.len(),
-    |_| 0
+    |_| 0,
+    |this: &GoodThomasAlgorithmSmall<_>| this.len()
 );
 
 #[cfg(test)]
@@ -532,12 +599,15 @@ mod unit_tests {
         for &len in &scratch_lengths {
             for &inplace_scratch in &scratch_lengths {
                 for &outofplace_scratch in &scratch_lengths {
-                    inner_ffts.push(Arc::new(BigScratchAlgorithm {
-                        len,
-                        inplace_scratch,
-                        outofplace_scratch,
-                        direction: FftDirection::Forward,
-                    }) as Arc<dyn Fft<f32>>);
+                    for &immut_scratch in &scratch_lengths {
+                        inner_ffts.push(Arc::new(BigScratchAlgorithm {
+                            len,
+                            inplace_scratch,
+                            outofplace_scratch,
+                            direction: FftDirection::Forward,
+                            immut_scratch,
+                        }) as Arc<dyn Fft<f32>>);
+                    }
                 }
             }
         }
@@ -564,6 +634,16 @@ mod unit_tests {
                     &mut outofplace_input,
                     &mut outofplace_output,
                     &mut outofplace_scratch,
+                );
+
+                let immut_input = vec![Complex::zero(); fft.len()];
+                let mut immut_output = vec![Complex::zero(); fft.len()];
+                let mut immut_scratch = vec![Complex::zero(); fft.get_immutable_scratch_len()];
+
+                fft.process_immutable_with_scratch(
+                    &immut_input,
+                    &mut immut_output,
+                    &mut immut_scratch,
                 );
             }
         }

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -168,7 +168,8 @@ impl<T: FftNum> MixedRadix<T> {
         transpose::transpose(input, output, self.width, self.height);
 
         // STEP 2: perform FFTs of size `height`
-        self.height_size_fft.process_with_scratch(output, scratch_raw);
+        self.height_size_fft
+            .process_with_scratch(output, scratch_raw);
 
         // STEP 3: Apply twiddle factors
         for (element, twiddle) in output.iter_mut().zip(self.twiddles.iter()) {
@@ -181,7 +182,8 @@ impl<T: FftNum> MixedRadix<T> {
         transpose::transpose(output, scratch, self.height, self.width);
 
         // STEP 5: perform FFTs of size `width`
-        self.width_size_fft.process_with_scratch(scratch, inner_scratch);
+        self.width_size_fft
+            .process_with_scratch(scratch, inner_scratch);
 
         // STEP 6: transpose again
         transpose::transpose(scratch, output, self.width, self.height);

--- a/src/algorithm/raders_algorithm.rs
+++ b/src/algorithm/raders_algorithm.rs
@@ -103,7 +103,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
             required_inner_scratch
         };
         let inplace_scratch_len = inner_fft_len + extra_inner_scratch;
-        let immut_scratch_len = inplace_scratch_len * 2;
+        let immut_scratch_len = inner_fft_len + required_inner_scratch;
 
         //precompute a FFT of our reordered twiddle factors
         let mut inner_fft_scratch = vec![Zero::zero(); required_inner_scratch];
@@ -117,7 +117,7 @@ impl<T: FftNum> RadersAlgorithm<T> {
             primitive_root_inverse,
 
             len: reduced_len,
-            inplace_scratch_len: inner_fft_len + extra_inner_scratch,
+            inplace_scratch_len,
             outofplace_scratch_len: extra_inner_scratch,
             immut_scratch_len,
             direction,

--- a/src/algorithm/radix3.rs
+++ b/src/algorithm/radix3.rs
@@ -118,8 +118,17 @@ impl<T: FftNum> Radix3<T> {
         self.outofplace_scratch_len
     }
 
-    #[inline]
     fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        self.perform_fft_out_of_place(input, output, scratch);
+    }
+
+    #[inline]
+    fn perform_fft_out_of_place(
         &self,
         input: &[Complex<T>],
         output: &mut [Complex<T>],
@@ -152,15 +161,6 @@ impl<T: FftNum> Radix3<T> {
             let twiddle_offset = num_columns * (ROW_COUNT - 1);
             layer_twiddles = &layer_twiddles[twiddle_offset..];
         }
-    }
-
-    fn perform_fft_out_of_place(
-        &self,
-        input: &mut [Complex<T>],
-        output: &mut [Complex<T>],
-        scratch: &mut [Complex<T>],
-    ) {
-        self.perform_fft_immut(input, output, scratch);
     }
 }
 boilerplate_fft_oop!(Radix3, |this: &Radix3<_>| this.len);

--- a/src/algorithm/radix3.rs
+++ b/src/algorithm/radix3.rs
@@ -118,9 +118,10 @@ impl<T: FftNum> Radix3<T> {
         self.outofplace_scratch_len
     }
 
-    fn perform_fft_out_of_place(
+    #[inline]
+    fn perform_fft_immut(
         &self,
-        input: &mut [Complex<T>],
+        input: &[Complex<T>],
         output: &mut [Complex<T>],
         scratch: &mut [Complex<T>],
     ) {
@@ -132,8 +133,7 @@ impl<T: FftNum> Radix3<T> {
         }
 
         // Base-level FFTs
-        let base_scratch = if scratch.len() > 0 { scratch } else { input };
-        self.base_fft.process_with_scratch(output, base_scratch);
+        self.base_fft.process_with_scratch(output, scratch);
 
         // cross-FFTs
         const ROW_COUNT: usize = 3;
@@ -152,6 +152,15 @@ impl<T: FftNum> Radix3<T> {
             let twiddle_offset = num_columns * (ROW_COUNT - 1);
             layer_twiddles = &layer_twiddles[twiddle_offset..];
         }
+    }
+
+    fn perform_fft_out_of_place(
+        &self,
+        input: &mut [Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        self.perform_fft_immut(input, output, scratch);
     }
 }
 boilerplate_fft_oop!(Radix3, |this: &Radix3<_>| this.len);

--- a/src/algorithm/radix4.rs
+++ b/src/algorithm/radix4.rs
@@ -124,6 +124,43 @@ impl<T: FftNum> Radix4<T> {
         self.outofplace_scratch_len
     }
 
+    #[inline]
+    fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        // copy the data into the output vector
+        if self.len() == self.base_len {
+            output.copy_from_slice(input);
+        } else {
+            bitreversed_transpose::<Complex<T>, 4>(self.base_len, input, output);
+        }
+
+        self.base_fft.process_with_scratch(output, scratch);
+
+        // cross-FFTs
+        const ROW_COUNT: usize = 4;
+        let mut cross_fft_len = self.base_len;
+        let mut layer_twiddles: &[Complex<T>] = &self.twiddles;
+
+        let butterfly4 = Butterfly4::new(self.direction);
+
+        while cross_fft_len < output.len() {
+            let num_columns = cross_fft_len;
+            cross_fft_len *= ROW_COUNT;
+
+            for data in output.chunks_exact_mut(cross_fft_len) {
+                unsafe { butterfly_4(data, layer_twiddles, num_columns, &butterfly4) }
+            }
+
+            // skip past all the twiddle factors used in this layer
+            let twiddle_offset = num_columns * (ROW_COUNT - 1);
+            layer_twiddles = &layer_twiddles[twiddle_offset..];
+        }
+    }
+
     fn perform_fft_out_of_place(
         &self,
         input: &mut [Complex<T>],

--- a/src/algorithm/radixn.rs
+++ b/src/algorithm/radixn.rs
@@ -158,6 +158,89 @@ impl<T: FftNum> RadixN<T> {
         self.outofplace_scratch_len
     }
 
+    fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        if let Some(unroll_factor) = self.factors.first() {
+            // for performance, we really, really want to unroll the transpose, but we need to make sure the output length is divisible by the unroll amount
+            // choosing the first factor seems to reliably perform well
+            match unroll_factor.factor {
+                RadixFactor::Factor2 => {
+                    factor_transpose::<Complex<T>, 2>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor3 => {
+                    factor_transpose::<Complex<T>, 3>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor4 => {
+                    factor_transpose::<Complex<T>, 4>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor5 => {
+                    factor_transpose::<Complex<T>, 5>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor6 => {
+                    factor_transpose::<Complex<T>, 6>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor7 => {
+                    factor_transpose::<Complex<T>, 7>(self.base_len, input, output, &self.factors)
+                }
+            }
+        } else {
+            // no factors, so just pass data straight to our base
+            output.copy_from_slice(input);
+        }
+
+        // Base-level FFTs
+        self.base_fft.process_with_scratch(output, scratch);
+
+        let mut cross_fft_len = self.base_len;
+        let mut layer_twiddles: &[Complex<T>] = &self.twiddles;
+
+        for factor in self.butterflies.iter() {
+            let cross_fft_columns = cross_fft_len;
+            cross_fft_len *= factor.radix();
+
+            match factor {
+                InternalRadixFactor::Factor2(butterfly2) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_2(data, layer_twiddles, cross_fft_columns, butterfly2) }
+                    }
+                }
+                InternalRadixFactor::Factor3(butterfly3) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_3(data, layer_twiddles, cross_fft_columns, butterfly3) }
+                    }
+                }
+                InternalRadixFactor::Factor4(butterfly4) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_4(data, layer_twiddles, cross_fft_columns, butterfly4) }
+                    }
+                }
+                InternalRadixFactor::Factor5(butterfly5) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_5(data, layer_twiddles, cross_fft_columns, butterfly5) }
+                    }
+                }
+                InternalRadixFactor::Factor6(butterfly6) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_6(data, layer_twiddles, cross_fft_columns, butterfly6) }
+                    }
+                }
+                InternalRadixFactor::Factor7(butterfly7) => {
+                    for data in output.chunks_exact_mut(cross_fft_len) {
+                        unsafe { butterfly_7(data, layer_twiddles, cross_fft_columns, butterfly7) }
+                    }
+                }
+            }
+
+            // skip past all the twiddle factors used in this layer
+            let twiddle_offset = cross_fft_columns * (factor.radix() - 1);
+            layer_twiddles = &layer_twiddles[twiddle_offset..];
+        }
+    }
+
     fn perform_fft_out_of_place(
         &self,
         input: &mut [Complex<T>],

--- a/src/array_utils.rs
+++ b/src/array_utils.rs
@@ -145,7 +145,7 @@ mod unit_tests {
 
 // Loop over exact chunks of the provided buffer. Very similar in semantics to ChunksExactMut, but generates smaller code and requires no modulo operations
 // Returns Ok() if every element ended up in a chunk, Err() if there was a remainder
-pub fn iter_chunks<T>(
+pub fn iter_chunks_mut<T>(
     mut buffer: &mut [T],
     chunk_size: usize,
     mut chunk_fn: impl FnMut(&mut [T]),
@@ -169,20 +169,62 @@ pub fn iter_chunks<T>(
 // Loop over exact zipped chunks of the 2 provided buffers. Very similar in semantics to ChunksExactMut.zip(ChunksExactMut), but generates smaller code and requires no modulo operations
 // Returns Ok() if every element of both buffers ended up in a chunk, Err() if there was a remainder
 pub fn iter_chunks_zipped<T>(
+    mut buffer1: &[T],
+    mut buffer2: &mut [T],
+    chunk_size: usize,
+    mut chunk_fn: impl FnMut(&[T], &mut [T]),
+) -> Result<(), ()> {
+    // If the two buffers aren't the same size, record the fact that they're different, then snip them to be the same size
+    let uneven = match buffer1.len().cmp(&buffer2.len()) {
+        std::cmp::Ordering::Less => {
+            buffer2 = &mut buffer2[..buffer1.len()];
+            true
+        }
+        std::cmp::Ordering::Equal => false,
+        std::cmp::Ordering::Greater => {
+            buffer1 = &buffer1[..buffer2.len()];
+            true
+        }
+    };
+
+    // Now that we know the two slices are the same length, loop over each one, splicing off chunk_size at a time, and calling chunk_fn on each
+    while buffer1.len() >= chunk_size && buffer2.len() >= chunk_size {
+        let (head1, tail1) = buffer1.split_at(chunk_size);
+        buffer1 = tail1;
+
+        let (head2, tail2) = buffer2.split_at_mut(chunk_size);
+        buffer2 = tail2;
+
+        chunk_fn(head1, head2);
+    }
+
+    // We have a remainder if the 2 chunks were uneven to start with, or if there's still data in the buffers -- in which case we want to indicate to the caller that there was an unwanted remainder
+    if !uneven && buffer1.len() == 0 {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+// Loop over exact zipped chunks of the 2 provided buffers. Very similar in semantics to ChunksExactMut.zip(ChunksExactMut), but generates smaller code and requires no modulo operations
+// Returns Ok() if every element of both buffers ended up in a chunk, Err() if there was a remainder
+pub fn iter_chunks_zipped_mut<T>(
     mut buffer1: &mut [T],
     mut buffer2: &mut [T],
     chunk_size: usize,
     mut chunk_fn: impl FnMut(&mut [T], &mut [T]),
 ) -> Result<(), ()> {
     // If the two buffers aren't the same size, record the fact that they're different, then snip them to be the same size
-    let uneven = if buffer1.len() > buffer2.len() {
-        buffer1 = &mut buffer1[..buffer2.len()];
-        true
-    } else if buffer2.len() < buffer1.len() {
-        buffer2 = &mut buffer2[..buffer1.len()];
-        true
-    } else {
-        false
+    let uneven = match buffer1.len().cmp(&buffer2.len()) {
+        std::cmp::Ordering::Less => {
+            buffer2 = &mut buffer2[..buffer1.len()];
+            true
+        }
+        std::cmp::Ordering::Equal => false,
+        std::cmp::Ordering::Greater => {
+            buffer1 = &mut buffer1[..buffer2.len()];
+            true
+        }
     };
 
     // Now that we know the two slices are the same length, loop over each one, splicing off chunk_size at a time, and calling chunk_fn on each

--- a/src/avx/avx32_butterflies.rs
+++ b/src/avx/avx32_butterflies.rs
@@ -5,8 +5,8 @@ use std::mem::MaybeUninit;
 use num_complex::Complex;
 
 use crate::array_utils;
-use crate::array_utils::workaround_transmute_mut;
 use crate::array_utils::DoubleBuf;
+use crate::array_utils::*;
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles};
 use crate::{Direction, Fft, FftDirection, Length};
@@ -37,9 +37,9 @@ macro_rules! boilerplate_fft_simd_butterfly {
         }
 
         impl<T: FftNum> Fft<T> for $struct_name<f32> {
-            fn process_outofplace_with_scratch(
+            fn process_immutable_with_scratch(
                 &self,
-                input: &mut [Complex<T>],
+                input: &[Complex<T>],
                 output: &mut [Complex<T>],
                 _scratch: &mut [Complex<T>],
             ) {
@@ -56,7 +56,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     |in_chunk, out_chunk| {
                         unsafe {
                             // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
-                            let input_slice = workaround_transmute_mut(in_chunk);
+                            let input_slice = workaround_transmute(in_chunk);
                             let output_slice = workaround_transmute_mut(out_chunk);
                             self.perform_fft_f32(DoubleBuf {
                                 input: input_slice,
@@ -72,6 +72,14 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
+            fn process_outofplace_with_scratch(
+                &self,
+                input: &mut [Complex<T>],
+                output: &mut [Complex<T>],
+                _scratch: &mut [Complex<T>],
+            ) {
+                self.process_immutable_with_scratch(input, output, _scratch);
+            }
             fn process_with_scratch(&self, buffer: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {
                 if buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
@@ -79,7 +87,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
 
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     unsafe {
                         // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
                         self.perform_fft_f32(workaround_transmute_mut::<_, Complex<f32>>(chunk));
@@ -98,6 +106,10 @@ macro_rules! boilerplate_fft_simd_butterfly {
             }
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
+                0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
                 0
             }
         }
@@ -156,10 +168,11 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             }
 
             #[inline]
-            fn perform_fft_out_of_place(
+            fn perform_fft_immut(
                 &self,
-                input: &mut [Complex<f32>],
+                input: &[Complex<f32>],
                 output: &mut [Complex<f32>],
+                _scratch: &mut [Complex<f32>],
             ) {
                 // Perform the column FFTs
                 // Safety: self.perform_column_butterflies() requres the "avx" and "fma" instruction sets, and we return Err() in our constructor if the instructions aren't available
@@ -169,8 +182,51 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                 // Safety: self.transpose() requres the "avx" instruction set, and we return Err() in our constructor if the instructions aren't available
                 unsafe { self.row_butterflies(output) };
             }
+
+            #[inline]
+            fn perform_fft_out_of_place(
+                &self,
+                input: &mut [Complex<f32>],
+                output: &mut [Complex<f32>],
+            ) {
+                self.perform_fft_immut(input, output, &mut []);
+            }
         }
         impl<T: FftNum> Fft<T> for $struct_name<f32> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+                let transmuted_input: &[Complex<f32>] =
+                    unsafe { array_utils::workaround_transmute(input) };
+                let transmuted_output: &mut [Complex<f32>] =
+                    unsafe { array_utils::workaround_transmute_mut(output) };
+                let transmuted_scratch: &mut [Complex<f32>] =
+                    unsafe { array_utils::workaround_transmute_mut(scratch) };
+                let result = array_utils::iter_chunks_zipped(
+                    transmuted_input,
+                    transmuted_output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        self.perform_fft_immut(in_chunk, out_chunk, transmuted_scratch)
+                    },
+                );
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -188,7 +244,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     unsafe { array_utils::workaround_transmute_mut(input) };
                 let transmuted_output: &mut [Complex<f32>] =
                     unsafe { array_utils::workaround_transmute_mut(output) };
-                let result = array_utils::iter_chunks_zipped(
+                let result = array_utils::iter_chunks_zipped_mut(
                     transmuted_input,
                     transmuted_output,
                     self.len(),
@@ -216,7 +272,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     unsafe { array_utils::workaround_transmute_mut(buffer) };
                 let transmuted_scratch: &mut [Complex<f32>] =
                     unsafe { array_utils::workaround_transmute_mut(scratch) };
-                let result = array_utils::iter_chunks(transmuted_buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(transmuted_buffer, self.len(), |chunk| {
                     self.perform_fft_inplace(chunk, transmuted_scratch)
                 });
 
@@ -232,6 +288,10 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             }
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
+                0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
                 0
             }
         }

--- a/src/avx/avx32_butterflies.rs
+++ b/src/avx/avx32_butterflies.rs
@@ -6,8 +6,8 @@ use num_complex::Complex;
 
 use crate::array_utils;
 use crate::array_utils::DoubleBuf;
-use crate::array_utils::*;
-use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::array_utils::{workaround_transmute, workaround_transmute_mut};
+use crate::common::{fft_error_immut, fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles};
 use crate::{Direction, Fft, FftDirection, Length};
 
@@ -45,8 +45,8 @@ macro_rules! boilerplate_fft_simd_butterfly {
             ) {
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let result = array_utils::iter_chunks_zipped(
@@ -201,8 +201,8 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             ) {
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary

--- a/src/avx/avx64_butterflies.rs
+++ b/src/avx/avx64_butterflies.rs
@@ -5,8 +5,8 @@ use std::mem::MaybeUninit;
 use num_complex::Complex;
 
 use crate::array_utils;
-use crate::array_utils::workaround_transmute_mut;
 use crate::array_utils::DoubleBuf;
+use crate::array_utils::{workaround_transmute, workaround_transmute_mut};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles};
 use crate::{Direction, Fft, FftDirection, Length};
@@ -35,9 +35,9 @@ macro_rules! boilerplate_fft_simd_butterfly {
             }
         }
         impl<T: FftNum> Fft<T> for $struct_name<f64> {
-            fn process_outofplace_with_scratch(
+            fn process_immutable_with_scratch(
                 &self,
-                input: &mut [Complex<T>],
+                input: &[Complex<T>],
                 output: &mut [Complex<T>],
                 _scratch: &mut [Complex<T>],
             ) {
@@ -54,7 +54,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     |in_chunk, out_chunk| {
                         unsafe {
                             // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
-                            let input_slice = workaround_transmute_mut(in_chunk);
+                            let input_slice = workaround_transmute(in_chunk);
                             let output_slice = workaround_transmute_mut(out_chunk);
                             self.perform_fft_f64(DoubleBuf {
                                 input: input_slice,
@@ -70,6 +70,14 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
+            fn process_outofplace_with_scratch(
+                &self,
+                input: &mut [Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                self.process_immutable_with_scratch(input, output, scratch);
+            }
             fn process_with_scratch(&self, buffer: &mut [Complex<T>], _scratch: &mut [Complex<T>]) {
                 if buffer.len() < self.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
@@ -77,7 +85,7 @@ macro_rules! boilerplate_fft_simd_butterfly {
                     return; // Unreachable, because fft_error_inplace asserts, but it helps codegen to put it here
                 }
 
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     unsafe {
                         // Specialization workaround: See the comments in FftPlannerAvx::new() for why we have to transmute these slices
                         self.perform_fft_f64(workaround_transmute_mut::<_, Complex<f64>>(chunk));
@@ -96,6 +104,10 @@ macro_rules! boilerplate_fft_simd_butterfly {
             }
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
+                0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
                 0
             }
         }
@@ -156,6 +168,22 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             }
 
             #[inline]
+            fn perform_fft_immut(
+                &self,
+                input: &[Complex<f64>],
+                output: &mut [Complex<f64>],
+                _scratch: &mut [Complex<f64>],
+            ) {
+                // Perform the column FFTs
+                // Safety: self.perform_column_butterflies() requres the "avx" and "fma" instruction sets, and we return Err() in our constructor if the instructions aren't available
+                unsafe { self.column_butterflies_and_transpose(input, output) };
+
+                // process the row FFTs in-place in the output buffer
+                // Safety: self.transpose() requres the "avx" instruction set, and we return Err() in our constructor if the instructions aren't available
+                unsafe { self.row_butterflies(output) };
+            }
+
+            #[inline]
             fn perform_fft_out_of_place(
                 &self,
                 input: &mut [Complex<f64>],
@@ -171,6 +199,40 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             }
         }
         impl<T: FftNum> Fft<T> for $struct_name<f64> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+                let transmuted_input: &[Complex<f64>] =
+                    unsafe { array_utils::workaround_transmute(input) };
+                let transmuted_output: &mut [Complex<f64>] =
+                    unsafe { array_utils::workaround_transmute_mut(output) };
+                let transmuted_scratch: &mut [Complex<f64>] =
+                    unsafe { array_utils::workaround_transmute_mut(scratch) };
+                let result = array_utils::iter_chunks_zipped(
+                    transmuted_input,
+                    transmuted_output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        self.perform_fft_immut(in_chunk, out_chunk, transmuted_scratch)
+                    },
+                );
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -188,7 +250,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     unsafe { array_utils::workaround_transmute_mut(input) };
                 let transmuted_output: &mut [Complex<f64>] =
                     unsafe { array_utils::workaround_transmute_mut(output) };
-                let result = array_utils::iter_chunks_zipped(
+                let result = array_utils::iter_chunks_zipped_mut(
                     transmuted_input,
                     transmuted_output,
                     self.len(),
@@ -216,7 +278,7 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
                     unsafe { array_utils::workaround_transmute_mut(buffer) };
                 let transmuted_scratch: &mut [Complex<f64>] =
                     unsafe { array_utils::workaround_transmute_mut(scratch) };
-                let result = array_utils::iter_chunks(transmuted_buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(transmuted_buffer, self.len(), |chunk| {
                     self.perform_fft_inplace(chunk, transmuted_scratch)
                 });
 
@@ -232,6 +294,10 @@ macro_rules! boilerplate_fft_simd_butterfly_with_scratch {
             }
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
+                0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
                 0
             }
         }

--- a/src/avx/avx64_butterflies.rs
+++ b/src/avx/avx64_butterflies.rs
@@ -7,7 +7,7 @@ use num_complex::Complex;
 use crate::array_utils;
 use crate::array_utils::DoubleBuf;
 use crate::array_utils::{workaround_transmute, workaround_transmute_mut};
-use crate::common::{fft_error_inplace, fft_error_outofplace, fft_error_immut};
+use crate::common::{fft_error_immut, fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, twiddles};
 use crate::{Direction, Fft, FftDirection, Length};
 

--- a/src/avx/avx_bluesteins.rs
+++ b/src/avx/avx_bluesteins.rs
@@ -144,6 +144,7 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
 
                 inplace_scratch_len: required_scratch,
                 outofplace_scratch_len: required_scratch,
+                immut_scratch_len: required_scratch,
 
                 direction,
             },
@@ -308,6 +309,61 @@ impl<A: AvxNum, T: FftNum> BluesteinsAvx<A, T> {
                 array_utils::workaround_transmute_mut(inner_input);
 
             self.finalize_bluesteins(transmuted_inner_input, transmuted_buffer);
+        }
+    }
+
+    fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        let (inner_input, inner_scratch) = scratch
+            .split_at_mut(self.inner_fft_multiplier.len() * A::VectorType::COMPLEX_PER_VECTOR);
+
+        // do the necessary setup for bluestein's algorithm: copy the data to the inner buffers, apply some twiddle factors, zero out the rest of the inner buffer
+        unsafe {
+            // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+            let transmuted_input: &[Complex<A>] = array_utils::workaround_transmute(input);
+            let transmuted_inner_input: &mut [Complex<A>] =
+                array_utils::workaround_transmute_mut(inner_input);
+
+            self.prepare_bluesteins(transmuted_input, transmuted_inner_input)
+        }
+
+        // run our inner forward FFT
+        self.common_data
+            .inner_fft
+            .process_with_scratch(inner_input, inner_scratch);
+
+        // Multiply our inner FFT output by our precomputed data. Then, conjugate the result to set up for an inverse FFT.
+        // We can conjugate the result of multiplication by conjugating both inputs. We pre-conjugated the multiplier array,
+        // so we just need to conjugate inner_input, which the pairwise_complex_multiply_conjugated function will handle
+        unsafe {
+            // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+            let transmuted_inner_input: &mut [Complex<A>] =
+                array_utils::workaround_transmute_mut(inner_input);
+
+            Self::pairwise_complex_multiply_conjugated(
+                transmuted_inner_input,
+                &self.inner_fft_multiplier,
+            )
+        };
+
+        // inverse FFT. we're computing a forward but we're massaging it into an inverse by conjugating the inputs and outputs
+        self.common_data
+            .inner_fft
+            .process_with_scratch(inner_input, inner_scratch);
+
+        // finalize the result
+        unsafe {
+            // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+            let transmuted_output: &mut [Complex<A>] =
+                array_utils::workaround_transmute_mut(output);
+            let transmuted_inner_input: &mut [Complex<A>] =
+                array_utils::workaround_transmute_mut(inner_input);
+
+            self.finalize_bluesteins(transmuted_inner_input, transmuted_output)
         }
     }
 

--- a/src/avx/avx_mixed_radix.rs
+++ b/src/avx/avx_mixed_radix.rs
@@ -1069,16 +1069,6 @@ impl<A: AvxNum, T: FftNum> MixedRadix16xnAvx<A, T> {
         // Normally, we can fit 4 complex numbers into an AVX register, but we only have `partial_remainder` columns left, so we need special logic to handle these final columns
         let partial_remainder = len_per_row % A::VectorType::COMPLEX_PER_VECTOR;
         if partial_remainder > 0 {
-            // We need to copy the partial remainders to the buffer
-            for c in 0..self.len() / len_per_row {
-                let cs = c * len_per_row + len_per_row - partial_remainder;
-                match partial_remainder {
-                    1 => buffer.store_partial1_complex(input.load_partial1_complex(cs), cs),
-                    2 => buffer.store_partial2_complex(input.load_partial2_complex(cs), cs),
-                    3 => buffer.store_partial3_complex(input.load_partial3_complex(cs), cs),
-                    _ => unreachable!(),
-                }
-            }
             let partial_remainder_base = chunk_count * A::VectorType::COMPLEX_PER_VECTOR;
             let partial_remainder_twiddle_base =
                 self.common_data.twiddles.len() - TWIDDLES_PER_COLUMN;
@@ -1086,6 +1076,10 @@ impl<A: AvxNum, T: FftNum> MixedRadix16xnAvx<A, T> {
 
             match partial_remainder {
                 1 => {
+                    for c in 0..self.len() / len_per_row {
+                        let cs = c * len_per_row + len_per_row - partial_remainder;
+                        buffer.store_partial1_complex(input.load_partial1_complex(cs), cs);
+                    }
                     column_butterfly16_loadfn!(
                         |index| buffer
                             .load_partial1_complex(partial_remainder_base + len_per_row * index),
@@ -1107,6 +1101,10 @@ impl<A: AvxNum, T: FftNum> MixedRadix16xnAvx<A, T> {
                     );
                 }
                 2 => {
+                    for c in 0..self.len() / len_per_row {
+                        let cs = c * len_per_row + len_per_row - partial_remainder;
+                        buffer.store_partial2_complex(input.load_partial2_complex(cs), cs);
+                    }
                     column_butterfly16_loadfn!(
                         |index| buffer
                             .load_partial2_complex(partial_remainder_base + len_per_row * index),
@@ -1128,6 +1126,10 @@ impl<A: AvxNum, T: FftNum> MixedRadix16xnAvx<A, T> {
                     );
                 }
                 3 => {
+                    for c in 0..self.len() / len_per_row {
+                        let cs = c * len_per_row + len_per_row - partial_remainder;
+                        buffer.store_partial3_complex(input.load_partial3_complex(cs), cs);
+                    }
                     column_butterfly16_loadfn!(
                         |index| buffer
                             .load_partial3_complex(partial_remainder_base + len_per_row * index),

--- a/src/avx/avx_mixed_radix.rs
+++ b/src/avx/avx_mixed_radix.rs
@@ -70,6 +70,44 @@ macro_rules! boilerplate_mixedradix {
         }
 
         #[inline]
+        fn perform_fft_immut(
+            &self,
+            input: &[Complex<T>],
+            output: &mut [Complex<T>],
+            scratch: &mut [Complex<T>],
+        ) {
+            // Perform the column FFTs
+            // Safety: self.perform_column_butterflies() requires the "avx" and "fma" instruction sets, and we return Err() in our constructor if the instructions aren't available
+            let (scratch, scratch2) = scratch.split_at_mut(scratch.len() / 2);
+            let scratch = &mut scratch[..input.len()];
+            unsafe {
+                // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+                let transmuted_input: &[Complex<A>] = array_utils::workaround_transmute(input);
+                let transmuted_output: &mut [Complex<A>] =
+                    array_utils::workaround_transmute_mut(scratch);
+
+                self.perform_column_butterflies_immut(transmuted_input, transmuted_output);
+            }
+
+            // process the row FFTs. If extra scratch was provided, pass it in. Otherwise, use the output.
+            self.common_data
+                .inner_fft
+                .process_with_scratch(scratch, scratch2);
+
+            // Transpose
+            // Safety: self.transpose() requires the "avx" instruction set, and we return Err() in our constructor if the instructions aren't available
+            unsafe {
+                // Specialization workaround: See the comments in FftPlannerAvx::new() for why these calls to array_utils::workaround_transmute are necessary
+                let transmuted_input: &mut [Complex<A>] =
+                    array_utils::workaround_transmute_mut(scratch);
+                let transmuted_output: &mut [Complex<A>] =
+                    array_utils::workaround_transmute_mut(output);
+
+                self.transpose(transmuted_input, transmuted_output)
+            }
+        }
+
+        #[inline]
         fn perform_fft_out_of_place(
             &self,
             input: &mut [Complex<T>],
@@ -138,11 +176,13 @@ macro_rules! mixedradix_gen_data {
 
         let inner_outofplace_scratch = $inner_fft.get_outofplace_scratch_len();
         let inner_inplace_scratch = $inner_fft.get_inplace_scratch_len();
+        let immut_scratch_len = usize::max($inner_fft.get_immutable_scratch_len() * 2, len * 2);
 
         CommonSimdData {
             twiddles: twiddles.into_boxed_slice(),
             inplace_scratch_len: len + inner_outofplace_scratch,
             outofplace_scratch_len: if inner_inplace_scratch > len { inner_inplace_scratch } else { 0 },
+            immut_scratch_len,
             inner_fft: $inner_fft,
             len,
             direction,
@@ -152,6 +192,143 @@ macro_rules! mixedradix_gen_data {
 
 macro_rules! mixedradix_column_butterflies {
     ($row_count: expr, $butterfly_fn: expr, $butterfly_fn_lo: expr) => {
+        #[target_feature(enable = "avx", enable = "fma")]
+        unsafe fn perform_column_butterflies_immut(
+            &self,
+            input: impl AvxArray<A>,
+            mut buffer: impl AvxArrayMut<A>,
+        ) {
+            // How many rows this FFT has, ie 2 for 2xn, 4 for 4xn, etc
+            const ROW_COUNT: usize = $row_count;
+            const TWIDDLES_PER_COLUMN: usize = ROW_COUNT - 1;
+
+            let len_per_row = self.len() / ROW_COUNT;
+            let chunk_count = len_per_row / A::VectorType::COMPLEX_PER_VECTOR;
+
+            // If we don't have any column FFTs, we need to move the
+            // input into the output buffer for the remainder processing
+            if chunk_count == 0 {
+                let simd_ops = self.len() / 4;
+                for i in (0..simd_ops).step_by(4) {
+                    buffer.store_complex(input.load_complex(i), i);
+                }
+            } else {
+                // process the column FFTs
+                for (c, twiddle_chunk) in self
+                    .common_data
+                    .twiddles
+                    .chunks_exact(TWIDDLES_PER_COLUMN)
+                    .take(chunk_count)
+                    .enumerate()
+                {
+                    let index_base = c * A::VectorType::COMPLEX_PER_VECTOR;
+
+                    // Load columns from the input into registers
+                    let mut columns = [AvxVector::zero(); ROW_COUNT];
+                    for i in 0..ROW_COUNT {
+                        columns[i] = input.load_complex(index_base + len_per_row * i);
+                    }
+
+                    // apply our butterfly function down the columns
+                    let output = $butterfly_fn(columns, self);
+
+                    // always write the first row directly back without twiddles
+                    buffer.store_complex(output[0], index_base);
+
+                    // for every other row, apply twiddle factors and then write back to memory
+                    for i in 1..ROW_COUNT {
+                        let twiddle = twiddle_chunk[i - 1];
+                        let output = AvxVector::mul_complex(twiddle, output[i]);
+                        buffer.store_complex(output, index_base + len_per_row * i);
+                    }
+                }
+            }
+
+            // finally, we might have a remainder chunk
+            // Normally, we can fit COMPLEX_PER_VECTOR complex numbers into an AVX register, but we only have `partial_remainder` columns left, so we need special logic to handle these final columns
+            let partial_remainder = len_per_row % A::VectorType::COMPLEX_PER_VECTOR;
+            if partial_remainder > 0 {
+                // We need to copy the partial remainders to the buffer
+                for c in 0..self.len() / len_per_row {
+                    let cs = c * len_per_row + len_per_row - partial_remainder;
+                    match partial_remainder {
+                        1 => buffer.store_partial1_complex(input.load_partial1_complex(cs), cs),
+                        2 => buffer.store_partial2_complex(input.load_partial2_complex(cs), cs),
+                        3 => buffer.store_partial3_complex(input.load_partial3_complex(cs), cs),
+                        _ => unreachable!(),
+                    }
+                }
+                let partial_remainder_base = chunk_count * A::VectorType::COMPLEX_PER_VECTOR;
+                let partial_remainder_twiddle_base =
+                    self.common_data.twiddles.len() - TWIDDLES_PER_COLUMN;
+                let final_twiddle_chunk =
+                    &self.common_data.twiddles[partial_remainder_twiddle_base..];
+
+                if partial_remainder > 2 {
+                    // Load 3 columns into full AVX vectors to process our remainder
+                    let mut columns = [AvxVector::zero(); ROW_COUNT];
+                    for i in 0..ROW_COUNT {
+                        columns[i] =
+                            buffer.load_partial3_complex(partial_remainder_base + len_per_row * i);
+                    }
+
+                    // apply our butterfly function down the columns
+                    let mid = $butterfly_fn(columns, self);
+
+                    // always write the first row without twiddles
+                    buffer.store_partial3_complex(mid[0], partial_remainder_base);
+
+                    // for the remaining rows, apply twiddle factors and then write back to memory
+                    for i in 1..ROW_COUNT {
+                        let twiddle = final_twiddle_chunk[i - 1];
+                        let output = AvxVector::mul_complex(twiddle, mid[i]);
+                        buffer.store_partial3_complex(
+                            output,
+                            partial_remainder_base + len_per_row * i,
+                        );
+                    }
+                } else {
+                    // Load 1 or 2 columns into half vectors to process our remainder. Thankfully, the compiler is smart enough to eliminate this branch on f64, since the partial remainder can only possibly be 1
+                    let mut columns = [AvxVector::zero(); ROW_COUNT];
+                    if partial_remainder == 1 {
+                        for i in 0..ROW_COUNT {
+                            columns[i] = buffer
+                                .load_partial1_complex(partial_remainder_base + len_per_row * i);
+                        }
+                    } else {
+                        for i in 0..ROW_COUNT {
+                            columns[i] = buffer
+                                .load_partial2_complex(partial_remainder_base + len_per_row * i);
+                        }
+                    }
+
+                    // apply our butterfly function down the columns
+                    let mut mid = $butterfly_fn_lo(columns, self);
+
+                    // apply twiddle factors
+                    for i in 1..ROW_COUNT {
+                        mid[i] = AvxVector::mul_complex(final_twiddle_chunk[i - 1].lo(), mid[i]);
+                    }
+
+                    // store output
+                    if partial_remainder == 1 {
+                        for i in 0..ROW_COUNT {
+                            buffer.store_partial1_complex(
+                                mid[i],
+                                partial_remainder_base + len_per_row * i,
+                            );
+                        }
+                    } else {
+                        for i in 0..ROW_COUNT {
+                            buffer.store_partial2_complex(
+                                mid[i],
+                                partial_remainder_base + len_per_row * i,
+                            );
+                        }
+                    }
+                }
+            }
+        }
         #[target_feature(enable = "avx", enable = "fma")]
         unsafe fn perform_column_butterflies(&self, mut buffer: impl AvxArrayMut<A>) {
             // How many rows this FFT has, ie 2 for 2xn, 4 for 4xn, etc
@@ -793,6 +970,125 @@ impl<A: AvxNum, T: FftNum> MixedRadix16xnAvx<A, T> {
         // Normally, we can fit 4 complex numbers into an AVX register, but we only have `partial_remainder` columns left, so we need special logic to handle these final columns
         let partial_remainder = len_per_row % A::VectorType::COMPLEX_PER_VECTOR;
         if partial_remainder > 0 {
+            let partial_remainder_base = chunk_count * A::VectorType::COMPLEX_PER_VECTOR;
+            let partial_remainder_twiddle_base =
+                self.common_data.twiddles.len() - TWIDDLES_PER_COLUMN;
+            let final_twiddle_chunk = &self.common_data.twiddles[partial_remainder_twiddle_base..];
+
+            match partial_remainder {
+                1 => {
+                    column_butterfly16_loadfn!(
+                        |index| buffer
+                            .load_partial1_complex(partial_remainder_base + len_per_row * index),
+                        |mut data, index| {
+                            if index > 0 {
+                                let twiddle: A::VectorType = final_twiddle_chunk[index - 1];
+                                data = AvxVector::mul_complex(data, twiddle.lo());
+                            }
+                            buffer.store_partial1_complex(
+                                data,
+                                partial_remainder_base + len_per_row * index,
+                            )
+                        },
+                        [
+                            self.twiddles_butterfly16[0].lo(),
+                            self.twiddles_butterfly16[1].lo()
+                        ],
+                        self.twiddles_butterfly4.lo()
+                    );
+                }
+                2 => {
+                    column_butterfly16_loadfn!(
+                        |index| buffer
+                            .load_partial2_complex(partial_remainder_base + len_per_row * index),
+                        |mut data, index| {
+                            if index > 0 {
+                                let twiddle: A::VectorType = final_twiddle_chunk[index - 1];
+                                data = AvxVector::mul_complex(data, twiddle.lo());
+                            }
+                            buffer.store_partial2_complex(
+                                data,
+                                partial_remainder_base + len_per_row * index,
+                            )
+                        },
+                        [
+                            self.twiddles_butterfly16[0].lo(),
+                            self.twiddles_butterfly16[1].lo()
+                        ],
+                        self.twiddles_butterfly4.lo()
+                    );
+                }
+                3 => {
+                    column_butterfly16_loadfn!(
+                        |index| buffer
+                            .load_partial3_complex(partial_remainder_base + len_per_row * index),
+                        |mut data, index| {
+                            if index > 0 {
+                                data = AvxVector::mul_complex(data, final_twiddle_chunk[index - 1]);
+                            }
+                            buffer.store_partial3_complex(
+                                data,
+                                partial_remainder_base + len_per_row * index,
+                            )
+                        },
+                        self.twiddles_butterfly16,
+                        self.twiddles_butterfly4
+                    );
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+    #[target_feature(enable = "avx", enable = "fma")]
+    unsafe fn perform_column_butterflies_immut(
+        &self,
+        input: impl AvxArray<A>,
+        mut buffer: impl AvxArrayMut<A>,
+    ) {
+        // How many rows this FFT has, ie 2 for 2xn, 4 for 4xn, etc
+        const ROW_COUNT: usize = 16;
+        const TWIDDLES_PER_COLUMN: usize = ROW_COUNT - 1;
+
+        let len_per_row = self.len() / ROW_COUNT;
+        let chunk_count = len_per_row / A::VectorType::COMPLEX_PER_VECTOR;
+
+        // process the column FFTs
+        for (c, twiddle_chunk) in self
+            .common_data
+            .twiddles
+            .chunks_exact(TWIDDLES_PER_COLUMN)
+            .take(chunk_count)
+            .enumerate()
+        {
+            let index_base = c * A::VectorType::COMPLEX_PER_VECTOR;
+
+            column_butterfly16_loadfn!(
+                |index| input.load_complex(index_base + len_per_row * index),
+                |mut data, index| {
+                    if index > 0 {
+                        data = AvxVector::mul_complex(data, twiddle_chunk[index - 1]);
+                    }
+                    buffer.store_complex(data, index_base + len_per_row * index)
+                },
+                self.twiddles_butterfly16,
+                self.twiddles_butterfly4
+            );
+        }
+
+        // finally, we might have a single partial chunk.
+        // Normally, we can fit 4 complex numbers into an AVX register, but we only have `partial_remainder` columns left, so we need special logic to handle these final columns
+        let partial_remainder = len_per_row % A::VectorType::COMPLEX_PER_VECTOR;
+        if partial_remainder > 0 {
+            // We need to copy the partial remainders to the buffer
+            for c in 0..self.len() / len_per_row {
+                let cs = c * len_per_row + len_per_row - partial_remainder;
+                match partial_remainder {
+                    1 => buffer.store_partial1_complex(input.load_partial1_complex(cs), cs),
+                    2 => buffer.store_partial2_complex(input.load_partial2_complex(cs), cs),
+                    3 => buffer.store_partial3_complex(input.load_partial3_complex(cs), cs),
+                    _ => unreachable!(),
+                }
+            }
             let partial_remainder_base = chunk_count * A::VectorType::COMPLEX_PER_VECTOR;
             let partial_remainder_twiddle_base =
                 self.common_data.twiddles.len() - TWIDDLES_PER_COLUMN;

--- a/src/avx/avx_vector.rs
+++ b/src/avx/avx_vector.rs
@@ -2265,7 +2265,7 @@ pub unsafe fn pairwise_complex_mul_conjugated<T: AvxNum>(
         multiplier.len(),
         input.len()
     ); // Assert to convince the compiler to omit bounds checks inside the loop
-    assert!(input.len() == output.len()); // Assert to convince the compiler to omit bounds checks inside the loop
+    assert_eq!(input.len(), output.len()); // Assert to convince the compiler to omit bounds checks inside the loop
     let main_loop_count = input.len() / T::VectorType::COMPLEX_PER_VECTOR;
     let remainder_count = input.len() % T::VectorType::COMPLEX_PER_VECTOR;
 

--- a/src/avx/mod.rs
+++ b/src/avx/mod.rs
@@ -43,14 +43,14 @@ macro_rules! boilerplate_avx_fft {
                     || output.len() != input.len()
                 {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(
+                    crate::common::fft_error_immut(
                         self.len(),
                         input.len(),
                         output.len(),
                         required_scratch,
                         scratch.len(),
                     );
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];
@@ -194,14 +194,14 @@ macro_rules! boilerplate_avx_fft_commondata {
                     || output.len() != input.len()
                 {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(
+                    crate::common::fft_error_immut(
                         self.len(),
                         input.len(),
                         output.len(),
                         self.get_immutable_scratch_len(),
                         scratch.len(),
                     );
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let scratch = &mut scratch[..required_scratch];

--- a/src/avx/mod.rs
+++ b/src/avx/mod.rs
@@ -23,13 +23,57 @@ struct CommonSimdData<T, V> {
 
     inplace_scratch_len: usize,
     outofplace_scratch_len: usize,
+    immut_scratch_len: usize,
 
     direction: FftDirection,
 }
 
 macro_rules! boilerplate_avx_fft {
-    ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr) => {
+    ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr, $immut_scratch_len_fn:expr) => {
         impl<A: AvxNum, T: FftNum> Fft<T> for $struct_name<A, T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                let required_scratch = self.get_immutable_scratch_len();
+                if scratch.len() < required_scratch
+                    || input.len() < self.len()
+                    || output.len() != input.len()
+                {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        required_scratch,
+                        scratch.len(),
+                    );
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                let scratch = &mut scratch[..required_scratch];
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| self.perform_fft_immut(in_chunk, out_chunk, scratch),
+                );
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_outofplace_scratch_len(),
+                        scratch.len(),
+                    )
+                }
+            }
+
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -53,7 +97,7 @@ macro_rules! boilerplate_avx_fft {
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks_zipped(
+                let result = array_utils::iter_chunks_zipped_mut(
                     input,
                     output,
                     self.len(),
@@ -88,7 +132,7 @@ macro_rules! boilerplate_avx_fft {
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_inplace(chunk, scratch)
                 });
 
@@ -111,6 +155,10 @@ macro_rules! boilerplate_avx_fft {
             fn get_outofplace_scratch_len(&self) -> usize {
                 $out_of_place_scratch_len_fn(self)
             }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
+                $immut_scratch_len_fn(self)
+            }
         }
         impl<A: AvxNum, T> Length for $struct_name<A, T> {
             #[inline(always)]
@@ -130,6 +178,52 @@ macro_rules! boilerplate_avx_fft {
 macro_rules! boilerplate_avx_fft_commondata {
     ($struct_name:ident) => {
         impl<A: AvxNum, T: FftNum> Fft<T> for $struct_name<A, T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                if self.len() == 0 {
+                    return;
+                }
+
+                let required_scratch = self.common_data.immut_scratch_len;
+                if scratch.len() < required_scratch
+                    || input.len() < self.len()
+                    || output.len() != input.len()
+                {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_immutable_scratch_len(),
+                        scratch.len(),
+                    );
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                let scratch = &mut scratch[..required_scratch];
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| self.perform_fft_immut(in_chunk, out_chunk, scratch),
+                );
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        self.get_outofplace_scratch_len(),
+                        scratch.len(),
+                    );
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -157,7 +251,7 @@ macro_rules! boilerplate_avx_fft_commondata {
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks_zipped(
+                let result = array_utils::iter_chunks_zipped_mut(
                     input,
                     output,
                     self.len(),
@@ -196,7 +290,7 @@ macro_rules! boilerplate_avx_fft_commondata {
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_inplace(chunk, scratch)
                 });
 
@@ -218,6 +312,10 @@ macro_rules! boilerplate_avx_fft_commondata {
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
                 self.common_data.outofplace_scratch_len
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
+                self.common_data.immut_scratch_len
             }
         }
         impl<A: AvxNum, T> Length for $struct_name<A, T> {

--- a/src/common.rs
+++ b/src/common.rs
@@ -73,6 +73,45 @@ pub fn fft_error_outofplace(
 macro_rules! boilerplate_fft_oop {
     ($struct_name:ident, $len_fn:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                if self.len() == 0 {
+                    return;
+                }
+
+                let required_scratch = self.get_immutable_scratch_len();
+                if input.len() < self.len()
+                    || output.len() != input.len()
+                    || scratch.len() < required_scratch
+                {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        required_scratch,
+                        scratch.len(),
+                    );
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| self.perform_fft_immut(in_chunk, out_chunk, scratch),
+                );
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -99,7 +138,7 @@ macro_rules! boilerplate_fft_oop {
                     return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
                 }
 
-                let result = array_utils::iter_chunks_zipped(
+                let result = array_utils::iter_chunks_zipped_mut(
                     input,
                     output,
                     self.len(),
@@ -132,7 +171,7 @@ macro_rules! boilerplate_fft_oop {
                 }
 
                 let (scratch, extra_scratch) = scratch.split_at_mut(self.len());
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_out_of_place(chunk, scratch, extra_scratch);
                     chunk.copy_from_slice(scratch);
                 });
@@ -156,6 +195,10 @@ macro_rules! boilerplate_fft_oop {
             fn get_outofplace_scratch_len(&self) -> usize {
                 self.outofplace_scratch_len()
             }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
+                self.inplace_scratch_len()
+            }
         }
         impl<T> Length for $struct_name<T> {
             #[inline(always)]
@@ -173,8 +216,49 @@ macro_rules! boilerplate_fft_oop {
 }
 
 macro_rules! boilerplate_fft {
-    ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr) => {
+    ($struct_name:ident, $len_fn:expr, $inplace_scratch_len_fn:expr, $out_of_place_scratch_len_fn:expr, $immut_scratch_len:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                scratch: &mut [Complex<T>],
+            ) {
+                if self.len() == 0 {
+                    return;
+                }
+                let required_scratch = self.get_immutable_scratch_len();
+                if scratch.len() < required_scratch
+                    || input.len() < self.len()
+                    || output.len() != input.len()
+                {
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        required_scratch,
+                        scratch.len(),
+                    );
+                }
+
+                let scratch = &mut scratch[..required_scratch];
+                let result = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| self.perform_fft_immut(in_chunk, out_chunk, scratch),
+                );
+                if result.is_err() {
+                    fft_error_outofplace(
+                        self.len(),
+                        input.len(),
+                        output.len(),
+                        required_scratch,
+                        scratch.len(),
+                    );
+                }
+            }
+
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -202,7 +286,7 @@ macro_rules! boilerplate_fft {
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks_zipped(
+                let result = array_utils::iter_chunks_zipped_mut(
                     input,
                     output,
                     self.len(),
@@ -241,7 +325,7 @@ macro_rules! boilerplate_fft {
                 }
 
                 let scratch = &mut scratch[..required_scratch];
-                let result = array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                let result = array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_inplace(chunk, scratch)
                 });
 
@@ -263,6 +347,10 @@ macro_rules! boilerplate_fft {
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
                 $out_of_place_scratch_len_fn(self)
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
+                $immut_scratch_len(self)
             }
         }
         impl<T: FftNum> Length for $struct_name<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,25 @@ pub trait Fft<T: FftNum>: Length + Direction + Sync + Send {
         scratch: &mut [Complex<T>],
     );
 
+    /// Divides `input` and `output` into chunks of `self.len()`, and computes a FFT on each chunk while
+    /// keeping `input` untouched.
+    ///
+    /// This method uses the `scratch` buffer as scratch space, so the contents should be considered garbage after calling.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if:
+    /// - `output.len() ! input.len()`
+    /// - `input.len() % self.len() > 0`
+    /// - `input.len() < self.len()`
+    /// - `scratch.len() < get_immutable_scratch_len()`
+    fn process_immutable_with_scratch(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    );
+
     /// Returns the size of the scratch buffer required by `process_with_scratch`
     ///
     /// For most FFT sizes, this method will return `self.len()`. For a few small sizes it will return 0, and for some special FFT sizes
@@ -247,6 +266,13 @@ pub trait Fft<T: FftNum>: Length + Direction + Sync + Send {
     /// (Sizes that require the use of Bluestein's Algorithm), this may return a scratch size larger than `self.len()`.
     /// The returned value may change from one version of RustFFT to the next.
     fn get_outofplace_scratch_len(&self) -> usize;
+
+    /// Returns the size of the scratch buffer required by `process_immutable_with_scratch`
+    ///
+    /// For most FFT sizes, this method will return `self.len()`. For a few small sizes it will return 0, and for some special FFT sizes
+    /// (Sizes that require the use of Bluestein's Algorithm), this may return a scratch size larger than `self.len()`.
+    /// The returned value may change from one version of RustFFT to the next.
+    fn get_immutable_scratch_len(&self) -> usize;
 }
 
 // Algorithms implemented to use AVX instructions. Only compiled on x86_64, and only compiled if the "avx" feature flag is set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,8 @@ pub trait Fft<T: FftNum>: Length + Direction + Sync + Send {
 
     /// Returns the size of the scratch buffer required by `process_immutable_with_scratch`
     ///
-    /// For most FFT sizes, this method will return `self.len()`. For a few small sizes it will return 0, and for some special FFT sizes
+    /// For most FFT sizes, this method will return something between self.len() and self.len() * 2.
+    /// For a few small sizes it will return 0, and for some special FFT sizes
     /// (Sizes that require the use of Bluestein's Algorithm), this may return a scratch size larger than `self.len()`.
     /// The returned value may change from one version of RustFFT to the next.
     fn get_immutable_scratch_len(&self) -> usize;

--- a/src/neon/mod.rs
+++ b/src/neon/mod.rs
@@ -12,10 +12,6 @@ mod neon_utils;
 
 pub mod neon_planner;
 
-pub use self::neon_butterflies::*;
-pub use self::neon_prime_butterflies::*;
-pub use self::neon_radix4::*;
-
 use std::arch::aarch64::{float32x4_t, float64x2_t};
 
 use crate::FftNum;

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -6,7 +6,7 @@ use crate::{common::FftNum, FftDirection};
 use crate::array_utils;
 use crate::array_utils::workaround_transmute_mut;
 use crate::array_utils::DoubleBuf;
-use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::common::{fft_error_immut, fft_error_inplace, fft_error_outofplace};
 use crate::twiddles;
 use crate::{Direction, Fft, Length};
 

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -43,7 +43,7 @@ macro_rules! boilerplate_fft_neon_f32_butterfly {
                 buffer: &mut [Complex<T>],
             ) -> Result<(), ()> {
                 let len = buffer.len();
-                let alldone = array_utils::iter_chunks(buffer, 2 * self.len(), |chunk| {
+                let alldone = array_utils::iter_chunks_mut(buffer, 2 * self.len(), |chunk| {
                     self.perform_parallel_fft_butterfly(chunk)
                 });
                 if alldone.is_err() && buffer.len() >= self.len() {
@@ -59,7 +59,7 @@ macro_rules! boilerplate_fft_neon_f32_butterfly {
                 output: &mut [Complex<T>],
             ) -> Result<(), ()> {
                 let len = input.len();
-                let alldone = array_utils::iter_chunks_zipped(
+                let alldone = array_utils::iter_chunks_zipped_mut(
                     input,
                     output,
                     2 * self.len(),
@@ -77,6 +77,36 @@ macro_rules! boilerplate_fft_neon_f32_butterfly {
                     let output_slice = workaround_transmute_mut(output);
                     self.perform_fft_contiguous(DoubleBuf {
                         input: &mut input_slice[len - self.len()..],
+                        output: &mut output_slice[len - self.len()..],
+                    })
+                }
+                Ok(())
+            }
+
+            pub(crate) unsafe fn perform_oop_fft_butterfly_multi_immut(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+            ) -> Result<(), ()> {
+                let len = input.len();
+                let alldone = array_utils::iter_chunks_zipped(
+                    input,
+                    output,
+                    2 * self.len(),
+                    |in_chunk, out_chunk| {
+                        let input_slice = crate::array_utils::workaround_transmute(in_chunk);
+                        let output_slice = workaround_transmute_mut(out_chunk);
+                        self.perform_parallel_fft_contiguous(DoubleBuf {
+                            input: input_slice,
+                            output: output_slice,
+                        })
+                    },
+                );
+                if alldone.is_err() && input.len() >= self.len() {
+                    let input_slice = crate::array_utils::workaround_transmute(input);
+                    let output_slice = workaround_transmute_mut(output);
+                    self.perform_fft_contiguous(DoubleBuf {
+                        input: &input_slice[len - self.len()..],
                         output: &mut output_slice[len - self.len()..],
                     })
                 }
@@ -101,7 +131,7 @@ macro_rules! boilerplate_fft_neon_f64_butterfly {
                 &self,
                 buffer: &mut [Complex<T>],
             ) -> Result<(), ()> {
-                array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_butterfly(chunk)
                 })
             }
@@ -113,8 +143,28 @@ macro_rules! boilerplate_fft_neon_f64_butterfly {
                 input: &mut [Complex<T>],
                 output: &mut [Complex<T>],
             ) -> Result<(), ()> {
+                array_utils::iter_chunks_zipped_mut(
+                    input,
+                    output,
+                    self.len(),
+                    |in_chunk, out_chunk| {
+                        let input_slice = workaround_transmute_mut(in_chunk);
+                        let output_slice = workaround_transmute_mut(out_chunk);
+                        self.perform_fft_contiguous(DoubleBuf {
+                            input: input_slice,
+                            output: output_slice,
+                        })
+                    },
+                )
+            }
+
+            pub(crate) unsafe fn perform_oop_fft_butterfly_multi_immut(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+            ) -> Result<(), ()> {
                 array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| {
-                    let input_slice = workaround_transmute_mut(in_chunk);
+                    let input_slice = crate::array_utils::workaround_transmute(in_chunk);
                     let output_slice = workaround_transmute_mut(out_chunk);
                     self.perform_fft_contiguous(DoubleBuf {
                         input: input_slice,
@@ -130,6 +180,25 @@ macro_rules! boilerplate_fft_neon_f64_butterfly {
 macro_rules! boilerplate_fft_neon_common_butterfly {
     ($struct_name:ident, $len:expr, $direction_fn:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                _scratch: &mut [Complex<T>],
+            ) {
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+                let result = unsafe { self.perform_oop_fft_butterfly_multi_immut(input, output) };
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -170,6 +239,10 @@ macro_rules! boilerplate_fft_neon_common_butterfly {
             }
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
+                0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
                 0
             }
         }

--- a/src/neon/neon_butterflies.rs
+++ b/src/neon/neon_butterflies.rs
@@ -188,15 +188,15 @@ macro_rules! boilerplate_fft_neon_common_butterfly {
             ) {
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
                 let result = unsafe { self.perform_oop_fft_butterfly_multi_immut(input, output) };
 
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
             fn process_outofplace_with_scratch(

--- a/src/neon/neon_common.rs
+++ b/src/neon/neon_common.rs
@@ -69,8 +69,8 @@ macro_rules! boilerplate_fft_neon_oop {
 
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let result = unsafe {

--- a/src/neon/neon_prime_butterflies.rs
+++ b/src/neon/neon_prime_butterflies.rs
@@ -8,7 +8,7 @@ use crate::{common::FftNum, FftDirection};
 use crate::array_utils;
 use crate::array_utils::workaround_transmute_mut;
 use crate::array_utils::DoubleBuf;
-use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::common::{fft_error_immut, fft_error_inplace, fft_error_outofplace};
 use crate::twiddles;
 use crate::{Direction, Fft, Length};
 

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -4,7 +4,7 @@ use std::any::TypeId;
 use std::sync::Arc;
 
 use crate::array_utils::{self, bitreversed_transpose, workaround_transmute_mut};
-use crate::common::{fft_error_inplace, fft_error_outofplace};
+use crate::common::{fft_error_immut, fft_error_inplace, fft_error_outofplace};
 use crate::{common::FftNum, FftDirection};
 use crate::{Direction, Fft, Length};
 

--- a/src/neon/neon_radix4.rs
+++ b/src/neon/neon_radix4.rs
@@ -89,41 +89,7 @@ impl<N: NeonNum, T: FftNum> NeonRadix4<N, T> {
         output: &mut [Complex<T>],
         _scratch: &mut [Complex<T>],
     ) {
-        // copy the data into the output vector
-        if self.len() == self.base_len {
-            output.copy_from_slice(input);
-        } else {
-            bitreversed_transpose::<Complex<T>, 4>(self.base_len, input, output);
-        }
-
-        // Base-level FFTs
-        self.base_fft.process_with_scratch(output, &mut []);
-
-        // cross-FFTs
-        const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = self.base_len * ROW_COUNT;
-        let mut layer_twiddles: &[N::VectorType] = &self.twiddles;
-
-        while cross_fft_len <= input.len() {
-            let num_rows = input.len() / cross_fft_len;
-            let num_scalar_columns = cross_fft_len / ROW_COUNT;
-            let num_vector_columns = num_scalar_columns / N::VectorType::COMPLEX_PER_VECTOR;
-
-            for i in 0..num_rows {
-                butterfly_4::<N, T>(
-                    &mut output[i * cross_fft_len..],
-                    layer_twiddles,
-                    num_scalar_columns,
-                    &self.rotation,
-                )
-            }
-
-            // skip past all the twiddle factors used in this layer
-            let twiddle_offset = num_vector_columns * (ROW_COUNT - 1);
-            layer_twiddles = &layer_twiddles[twiddle_offset..];
-
-            cross_fft_len *= ROW_COUNT;
-        }
+        self.perform_fft_out_of_place(input, output, _scratch);
     }
 
     //#[target_feature(enable = "neon")]

--- a/src/sse/sse_butterflies.rs
+++ b/src/sse/sse_butterflies.rs
@@ -4,8 +4,8 @@ use num_complex::Complex;
 use crate::{common::FftNum, FftDirection};
 
 use crate::array_utils;
-use crate::array_utils::workaround_transmute_mut;
 use crate::array_utils::DoubleBuf;
+use crate::array_utils::{workaround_transmute, workaround_transmute_mut};
 use crate::common::{fft_error_inplace, fft_error_outofplace};
 use crate::twiddles;
 use crate::{Direction, Fft, Length};
@@ -48,7 +48,7 @@ macro_rules! boilerplate_fft_sse_f32_butterfly {
                 buffer: &mut [Complex<T>],
             ) -> Result<(), ()> {
                 let len = buffer.len();
-                let alldone = array_utils::iter_chunks(buffer, 2 * self.len(), |chunk| {
+                let alldone = array_utils::iter_chunks_mut(buffer, 2 * self.len(), |chunk| {
                     self.perform_parallel_fft_butterfly(chunk)
                 });
                 if alldone.is_err() && buffer.len() >= self.len() {
@@ -61,7 +61,7 @@ macro_rules! boilerplate_fft_sse_f32_butterfly {
             #[target_feature(enable = "sse4.1")]
             pub(crate) unsafe fn perform_oop_fft_butterfly_multi(
                 &self,
-                input: &mut [Complex<T>],
+                input: &[Complex<T>],
                 output: &mut [Complex<T>],
             ) -> Result<(), ()> {
                 let len = input.len();
@@ -70,7 +70,7 @@ macro_rules! boilerplate_fft_sse_f32_butterfly {
                     output,
                     2 * self.len(),
                     |in_chunk, out_chunk| {
-                        let input_slice = workaround_transmute_mut(in_chunk);
+                        let input_slice = crate::array_utils::workaround_transmute(in_chunk);
                         let output_slice = workaround_transmute_mut(out_chunk);
                         self.perform_parallel_fft_contiguous(DoubleBuf {
                             input: input_slice,
@@ -79,10 +79,10 @@ macro_rules! boilerplate_fft_sse_f32_butterfly {
                     },
                 );
                 if alldone.is_err() && input.len() >= self.len() {
-                    let input_slice = workaround_transmute_mut(input);
+                    let input_slice = crate::array_utils::workaround_transmute(input);
                     let output_slice = workaround_transmute_mut(output);
                     self.perform_fft_contiguous(DoubleBuf {
-                        input: &mut input_slice[len - self.len()..],
+                        input: &input_slice[len - self.len()..],
                         output: &mut output_slice[len - self.len()..],
                     })
                 }
@@ -107,7 +107,7 @@ macro_rules! boilerplate_fft_sse_f32_butterfly_noparallel {
                 &self,
                 buffer: &mut [Complex<T>],
             ) -> Result<(), ()> {
-                array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_butterfly(chunk)
                 })
             }
@@ -116,11 +116,11 @@ macro_rules! boilerplate_fft_sse_f32_butterfly_noparallel {
             #[target_feature(enable = "sse4.1")]
             pub(crate) unsafe fn perform_oop_fft_butterfly_multi(
                 &self,
-                input: &mut [Complex<T>],
+                input: &[Complex<T>],
                 output: &mut [Complex<T>],
             ) -> Result<(), ()> {
                 array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| {
-                    let input_slice = workaround_transmute_mut(in_chunk);
+                    let input_slice = workaround_transmute(in_chunk);
                     let output_slice = workaround_transmute_mut(out_chunk);
                     self.perform_fft_contiguous(DoubleBuf {
                         input: input_slice,
@@ -147,7 +147,7 @@ macro_rules! boilerplate_fft_sse_f64_butterfly {
                 &self,
                 buffer: &mut [Complex<T>],
             ) -> Result<(), ()> {
-                array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                     self.perform_fft_butterfly(chunk)
                 })
             }
@@ -156,11 +156,11 @@ macro_rules! boilerplate_fft_sse_f64_butterfly {
             #[target_feature(enable = "sse4.1")]
             pub(crate) unsafe fn perform_oop_fft_butterfly_multi(
                 &self,
-                input: &mut [Complex<T>],
+                input: &[Complex<T>],
                 output: &mut [Complex<T>],
             ) -> Result<(), ()> {
                 array_utils::iter_chunks_zipped(input, output, self.len(), |in_chunk, out_chunk| {
-                    let input_slice = workaround_transmute_mut(in_chunk);
+                    let input_slice = crate::array_utils::workaround_transmute(in_chunk);
                     let output_slice = workaround_transmute_mut(out_chunk);
                     self.perform_fft_contiguous(DoubleBuf {
                         input: input_slice,
@@ -176,6 +176,25 @@ macro_rules! boilerplate_fft_sse_f64_butterfly {
 macro_rules! boilerplate_fft_sse_common_butterfly {
     ($struct_name:ident, $len:expr, $direction_fn:expr) => {
         impl<T: FftNum> Fft<T> for $struct_name<T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                _scratch: &mut [Complex<T>],
+            ) {
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+                let result = unsafe { self.perform_oop_fft_butterfly_multi(input, output) };
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -216,6 +235,10 @@ macro_rules! boilerplate_fft_sse_common_butterfly {
             }
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
+                0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
                 0
             }
         }

--- a/src/sse/sse_butterflies.rs
+++ b/src/sse/sse_butterflies.rs
@@ -184,8 +184,8 @@ macro_rules! boilerplate_fft_sse_common_butterfly {
             ) {
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    crate::common::fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
                 let result = unsafe { self.perform_oop_fft_butterfly_multi(input, output) };
 

--- a/src/sse/sse_common.rs
+++ b/src/sse/sse_common.rs
@@ -69,8 +69,8 @@ macro_rules! boilerplate_fft_sse_oop {
 
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    crate::common::fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let result = unsafe {

--- a/src/wasm_simd/wasm_simd_butterflies.rs
+++ b/src/wasm_simd/wasm_simd_butterflies.rs
@@ -142,8 +142,8 @@ macro_rules! boilerplate_fft_wasm_simd_common_butterfly {
             ) {
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
                 let result = unsafe { self.perform_oop_fft_butterfly_multi(input, output) };
 

--- a/src/wasm_simd/wasm_simd_butterflies.rs
+++ b/src/wasm_simd/wasm_simd_butterflies.rs
@@ -150,7 +150,7 @@ macro_rules! boilerplate_fft_wasm_simd_common_butterfly {
                 if result.is_err() {
                     // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
                     // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
                 }
             }
             fn process_outofplace_with_scratch(

--- a/src/wasm_simd/wasm_simd_common.rs
+++ b/src/wasm_simd/wasm_simd_common.rs
@@ -57,6 +57,37 @@ macro_rules! separate_interleaved_complex_f32 {
 macro_rules! boilerplate_fft_wasm_simd_oop {
     ($struct_name:ident, $len_fn:expr) => {
         impl<S: WasmNum, T: FftNum> Fft<T> for $struct_name<S, T> {
+            fn process_immutable_with_scratch(
+                &self,
+                input: &[Complex<T>],
+                output: &mut [Complex<T>],
+                _scratch: &mut [Complex<T>],
+            ) {
+                if self.len() == 0 {
+                    return;
+                }
+
+                if input.len() < self.len() || output.len() != input.len() {
+                    // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                }
+
+                let result = unsafe {
+                    array_utils::iter_chunks_zipped(
+                        input,
+                        output,
+                        self.len(),
+                        |in_chunk, out_chunk| self.perform_fft_immut(in_chunk, out_chunk, &mut []),
+                    )
+                };
+
+                if result.is_err() {
+                    // We want to trigger a panic, because the buffer sizes weren't cleanly divisible by the FFT size,
+                    // but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
+                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
+                }
+            }
             fn process_outofplace_with_scratch(
                 &self,
                 input: &mut [Complex<T>],
@@ -74,7 +105,7 @@ macro_rules! boilerplate_fft_wasm_simd_oop {
                 }
 
                 let result = unsafe {
-                    array_utils::iter_chunks_zipped(
+                    array_utils::iter_chunks_zipped_mut(
                         input,
                         output,
                         self.len(),
@@ -109,7 +140,7 @@ macro_rules! boilerplate_fft_wasm_simd_oop {
 
                 let scratch = &mut scratch[..required_scratch];
                 let result = unsafe {
-                    array_utils::iter_chunks(buffer, self.len(), |chunk| {
+                    array_utils::iter_chunks_mut(buffer, self.len(), |chunk| {
                         self.perform_fft_out_of_place(chunk, scratch, &mut []);
                         chunk.copy_from_slice(scratch);
                     })
@@ -132,6 +163,10 @@ macro_rules! boilerplate_fft_wasm_simd_oop {
             #[inline(always)]
             fn get_outofplace_scratch_len(&self) -> usize {
                 0
+            }
+            #[inline(always)]
+            fn get_immutable_scratch_len(&self) -> usize {
+                self.len()
             }
         }
         impl<S: WasmNum, T> Length for $struct_name<S, T> {

--- a/src/wasm_simd/wasm_simd_common.rs
+++ b/src/wasm_simd/wasm_simd_common.rs
@@ -69,8 +69,8 @@ macro_rules! boilerplate_fft_wasm_simd_oop {
 
                 if input.len() < self.len() || output.len() != input.len() {
                     // We want to trigger a panic, but we want to avoid doing it in this function to reduce code size, so call a function marked cold and inline(never) that will do it for us
-                    fft_error_outofplace(self.len(), input.len(), output.len(), 0, 0);
-                    return; // Unreachable, because fft_error_outofplace asserts, but it helps codegen to put it here
+                    fft_error_immut(self.len(), input.len(), output.len(), 0, 0);
+                    return; // Unreachable, because fft_error_immut asserts, but it helps codegen to put it here
                 }
 
                 let result = unsafe {

--- a/src/wasm_simd/wasm_simd_radix4.rs
+++ b/src/wasm_simd/wasm_simd_radix4.rs
@@ -89,41 +89,7 @@ impl<S: WasmNum, T: FftNum> WasmSimdRadix4<S, T> {
         output: &mut [Complex<T>],
         _scratch: &mut [Complex<T>],
     ) {
-        // copy the data into the output vector
-        if self.len() == self.base_len {
-            output.copy_from_slice(input);
-        } else {
-            bitreversed_transpose::<Complex<T>, 4>(self.base_len, input, output);
-        }
-
-        // Base-level FFTs
-        self.base_fft.process_with_scratch(output, &mut []);
-
-        // cross-FFTs
-        const ROW_COUNT: usize = 4;
-        let mut cross_fft_len = self.base_len * ROW_COUNT;
-        let mut layer_twiddles: &[S::VectorType] = &self.twiddles;
-
-        while cross_fft_len <= input.len() {
-            let num_rows = input.len() / cross_fft_len;
-            let num_scalar_columns = cross_fft_len / ROW_COUNT;
-            let num_vector_columns = num_scalar_columns / S::VectorType::COMPLEX_PER_VECTOR;
-
-            for i in 0..num_rows {
-                butterfly_4::<S, T>(
-                    &mut output[i * cross_fft_len..],
-                    layer_twiddles,
-                    num_scalar_columns,
-                    &self.rotation,
-                )
-            }
-
-            // skip past all the twiddle factors used in this layer
-            let twiddle_offset = num_vector_columns * (ROW_COUNT - 1);
-            layer_twiddles = &layer_twiddles[twiddle_offset..];
-
-            cross_fft_len *= ROW_COUNT;
-        }
+        self.perform_fft_out_of_place(input, output, _scratch);
     }
 
     #[target_feature(enable = "simd128")]

--- a/src/wasm_simd/wasm_simd_radix4.rs
+++ b/src/wasm_simd/wasm_simd_radix4.rs
@@ -83,6 +83,50 @@ impl<S: WasmNum, T: FftNum> WasmSimdRadix4<S, T> {
     }
 
     #[target_feature(enable = "simd128")]
+    unsafe fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        _scratch: &mut [Complex<T>],
+    ) {
+        // copy the data into the output vector
+        if self.len() == self.base_len {
+            output.copy_from_slice(input);
+        } else {
+            bitreversed_transpose::<Complex<T>, 4>(self.base_len, input, output);
+        }
+
+        // Base-level FFTs
+        self.base_fft.process_with_scratch(output, &mut []);
+
+        // cross-FFTs
+        const ROW_COUNT: usize = 4;
+        let mut cross_fft_len = self.base_len * ROW_COUNT;
+        let mut layer_twiddles: &[S::VectorType] = &self.twiddles;
+
+        while cross_fft_len <= input.len() {
+            let num_rows = input.len() / cross_fft_len;
+            let num_scalar_columns = cross_fft_len / ROW_COUNT;
+            let num_vector_columns = num_scalar_columns / S::VectorType::COMPLEX_PER_VECTOR;
+
+            for i in 0..num_rows {
+                butterfly_4::<S, T>(
+                    &mut output[i * cross_fft_len..],
+                    layer_twiddles,
+                    num_scalar_columns,
+                    &self.rotation,
+                )
+            }
+
+            // skip past all the twiddle factors used in this layer
+            let twiddle_offset = num_vector_columns * (ROW_COUNT - 1);
+            layer_twiddles = &layer_twiddles[twiddle_offset..];
+
+            cross_fft_len *= ROW_COUNT;
+        }
+    }
+
+    #[target_feature(enable = "simd128")]
     unsafe fn perform_fft_out_of_place(
         &self,
         input: &[Complex<T>],

--- a/tests/test_immutable.rs
+++ b/tests/test_immutable.rs
@@ -1,0 +1,52 @@
+use num_complex::Complex;
+use rustfft::{FftNum, FftPlanner};
+
+const TEST_MAX: usize = 1001;
+
+#[test]
+fn immutable_f32() {
+    for i in 0..TEST_MAX {
+        let input = vec![Complex::new(7.0, 8.0); i];
+
+        let mut_output = fft_wrapper_mut::<f32>(&input);
+        let immut_output = fft_wrapper_immut::<f32>(&input);
+
+        assert_eq!(mut_output, immut_output, "{}", i);
+    }
+}
+
+#[test]
+fn immutable_f64() {
+    for i in 0..TEST_MAX {
+        let input = vec![Complex::new(7.0, 8.0); i];
+
+        let mut_output = fft_wrapper_mut::<f64>(&input);
+        let immut_output = fft_wrapper_immut::<f64>(&input);
+
+        assert_eq!(mut_output, immut_output, "{}", i);
+    }
+}
+
+fn fft_wrapper_mut<T: FftNum>(input: &[Complex<T>]) -> Vec<Complex<T>> {
+    let cz = Complex::new(T::zero(), T::zero());
+    let mut plan = FftPlanner::<T>::new();
+    let p = plan.plan_fft_forward(input.len());
+
+    let mut scratch = vec![cz; p.get_inplace_scratch_len()];
+    let mut output = input.to_vec();
+
+    p.process_with_scratch(&mut output, &mut scratch);
+    output
+}
+
+fn fft_wrapper_immut<T: FftNum>(input: &[Complex<T>]) -> Vec<Complex<T>> {
+    let cz = Complex::new(T::zero(), T::zero());
+    let mut plan = FftPlanner::<T>::new();
+    let p = plan.plan_fft_forward(input.len());
+
+    let mut scratch = vec![cz; p.get_immutable_scratch_len()];
+    let mut output = vec![cz; input.len()];
+
+    p.process_immutable_with_scratch(input, &mut output, &mut scratch);
+    output
+}


### PR DESCRIPTION
Follow on for #150 

I found it easier to follow up https://github.com/ejmahler/RustFFT/pull/151#issuecomment-2709159596 with a fresh PR, so this is instead of https://github.com/ejmahler/RustFFT/pull/151.

I implemented the immutable method for scalar, AVX, SSE, Neon, and wasm, so no default method was actually needed.