### PR TITLE
Disable doctests for wasm

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -161,4 +161,4 @@ jobs:
         with:
           version: "latest"
       - name: Run test suites with wasm-pack
-        run: wasm-pack test --node -- --features wasm_simd
+        run: wasm-pack test --node --lib -- --features wasm_simd


### PR DESCRIPTION
The latest nightly's implementation of wasm doctests appears to be broken, finding false positive doctests that it never has before.

Since we don't actually need any coverage on our doctests for specifically wasm with simd, this just disables them for now.