### PR TITLE
Pin wasm-bindgen-macro to version 0.2.106

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.71
+          - 1.77
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.71
+          - 1.77
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -97,7 +97,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.71
+          - 1.77
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -147,7 +147,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.71
+          - 1.77
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.61
+          - 1.71
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.61
+          - 1.71
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -97,7 +97,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.61
+          - 1.71
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -147,7 +147,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.61
+          - 1.71
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,13 +59,9 @@ libc = "=0.2.163"
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 once_cell = "=1.20.2"
 
-# we don't need wasm-bindgen-macro directly, but a dependency does, and version 0.2.106+ requires rustc 1.71+
+# we don't need wasm-bindgen directly, but a dependency does, and version 0.2.106+ requires rustc 1.71+
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-wasm-bindgen-macro = "=0.2.106"
-
-# we don't need wasm-bindgen-shared directly, but a dependency does, and version 0.2.105+ requires rustc 1.71+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-wasm-bindgen-shared = "=0.2.105"
+wasm-bindgen = "=0.2.105"
 
 # we don't serde_json directly, but a dependency does, and version 1.0.146+ requires rustc 1.65+
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,6 @@ once_cell = "=1.20.2"
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 wasm-bindgen-macro = "=0.2.106"
 
+# we don't serde_json directly, but a dependency does, and version 1.0.146+ requires rustc 1.65+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+serde_json = "=1.0.145"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ wasm-bindgen-test = "^0.3.36"
 # we don't need bumpalo directly, but a dependency does, and version 3.15.x requires rustc 1.73+
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 bumpalo = "=3.14.0"
+
+# we don't need wasm-bindgen directly, but a dependency does, and version 0.2.118+ requires rustc 1.73+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+wasm-bindgen = "=0.2.117"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,7 @@ libc = "=0.2.163"
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 once_cell = "=1.20.2"
 
+# we don't need wasm-bindgen-macro directly, but a dependency does, and version 0.2.106+ requires rustc 1.71+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+wasm-bindgen-macro = "=0.2.106"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "rustfft"
 version = "6.4.1"
 authors = ["Allen Welkie <allen.welkie at gmail>", "Elliott Mahler <join.together at gmail>"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.71"
 
 description = "High-performance FFT library written in pure Rust."
 documentation = "https://docs.rs/rustfft/"
@@ -50,23 +50,3 @@ wasm-bindgen-test = "^0.3.36"
 # we don't need bumpalo directly, but a dependency does, and version 3.15.x requires rustc 1.73+
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 bumpalo = "=3.14.0"
-
-# we don't need libc directly, but a dependency does, and version 0.2.164+ requires rustc 1.63+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-libc = "=0.2.163"
-
-# we don't need once_cell directly, but a dependency does, and version 1.21+ requires rustc 1.66+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-once_cell = "=1.20.2"
-
-# we don't need wasm-bindgen directly, but a dependency does, and version 0.2.106+ requires rustc 1.71+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-wasm-bindgen = "=0.2.105"
-
-# we don't serde_json directly, but a dependency does, and version 1.0.146+ requires rustc 1.65+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-serde_json = "=1.0.145"
-
-# we don't itoa directly, but a dependency does, and version 1.0.16+ requires rustc 1.68+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-itoa = "=1.0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "rustfft"
 version = "6.4.1"
 authors = ["Allen Welkie <allen.welkie at gmail>", "Elliott Mahler <join.together at gmail>"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.77"
 
 description = "High-performance FFT library written in pure Rust."
 documentation = "https://docs.rs/rustfft/"
@@ -46,11 +46,3 @@ rand = "0.8"
 paste = "1.0.9"
 getrandom = {version = "^0.2", features = ["js"]}
 wasm-bindgen-test = "^0.3.36"
-
-# we don't need bumpalo directly, but a dependency does, and version 3.15.x requires rustc 1.73+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-bumpalo = "=3.14.0"
-
-# we don't need wasm-bindgen directly, but a dependency does, and version 0.2.118+ requires rustc 1.73+
-# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
-wasm-bindgen = "=0.2.117"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ wasm-bindgen = "=0.2.105"
 # we don't serde_json directly, but a dependency does, and version 1.0.146+ requires rustc 1.65+
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 serde_json = "=1.0.145"
+
+# we don't itoa directly, but a dependency does, and version 1.0.16+ requires rustc 1.68+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+itoa = "=1.0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ once_cell = "=1.20.2"
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 wasm-bindgen-macro = "=0.2.106"
 
+# we don't need wasm-bindgen-shared directly, but a dependency does, and version 0.2.105+ requires rustc 1.71+
+# it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
+wasm-bindgen-shared = "=0.2.105"
+
 # we don't serde_json directly, but a dependency does, and version 1.0.146+ requires rustc 1.65+
 # it probably isn't wise to stay on an old version for a long time, but we'll have to upgrade MSRV to upgrade
 serde_json = "=1.0.145"


### PR DESCRIPTION
Fixes the test failures with recent PRs