### PR TITLE
Change compile test to `#[cfg(test)]`

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -882,7 +882,7 @@ mod unit_tests {
     }
 
     // This test is not designed to be run, only to compile.
-    // We cannot make it #[test] since there is a generic parameter.
+    #[cfg(test)]
     #[allow(dead_code)]
     fn test_impl_fft_planner_send<T: FftNum>() {
         fn is_send<T: Send>() {}


### PR DESCRIPTION
I was looking at how to do multi-dimensional FFTs (I may submit a PR for it later), and saw this note which I think can be fixed.

It's relatively minor, but thought I'd submit a PR for it anyway.