### PR TITLE
Fix a soundness issue due to arithmetic overflow

### DIFF
--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -365,7 +365,9 @@ impl<T: FftNum> GoodThomasAlgorithmSmall<T> {
 
         let width = width_fft.len();
         let height = height_fft.len();
-        let len = width * height;
+        let len = width
+            .checked_mul(height)
+            .expect("GoodThomasAlgorithmSmall length overflow");
 
         assert_eq!(width_fft.get_outofplace_scratch_len(), 0, "GoodThomasAlgorithmSmall should only be used with algorithms that require 0 out-of-place scratch. Width FFT (len={}) requires {}, should require 0", width, width_fft.get_outofplace_scratch_len());
         assert_eq!(height_fft.get_outofplace_scratch_len(), 0, "GoodThomasAlgorithmSmall should only be used with algorithms that require 0 out-of-place scratch. Height FFT (len={}) requires {}, should require 0", height, height_fft.get_outofplace_scratch_len());
@@ -568,15 +570,14 @@ mod unit_tests {
         check_fft_algorithm(&fft, width * height, direction);
     }
 
-    #[cfg(miri)]
     #[test]
-    fn miri_good_thomas_small_inner_len_product_overflow() {
-        // Memory safety issue: GoodThomasAlgorithmSmall accepts safe user-provided
-        // Fft trait objects and computes `width * height` with unchecked usize
-        // arithmetic. In release, coprime reported lengths can wrap to a tiny
-        // `self.len()`. The process path then validates only that wrapped length
-        // before calling unsafe transpose_small with the original huge dimensions,
-        // causing unchecked out-of-bounds slice access.
+    #[should_panic(expected = "GoodThomasAlgorithmSmall length overflow")]
+    fn test_good_thomas_small_rejects_inner_len_product_overflow() {
+        // Regression test for a memory safety issue: GoodThomasAlgorithmSmall
+        // accepts safe user-provided Fft trait objects, so adversarial coprime
+        // `len()` values must be rejected before a wrapped length can validate a
+        // tiny buffer and then reach unsafe transpose_small with the original huge
+        // dimensions.
         let width_fft = Arc::new(BigScratchAlgorithm {
             len: usize::MAX,
             inplace_scratch: 0,
@@ -592,12 +593,7 @@ mod unit_tests {
             direction: FftDirection::Forward,
         }) as Arc<dyn Fft<f32>>;
 
-        let fft = GoodThomasAlgorithmSmall::new(width_fft, height_fft);
-        assert_eq!(fft.len(), 3);
-
-        let mut buffer = vec![Complex::zero(); fft.len()];
-        let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
-        fft.process_with_scratch(&mut buffer, &mut scratch);
+        GoodThomasAlgorithmSmall::new(width_fft, height_fft);
     }
 
     #[test]

--- a/src/algorithm/good_thomas_algorithm.rs
+++ b/src/algorithm/good_thomas_algorithm.rs
@@ -568,6 +568,38 @@ mod unit_tests {
         check_fft_algorithm(&fft, width * height, direction);
     }
 
+    #[cfg(miri)]
+    #[test]
+    fn miri_good_thomas_small_inner_len_product_overflow() {
+        // Memory safety issue: GoodThomasAlgorithmSmall accepts safe user-provided
+        // Fft trait objects and computes `width * height` with unchecked usize
+        // arithmetic. In release, coprime reported lengths can wrap to a tiny
+        // `self.len()`. The process path then validates only that wrapped length
+        // before calling unsafe transpose_small with the original huge dimensions,
+        // causing unchecked out-of-bounds slice access.
+        let width_fft = Arc::new(BigScratchAlgorithm {
+            len: usize::MAX,
+            inplace_scratch: 0,
+            outofplace_scratch: 0,
+            immut_scratch: 0,
+            direction: FftDirection::Forward,
+        }) as Arc<dyn Fft<f32>>;
+        let height_fft = Arc::new(BigScratchAlgorithm {
+            len: usize::MAX - 2,
+            inplace_scratch: 0,
+            outofplace_scratch: 0,
+            immut_scratch: 0,
+            direction: FftDirection::Forward,
+        }) as Arc<dyn Fft<f32>>;
+
+        let fft = GoodThomasAlgorithmSmall::new(width_fft, height_fft);
+        assert_eq!(fft.len(), 3);
+
+        let mut buffer = vec![Complex::zero(); fft.len()];
+        let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
+        fft.process_with_scratch(&mut buffer, &mut scratch);
+    }
+
     #[test]
     fn test_output_mapping() {
         let width = 15;

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -286,7 +286,9 @@ impl<T: FftNum> MixedRadixSmall<T> {
         // Verify that the inner FFTs don't require out-of-place scratch, and only arequire a small amount of inplace scratch
         let width = width_fft.len();
         let height = height_fft.len();
-        let len = width * height;
+        let len = width
+            .checked_mul(height)
+            .expect("MixedRadixSmall length overflow");
 
         assert_eq!(width_fft.get_outofplace_scratch_len(), 0, "MixedRadixSmall should only be used with algorithms that require 0 out-of-place scratch. Width FFT (len={}) requires {}, should require 0", width, width_fft.get_outofplace_scratch_len());
         assert_eq!(height_fft.get_outofplace_scratch_len(), 0, "MixedRadixSmall should only be used with algorithms that require 0 out-of-place scratch. Height FFT (len={}) requires {}, should require 0", height, height_fft.get_outofplace_scratch_len());
@@ -450,15 +452,13 @@ mod unit_tests {
         check_fft_algorithm(&fft, width * height, direction);
     }
 
-    #[cfg(miri)]
     #[test]
-    fn miri_mixed_radix_small_inner_len_product_overflow() {
-        // Memory safety issue: MixedRadixSmall accepts safe user-provided Fft trait
-        // objects and computes `width * height` with unchecked usize arithmetic.
-        // In release, two safe inner FFTs can report lengths whose product wraps to
-        // a tiny `self.len()`. The public process path then validates only that
-        // wrapped length before calling the unsafe transpose_small with the original
-        // huge width and height, causing unchecked out-of-bounds slice access.
+    #[should_panic(expected = "MixedRadixSmall length overflow")]
+    fn test_mixed_radix_small_rejects_inner_len_product_overflow() {
+        // Regression test for a memory safety issue: MixedRadixSmall accepts safe
+        // user-provided Fft trait objects, so adversarial `len()` values must be
+        // rejected before a wrapped length can validate a tiny buffer and then
+        // reach unsafe transpose_small with the original huge dimensions.
         let width_fft = Arc::new(BigScratchAlgorithm {
             len: usize::MAX,
             inplace_scratch: 0,
@@ -474,12 +474,7 @@ mod unit_tests {
             direction: FftDirection::Forward,
         }) as Arc<dyn Fft<f32>>;
 
-        let fft = MixedRadixSmall::new(width_fft, height_fft);
-        assert_eq!(fft.len(), 1);
-
-        let mut buffer = vec![Complex::zero(); fft.len()];
-        let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
-        fft.process_with_scratch(&mut buffer, &mut scratch);
+        MixedRadixSmall::new(width_fft, height_fft);
     }
 
     // Verify that the mixed radix algorithm correctly provides scratch space to inner FFTs

--- a/src/algorithm/mixed_radix.rs
+++ b/src/algorithm/mixed_radix.rs
@@ -450,6 +450,38 @@ mod unit_tests {
         check_fft_algorithm(&fft, width * height, direction);
     }
 
+    #[cfg(miri)]
+    #[test]
+    fn miri_mixed_radix_small_inner_len_product_overflow() {
+        // Memory safety issue: MixedRadixSmall accepts safe user-provided Fft trait
+        // objects and computes `width * height` with unchecked usize arithmetic.
+        // In release, two safe inner FFTs can report lengths whose product wraps to
+        // a tiny `self.len()`. The public process path then validates only that
+        // wrapped length before calling the unsafe transpose_small with the original
+        // huge width and height, causing unchecked out-of-bounds slice access.
+        let width_fft = Arc::new(BigScratchAlgorithm {
+            len: usize::MAX,
+            inplace_scratch: 0,
+            outofplace_scratch: 0,
+            immut_scratch: 0,
+            direction: FftDirection::Forward,
+        }) as Arc<dyn Fft<f32>>;
+        let height_fft = Arc::new(BigScratchAlgorithm {
+            len: usize::MAX,
+            inplace_scratch: 0,
+            outofplace_scratch: 0,
+            immut_scratch: 0,
+            direction: FftDirection::Forward,
+        }) as Arc<dyn Fft<f32>>;
+
+        let fft = MixedRadixSmall::new(width_fft, height_fft);
+        assert_eq!(fft.len(), 1);
+
+        let mut buffer = vec![Complex::zero(); fft.len()];
+        let mut scratch = vec![Complex::zero(); fft.get_inplace_scratch_len()];
+        fft.process_with_scratch(&mut buffer, &mut scratch);
+    }
+
     // Verify that the mixed radix algorithm correctly provides scratch space to inner FFTs
     #[test]
     fn test_mixed_radix_inner_scratch() {


### PR DESCRIPTION
The first commit adds proof-of-concept tests that trigger out-of-bounds accesses under miri. The second one applies a fix by panicking on arithmetic overflow instead of allowing buffer overflow.

This is a memory safety issue, but I don't know how relevant this is to real-world uses since the proof-of-concept requires a custom `Fft` trait implementation.