### PR TITLE
Add a SIMD RadixN for NEON, SSE and wasm_simd

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -281,4 +281,42 @@ impl RadixFactor {
             RadixFactor::Factor7 => 7,
         }
     }
+
+    /// Split a RadixN cross-FFT length into the layers that make it up, or None if it has a
+    /// factor no layer can handle.
+    ///
+    /// Every planner picks its base by its own rules, but once the base is divided out the rest
+    /// is the same arithmetic for all of them, so this is deliberately free of any policy.
+    pub fn split_cross_len(mut cross_len: usize) -> Option<Box<[RadixFactor]>> {
+        let mut factors = Vec::new();
+        while cross_len % 7 == 0 {
+            cross_len /= 7;
+            factors.push(RadixFactor::Factor7);
+        }
+        while cross_len % 6 == 0 {
+            cross_len /= 6;
+            factors.push(RadixFactor::Factor6);
+        }
+        while cross_len % 5 == 0 {
+            cross_len /= 5;
+            factors.push(RadixFactor::Factor5);
+        }
+        while cross_len % 3 == 0 {
+            cross_len /= 3;
+            factors.push(RadixFactor::Factor3);
+        }
+        if !cross_len.is_power_of_two() {
+            return None;
+        }
+
+        // benchmarking suggests that we want to add the 4s *last*, i suspect because 4 is a
+        // better-than-usual value for the transpose
+        let cross_bits = cross_len.trailing_zeros();
+        if cross_bits % 2 == 1 {
+            factors.push(RadixFactor::Factor2);
+        }
+        factors.extend(std::iter::repeat(RadixFactor::Factor4).take(cross_bits as usize / 2));
+
+        Some(factors.into_boxed_slice())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,11 +131,17 @@ mod plan;
 mod twiddles;
 
 // The SIMD backends all share one RadixN, generic over the vector type each of them provides
-#[cfg(all(target_arch = "aarch64", feature = "neon"))]
+#[cfg(any(
+    all(target_arch = "aarch64", feature = "neon"),
+    all(target_arch = "x86_64", feature = "sse"),
+))]
 mod simd_radixn;
 
 // ...and the planner arithmetic that goes with it
-#[cfg(all(target_arch = "aarch64", feature = "neon"))]
+#[cfg(any(
+    all(target_arch = "aarch64", feature = "neon"),
+    all(target_arch = "x86_64", feature = "sse"),
+))]
 mod simd_planner;
 
 use num_complex::Complex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ mod twiddles;
 #[cfg(any(
     all(target_arch = "aarch64", feature = "neon"),
     all(target_arch = "x86_64", feature = "sse"),
+    all(target_arch = "wasm32", feature = "wasm_simd"),
 ))]
 mod simd_radixn;
 
@@ -141,6 +142,7 @@ mod simd_radixn;
 #[cfg(any(
     all(target_arch = "aarch64", feature = "neon"),
     all(target_arch = "x86_64", feature = "sse"),
+    all(target_arch = "wasm32", feature = "wasm_simd"),
 ))]
 mod simd_planner;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,14 @@ mod math_utils;
 mod plan;
 mod twiddles;
 
+// The SIMD backends all share one RadixN, generic over the vector type each of them provides
+#[cfg(all(target_arch = "aarch64", feature = "neon"))]
+mod simd_radixn;
+
+// ...and the planner arithmetic that goes with it
+#[cfg(all(target_arch = "aarch64", feature = "neon"))]
+mod simd_planner;
+
 use num_complex::Complex;
 use num_traits::Zero;
 

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -185,6 +185,26 @@ impl PrimeFactors {
     pub fn get_other_factors(&self) -> &[PrimeFactor] {
         &self.other_factors
     }
+    /// How many times `value` divides this number, or zero if it isn't a factor at all.
+    /// `value` is assumed to be prime.
+    #[allow(unused)]
+    pub fn get_power_of(&self, value: usize) -> u32 {
+        match value {
+            2 => self.power_two,
+            3 => self.power_three,
+            _ => self
+                .other_factors
+                .iter()
+                .find_map(|f| {
+                    if f.value == value {
+                        Some(f.count)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(0),
+        }
+    }
     #[allow(unused)]
     pub fn is_power_of_three(&self) -> bool {
         self.power_three > 0 && self.power_two == 0 && self.other_factors.len() == 0

--- a/src/neon/mod.rs
+++ b/src/neon/mod.rs
@@ -7,6 +7,7 @@ mod neon_vector;
 pub mod neon_butterflies;
 pub mod neon_prime_butterflies;
 pub mod neon_radix4;
+pub mod neon_radixn;
 
 mod neon_utils;
 

--- a/src/neon/neon_common.rs
+++ b/src/neon/neon_common.rs
@@ -144,6 +144,65 @@ macro_rules! boilerplate_fft_neon_oop {
     };
 }
 
+// The `RadixNVector::fft_helper_*` methods, which are the same forwarding calls for every NEON
+// vector type: they hand the chunk loop to the target-feature-enabled wrappers below.
+macro_rules! neon_radixn_fft_helpers {
+    () => {
+        #[inline(always)]
+        unsafe fn fft_helper_immut<E>(
+            input: &[E],
+            output: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&[E], &mut [E], &mut [E]),
+        ) {
+            super::neon_common::neon_fft_helper_immut(
+                input,
+                output,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+        #[inline(always)]
+        unsafe fn fft_helper_outofplace<E>(
+            input: &mut [E],
+            output: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&mut [E], &mut [E], &mut [E]),
+        ) {
+            super::neon_common::neon_fft_helper_outofplace(
+                input,
+                output,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+        #[inline(always)]
+        unsafe fn fft_helper_inplace<E>(
+            buffer: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&mut [E], &mut [E]),
+        ) {
+            super::neon_common::neon_fft_helper_inplace(
+                buffer,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+    };
+}
+
 // A wrapper for the FFT helper functions that make sure the entire thing happens with the benefit of the NEON target feature,
 // so that things like loading twiddle factor registers etc can be lifted out of the loop
 #[target_feature(enable = "neon")]

--- a/src/neon/neon_planner.rs
+++ b/src/neon/neon_planner.rs
@@ -4,17 +4,24 @@ use std::collections::HashMap;
 
 use std::sync::Arc;
 
-use crate::{common::FftNum, fft_cache::FftCache, FftDirection};
+use crate::{
+    common::{FftNum, RadixFactor},
+    fft_cache::FftCache,
+    FftDirection,
+};
 
 use crate::algorithm::*;
 use crate::neon::neon_butterflies::*;
 use crate::neon::neon_prime_butterflies;
 use crate::neon::neon_radix4::*;
+use crate::neon::neon_radixn::*;
 use crate::Fft;
 
 use crate::math_utils::{PrimeFactor, PrimeFactors};
+use crate::simd_planner::{self, RadixNPlan};
 
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
+
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
@@ -50,6 +57,10 @@ pub enum Recipe {
         k: u32,
         base_fft: Arc<Recipe>,
     },
+    RadixN {
+        factors: Box<[RadixFactor]>,
+        base_fft: Arc<Recipe>,
+    },
     Butterfly1,
     Butterfly2,
     Butterfly3,
@@ -74,6 +85,9 @@ impl Recipe {
         match self {
             Recipe::Dft(length) => *length,
             Recipe::Radix4 { k, base_fft } => base_fft.len() * (1 << (k * 2)),
+            Recipe::RadixN { factors, base_fft } => {
+                base_fft.len() * factors.iter().map(|f| f.radix()).product::<usize>()
+            }
             Recipe::Butterfly1 => 1,
             Recipe::Butterfly2 => 2,
             Recipe::Butterfly3 => 3,
@@ -268,6 +282,16 @@ impl<T: FftNum> FftPlannerNeon<T> {
                     panic!("Not f32 or f64");
                 }
             }
+            Recipe::RadixN { factors, base_fft } => {
+                let base_fft = self.build_fft(&base_fft, direction);
+                if id_t == id_f32 {
+                    Arc::new(NeonRadixN::<f32, T>::new(factors, base_fft)) as Arc<dyn Fft<T>>
+                } else if id_t == id_f64 {
+                    Arc::new(NeonRadixN::<f64, T>::new(factors, base_fft)) as Arc<dyn Fft<T>>
+                } else {
+                    panic!("Not f32 or f64");
+                }
+            }
             Recipe::Butterfly1 => {
                 if id_t == id_f32 {
                     Arc::new(NeonF32Butterfly1::new(direction)) as Arc<dyn Fft<T>>
@@ -445,47 +469,54 @@ impl<T: FftNum> FftPlannerNeon<T> {
             fft_instance
         } else if factors.is_prime() {
             self.design_prime(len)
+        } else if len.trailing_zeros() >= MIN_RADIX4_BITS
+            && factors.get_other_factors().is_empty()
+            && factors.get_power_of_three() < 2
+        {
+            // pure powers of two, and 3 * 2^k, are Radix4's job. It's a specialised RadixN, and
+            // measurably faster than the generic driver on the shapes it covers.
+            self.design_radix4(factors)
+        } else if let Some(butterfly_product) = self.design_butterfly_product(len) {
+            butterfly_product
+        } else if let Some(radixn) = self.design_radixn(&factors) {
+            radixn
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
-            if factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2 {
-                self.design_radix4(factors)
-            } else {
-                let non_power_of_two = factors
-                    .remove_factors(PrimeFactor {
-                        value: 2,
-                        count: len.trailing_zeros(),
-                    })
-                    .unwrap();
-                let power_of_two = PrimeFactors::compute(1 << len.trailing_zeros());
-                self.design_mixed_radix(power_of_two, non_power_of_two)
-            }
+            // RadixN couldn't take this one, so fall back to peeling the power of two off the
+            // front and mixed-radixing the rest.
+            let non_power_of_two = factors
+                .remove_factors(PrimeFactor {
+                    value: 2,
+                    count: len.trailing_zeros(),
+                })
+                .unwrap();
+            let power_of_two = PrimeFactors::compute(1 << len.trailing_zeros());
+            self.design_mixed_radix(power_of_two, non_power_of_two)
         } else {
-            // Can we do this as a mixed radix with just two butterflies?
-            // Loop through and find all combinations
-            // If more than one is found, keep the one where the factors are closer together.
-            // For example length 20 where 10x2 and 5x4 are possible, we use 5x4.
-            let mut bf_left = 0;
-            let mut bf_right = 0;
-            // If the length is below 14, or over 1024 we don't need to try this.
-            if len > 13 && len <= 1024 {
-                for (n, bf_l) in self.all_butterflies.iter().enumerate() {
-                    if len % bf_l == 0 {
-                        let bf_r = len / bf_l;
-                        if self.all_butterflies.iter().skip(n).any(|&m| m == bf_r) {
-                            bf_left = *bf_l;
-                            bf_right = bf_r;
-                        }
-                    }
-                }
-                if bf_left > 0 {
-                    let fact_l = PrimeFactors::compute(bf_left);
-                    let fact_r = PrimeFactors::compute(bf_right);
-                    return self.design_mixed_radix(fact_l, fact_r);
-                }
-            }
-            // Not possible with just butterflies, go with the general solution.
             let (left_factors, right_factors) = factors.partition_factors();
             self.design_mixed_radix(left_factors, right_factors)
         }
+    }
+
+    // Can we do this as a mixed radix with just two butterflies?
+    fn design_butterfly_product(&mut self, len: usize) -> Option<Arc<Recipe>> {
+        let (bf_left, bf_right) =
+            simd_planner::design_butterfly_product(len, &self.all_butterflies)?;
+
+        let fact_l = PrimeFactors::compute(bf_left);
+        let fact_r = PrimeFactors::compute(bf_right);
+        Some(self.design_mixed_radix(fact_l, fact_r))
+    }
+
+    // Design a RadixN, or the Radix4 that some of its shapes are better served by. Returns None
+    // when RadixN can't cover this length, and the caller falls back to mixed radix.
+    fn design_radixn(&mut self, factors: &PrimeFactors) -> Option<Arc<Recipe>> {
+        let plan = simd_planner::design_radixn(factors, simd_planner::complex_per_vector::<T>())?;
+
+        let base_fft = self.design_fft_for_len(plan.base_len());
+        Some(match plan {
+            RadixNPlan::Radix4 { k, .. } => Arc::new(Recipe::Radix4 { k, base_fft }),
+            RadixNPlan::RadixN { factors, .. } => Arc::new(Recipe::RadixN { factors, base_fft }),
+        })
     }
 
     fn design_mixed_radix(
@@ -643,6 +674,13 @@ mod unit_tests {
         }
     }
 
+    fn is_radixn(plan: &Recipe) -> bool {
+        match plan {
+            &Recipe::RadixN { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_mixedradixsmall(plan: &Recipe) -> bool {
         match plan {
             &Recipe::MixedRadixSmall { .. } => true,
@@ -721,7 +759,19 @@ mod unit_tests {
 
     #[test]
     fn test_plan_neon_mixedradix() {
-        // Products of several different primes should become MixedRadix
+        // Products of several primes that are all too big for a RadixN cross-FFT layer should
+        // become MixedRadix
+        let mut planner = FftPlannerNeon::<f64>::new().unwrap();
+        for len in [11 * 11 * 13, 11 * 13 * 17, 17 * 19 * 23, 11 * 13 * 17 * 19] {
+            let plan = planner.design_fft_for_len(len);
+            assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
+            assert_eq!(plan.len(), len, "Recipe reports wrong length");
+        }
+    }
+
+    #[test]
+    fn test_plan_neon_radixn() {
+        // Products of several small primes should become RadixN
         let mut planner = FftPlannerNeon::<f64>::new().unwrap();
         for pow2 in 2..5 {
             for pow3 in 2..5 {
@@ -732,7 +782,7 @@ mod unit_tests {
                             * 5usize.pow(pow5)
                             * 7usize.pow(pow7);
                         let plan = planner.design_fft_for_len(len);
-                        assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
+                        assert!(is_radixn(&plan), "Expected RadixN, got {:?}", plan);
                         assert_eq!(plan.len(), len, "Recipe reports wrong length");
                     }
                 }
@@ -741,10 +791,27 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_plan_neon_radixn_f32_needs_an_even_base() {
+        // An f32 vector holds two complex numbers, so RadixN needs an even column count and can
+        // never take an odd length. Those have to keep falling back to mixed radix.
+        let mut planner32 = FftPlannerNeon::<f32>::new().unwrap();
+        let mut planner64 = FftPlannerNeon::<f64>::new().unwrap();
+        for len in [1215, 10125, 3125] {
+            let plan32 = planner32.design_fft_for_len(len);
+            assert!(!is_radixn(&plan32), "Expected no RadixN, got {:?}", plan32);
+            assert_eq!(plan32.len(), len, "Recipe reports wrong length");
+
+            let plan64 = planner64.design_fft_for_len(len);
+            assert!(is_radixn(&plan64), "Expected RadixN, got {:?}", plan64);
+            assert_eq!(plan64.len(), len, "Recipe reports wrong length");
+        }
+    }
+
+    #[test]
     fn test_plan_neon_mixedradixsmall() {
         // Products of two "small" lengths < 31 that have a common divisor >1, and isn't a power of 2 should be MixedRadixSmall
         let mut planner = FftPlannerNeon::<f64>::new().unwrap();
-        for len in [5 * 20, 5 * 25].iter() {
+        for len in [5 * 20, 6 * 9, 12 * 15, 10 * 15].iter() {
             let plan = planner.design_fft_for_len(*len);
             assert!(
                 is_mixedradixsmall(&plan),

--- a/src/neon/neon_prime_butterflies.rs
+++ b/src/neon/neon_prime_butterflies.rs
@@ -78,7 +78,7 @@ fn make_twiddles<const TW: usize, T: FftNum>(len: usize, direction: FftDirection
     })
 }
 
-struct NeonF32Butterfly7<T> {
+pub struct NeonF32Butterfly7<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 3],
     twiddles_im: [float32x4_t; 3],
@@ -89,7 +89,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly7, 7, |this: &NeonF32Butterf
 impl<T: FftNum> NeonF32Butterfly7<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(7, direction);
         Self {
@@ -182,7 +182,7 @@ impl<T: FftNum> NeonF32Butterfly7<T> {
     }
 }
 
-struct NeonF64Butterfly7<T> {
+pub struct NeonF64Butterfly7<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 3],
     twiddles_im: [float64x2_t; 3],
@@ -193,7 +193,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly7, 7, |this: &NeonF64Butterf
 impl<T: FftNum> NeonF64Butterfly7<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(7, direction);
         unsafe {Self {
@@ -257,7 +257,7 @@ impl<T: FftNum> NeonF64Butterfly7<T> {
     }
 }
 
-struct NeonF32Butterfly11<T> {
+pub struct NeonF32Butterfly11<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 5],
     twiddles_im: [float32x4_t; 5],
@@ -268,7 +268,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly11, 11, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly11<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(11, direction);
         Self {
@@ -411,7 +411,7 @@ impl<T: FftNum> NeonF32Butterfly11<T> {
     }
 }
 
-struct NeonF64Butterfly11<T> {
+pub struct NeonF64Butterfly11<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 5],
     twiddles_im: [float64x2_t; 5],
@@ -422,7 +422,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly11, 11, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly11<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(11, direction);
         unsafe {Self {
@@ -528,7 +528,7 @@ impl<T: FftNum> NeonF64Butterfly11<T> {
     }
 }
 
-struct NeonF32Butterfly13<T> {
+pub struct NeonF32Butterfly13<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 6],
     twiddles_im: [float32x4_t; 6],
@@ -539,7 +539,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly13, 13, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly13<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(13, direction);
         Self {
@@ -713,7 +713,7 @@ impl<T: FftNum> NeonF32Butterfly13<T> {
     }
 }
 
-struct NeonF64Butterfly13<T> {
+pub struct NeonF64Butterfly13<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 6],
     twiddles_im: [float64x2_t; 6],
@@ -724,7 +724,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly13, 13, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly13<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(13, direction);
         unsafe {Self {
@@ -857,7 +857,7 @@ impl<T: FftNum> NeonF64Butterfly13<T> {
     }
 }
 
-struct NeonF32Butterfly17<T> {
+pub struct NeonF32Butterfly17<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 8],
     twiddles_im: [float32x4_t; 8],
@@ -868,7 +868,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly17, 17, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly17<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(17, direction);
         Self {
@@ -1116,7 +1116,7 @@ impl<T: FftNum> NeonF32Butterfly17<T> {
     }
 }
 
-struct NeonF64Butterfly17<T> {
+pub struct NeonF64Butterfly17<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 8],
     twiddles_im: [float64x2_t; 8],
@@ -1127,7 +1127,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly17, 17, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly17<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(17, direction);
         unsafe {Self {
@@ -1326,7 +1326,7 @@ impl<T: FftNum> NeonF64Butterfly17<T> {
     }
 }
 
-struct NeonF32Butterfly19<T> {
+pub struct NeonF32Butterfly19<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 9],
     twiddles_im: [float32x4_t; 9],
@@ -1337,7 +1337,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly19, 19, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly19<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(19, direction);
         Self {
@@ -1628,7 +1628,7 @@ impl<T: FftNum> NeonF32Butterfly19<T> {
     }
 }
 
-struct NeonF64Butterfly19<T> {
+pub struct NeonF64Butterfly19<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 9],
     twiddles_im: [float64x2_t; 9],
@@ -1639,7 +1639,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly19, 19, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly19<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(19, direction);
         unsafe {Self {
@@ -1877,7 +1877,7 @@ impl<T: FftNum> NeonF64Butterfly19<T> {
     }
 }
 
-struct NeonF32Butterfly23<T> {
+pub struct NeonF32Butterfly23<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 11],
     twiddles_im: [float32x4_t; 11],
@@ -1888,7 +1888,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly23, 23, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly23<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(23, direction);
         Self {
@@ -2277,7 +2277,7 @@ impl<T: FftNum> NeonF32Butterfly23<T> {
     }
 }
 
-struct NeonF64Butterfly23<T> {
+pub struct NeonF64Butterfly23<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 11],
     twiddles_im: [float64x2_t; 11],
@@ -2288,7 +2288,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly23, 23, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly23<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(23, direction);
         unsafe {Self {
@@ -2616,7 +2616,7 @@ impl<T: FftNum> NeonF64Butterfly23<T> {
     }
 }
 
-struct NeonF32Butterfly29<T> {
+pub struct NeonF32Butterfly29<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 14],
     twiddles_im: [float32x4_t; 14],
@@ -2627,7 +2627,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly29, 29, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly29<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(29, direction);
         Self {
@@ -3193,7 +3193,7 @@ impl<T: FftNum> NeonF32Butterfly29<T> {
     }
 }
 
-struct NeonF64Butterfly29<T> {
+pub struct NeonF64Butterfly29<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 14],
     twiddles_im: [float64x2_t; 14],
@@ -3204,7 +3204,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly29, 29, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly29<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(29, direction);
         unsafe {Self {
@@ -3697,7 +3697,7 @@ impl<T: FftNum> NeonF64Butterfly29<T> {
     }
 }
 
-struct NeonF32Butterfly31<T> {
+pub struct NeonF32Butterfly31<T> {
     direction: FftDirection,
     twiddles_re: [float32x4_t; 15],
     twiddles_im: [float32x4_t; 15],
@@ -3708,7 +3708,7 @@ boilerplate_fft_neon_f32_butterfly!(NeonF32Butterfly31, 31, |this: &NeonF32Butte
 impl<T: FftNum> NeonF32Butterfly31<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(31, direction);
         Self {
@@ -4341,7 +4341,7 @@ impl<T: FftNum> NeonF32Butterfly31<T> {
     }
 }
 
-struct NeonF64Butterfly31<T> {
+pub struct NeonF64Butterfly31<T> {
     direction: FftDirection,
     twiddles_re: [float64x2_t; 15],
     twiddles_im: [float64x2_t; 15],
@@ -4352,7 +4352,7 @@ boilerplate_fft_neon_f64_butterfly!(NeonF64Butterfly31, 31, |this: &NeonF64Butte
 impl<T: FftNum> NeonF64Butterfly31<T> {
     /// Safety: The current machine must support the neon instruction set
     #[target_feature(enable = "neon")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(31, direction);
         unsafe {Self {

--- a/src/neon/neon_radixn.rs
+++ b/src/neon/neon_radixn.rs
@@ -1,0 +1,224 @@
+//! The NEON side of `SimdRadixN`.
+//!
+//! The algorithm itself lives in `src/simd_radixn.rs`, shared by every SIMD backend. All that is
+//! left here is the `RadixNVector` impl for each vector type: the NEON loads, stores and vector
+//! math, and the element-type-specific butterfly structs for radix 3, 5, 6 and 7.
+
+use std::arch::aarch64::{float32x4_t, float64x2_t};
+
+use num_complex::Complex;
+
+use crate::simd_radixn::{RadixNVector, SimdRadixN};
+use crate::FftDirection;
+
+use super::neon_butterflies::{
+    NeonF32Butterfly3, NeonF32Butterfly5, NeonF32Butterfly6, NeonF64Butterfly3, NeonF64Butterfly5,
+    NeonF64Butterfly6,
+};
+use super::neon_prime_butterflies::{NeonF32Butterfly7, NeonF64Butterfly7};
+use super::neon_vector::{NeonArray, NeonArrayMut, NeonVector, Rotation90};
+use super::NeonNum;
+
+/// FFT algorithm for lengths that factor into small radixes, NEON accelerated version.
+/// This is designed to be used via a Planner, and not created directly.
+pub type NeonRadixN<N, T> = SimdRadixN<<N as NeonNum>::VectorType, T>;
+
+impl RadixNVector for float64x2_t {
+    const COMPLEX_PER_VECTOR: usize = 1;
+
+    type ScalarType = f64;
+    type Rotation = Rotation90<Self>;
+
+    type Butterfly3 = NeonF64Butterfly3<f64>;
+    type Butterfly5 = NeonF64Butterfly5<f64>;
+    type Butterfly6 = NeonF64Butterfly6<f64>;
+    type Butterfly7 = NeonF64Butterfly7<f64>;
+
+    #[inline(always)]
+    unsafe fn load(data: &[Complex<f64>], index: usize) -> Self {
+        data.load_complex(index)
+    }
+    #[inline(always)]
+    unsafe fn store(mut data: &mut [Complex<f64>], value: Self, index: usize) {
+        data.store_complex(value, index)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        NeonVector::mul_complex(left, right)
+    }
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        NeonVector::make_mixedradix_twiddle_chunk(x, y, len, direction)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation {
+        NeonVector::make_rotate90(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3 {
+        NeonF64Butterfly3::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5 {
+        NeonF64Butterfly5::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6 {
+        NeonF64Butterfly6::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7 {
+        NeonF64Butterfly7::new(direction)
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        NeonVector::column_butterfly2(rows)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3] {
+        bf.perform_fft_direct(rows[0], rows[1], rows[2])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4] {
+        NeonVector::column_butterfly4(rows, rotation)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5] {
+        bf.perform_fft_direct(rows[0], rows[1], rows[2], rows[3], rows[4])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6] {
+        bf.perform_fft_direct(rows)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7] {
+        bf.perform_fft_direct(rows)
+    }
+
+    neon_radixn_fft_helpers!();
+}
+
+impl RadixNVector for float32x4_t {
+    const COMPLEX_PER_VECTOR: usize = 2;
+
+    type ScalarType = f32;
+    type Rotation = Rotation90<Self>;
+
+    type Butterfly3 = NeonF32Butterfly3<f32>;
+    type Butterfly5 = NeonF32Butterfly5<f32>;
+    type Butterfly6 = NeonF32Butterfly6<f32>;
+    type Butterfly7 = NeonF32Butterfly7<f32>;
+
+    #[inline(always)]
+    unsafe fn load(data: &[Complex<f32>], index: usize) -> Self {
+        data.load_complex(index)
+    }
+    #[inline(always)]
+    unsafe fn store(mut data: &mut [Complex<f32>], value: Self, index: usize) {
+        data.store_complex(value, index)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        NeonVector::mul_complex(left, right)
+    }
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        NeonVector::make_mixedradix_twiddle_chunk(x, y, len, direction)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation {
+        NeonVector::make_rotate90(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3 {
+        NeonF32Butterfly3::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5 {
+        NeonF32Butterfly5::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6 {
+        NeonF32Butterfly6::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7 {
+        NeonF32Butterfly7::new(direction)
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        NeonVector::column_butterfly2(rows)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3] {
+        bf.perform_parallel_fft_direct(rows[0], rows[1], rows[2])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4] {
+        NeonVector::column_butterfly4(rows, rotation)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5] {
+        bf.perform_parallel_fft_direct(rows[0], rows[1], rows[2], rows[3], rows[4])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6] {
+        bf.perform_parallel_fft_direct(rows[0], rows[1], rows[2], rows[3], rows[4], rows[5])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7] {
+        bf.perform_parallel_fft_direct(rows)
+    }
+
+    neon_radixn_fft_helpers!();
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::simd_radixn::test_bodies;
+
+    #[test]
+    fn test_neon_radixn_f64() {
+        // f64 fits one complex per vector, so every base length is legal
+        test_bodies::factor_pairs::<float64x2_t>(&[1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn test_neon_radixn_f32() {
+        // f32 fits two complex per vector, so the base length has to be even
+        test_bodies::factor_pairs::<float32x4_t>(&[2, 4, 6]);
+    }
+
+    #[test]
+    fn test_neon_radixn_composite_base() {
+        test_bodies::composite_base::<float32x4_t, float64x2_t>();
+    }
+
+    #[test]
+    fn test_neon_radixn_large_recipes() {
+        test_bodies::large_recipes::<float32x4_t, float64x2_t>();
+    }
+
+    #[test]
+    #[ignore]
+    fn test_neon_radixn_six_layers() {
+        test_bodies::six_layers::<float32x4_t, float64x2_t>();
+    }
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -506,18 +506,10 @@ impl<T: FftNum> FftPlannerScalar<T> {
     }
 
     fn design_radixn(&mut self, factors: PrimeFactors) -> Arc<Recipe> {
-        let p2 = factors.get_power_of_two();
-        let p3 = factors.get_power_of_three();
-        let p5 = factors
-            .get_other_factors()
-            .iter()
-            .find_map(|f| if f.value == 5 { Some(f.count) } else { None }) // if we had rustc 1.62, we could use (f.value == 5).then_some(f.count)
-            .unwrap_or(0);
-        let p7 = factors
-            .get_other_factors()
-            .iter()
-            .find_map(|f| if f.value == 7 { Some(f.count) } else { None })
-            .unwrap_or(0);
+        let p2 = factors.get_power_of(2);
+        let p3 = factors.get_power_of(3);
+        let p5 = factors.get_power_of(5);
+        let p7 = factors.get_power_of(7);
 
         let base_len: usize = if factors.has_factors_gt(MAX_RADIXN_FACTOR) {
             // If we have factors larger than RadixN can handle, we *must* use the product of those factors as our base
@@ -563,7 +555,7 @@ impl<T: FftNum> FftPlannerScalar<T> {
 
         // now that we know the base length, divide it out get what radix4 needs to compute
         let base_fft = self.design_fft_for_len(base_len);
-        let mut cross_len = factors.get_product() / base_len;
+        let cross_len = factors.get_product() / base_len;
 
         // see if we can use radix4
         let cross_bits = cross_len.trailing_zeros();
@@ -574,36 +566,10 @@ impl<T: FftNum> FftPlannerScalar<T> {
 
         // we weren't able to use radix4, so fall back to RadixN
         // theoretically we could do this with the p2, p3, p5 etc values above, but our choice of base knocked them out of sync
-        let mut factors = Vec::new();
-        while cross_len % 7 == 0 {
-            cross_len /= 7;
-            factors.push(RadixFactor::Factor7);
-        }
-        while cross_len % 6 == 0 {
-            cross_len /= 6;
-            factors.push(RadixFactor::Factor6);
-        }
-        while cross_len % 5 == 0 {
-            cross_len /= 5;
-            factors.push(RadixFactor::Factor5);
-        }
-        while cross_len % 3 == 0 {
-            cross_len /= 3;
-            factors.push(RadixFactor::Factor3);
-        }
-        assert!(cross_len.is_power_of_two());
+        let factors = RadixFactor::split_cross_len(cross_len)
+            .expect("Every factor RadixN can't handle should have gone into the base");
 
-        // benchmarking suggests that we want to add the 4s *last*, i suspect because 4 is a better-than-usual value for the transpose
-        let cross_bits = cross_len.trailing_zeros();
-        if cross_bits % 2 == 1 {
-            factors.push(RadixFactor::Factor2);
-        }
-        factors.extend(std::iter::repeat(RadixFactor::Factor4).take(cross_bits as usize / 2));
-
-        Arc::new(Recipe::RadixN {
-            factors: factors.into_boxed_slice(),
-            base_fft,
-        })
+        Arc::new(Recipe::RadixN { factors, base_fft })
     }
 
     // Returns Some(instance) if we have a butterfly available for this size. Returns None if there is no butterfly available for this size

--- a/src/simd_planner.rs
+++ b/src/simd_planner.rs
@@ -1,0 +1,178 @@
+//! The FFT design decisions that every SIMD planner makes the same way.
+//!
+//! `FftPlannerNeon`, `FftPlannerSse` and `FftPlannerWasmSimd` each own a private `Recipe` enum
+//! and a private cache, so they can't share the planner itself. What they can share is the
+//! arithmetic that picks a plan, which is a pure function of the length's prime factors and of
+//! how many complex numbers fit in one of the backend's vectors. These functions do that part
+//! and hand back plain numbers; the caller turns them into its own recipes.
+//!
+//! The scalar planner in `src/plan.rs` deliberately stays out of this. Sharing the choice logic
+//! would tie the SIMD backends to the scalar planner's algorithm set, and the two have never been
+//! required to match: each backend has its own butterflies, its own Radix4 bases, and its own
+//! answer for primes. Its `design_radixn` already differs in ways that change plans, not just
+//! style, so folding it in would be a planner change to measure, not a deduplication.
+
+use crate::common::RadixFactor;
+use crate::math_utils::PrimeFactors;
+use crate::FftNum;
+
+use std::any::TypeId;
+
+const MAX_RADIXN_FACTOR: usize = 7; // The largest butterfly factor that the RadixN algorithm can handle
+
+/// How many complex numbers fit in one SIMD vector, which is what decides the column-count
+/// constraints on RadixN and Radix4.
+///
+/// Every backend here has 128 bit vectors, so this only depends on the float type.
+pub fn complex_per_vector<T: FftNum>() -> usize {
+    if TypeId::of::<T>() == TypeId::of::<f32>() {
+        2
+    } else {
+        1
+    }
+}
+
+/// What `design_radixn` decided, in terms the caller turns into its own recipe.
+pub enum RadixNPlan {
+    Radix4 {
+        k: u32,
+        base_len: usize,
+    },
+    RadixN {
+        factors: Box<[RadixFactor]>,
+        base_len: usize,
+    },
+}
+
+impl RadixNPlan {
+    /// The base FFT length, which both variants carry, so the caller can build it once.
+    pub fn base_len(&self) -> usize {
+        match self {
+            RadixNPlan::Radix4 { base_len, .. } => *base_len,
+            RadixNPlan::RadixN { base_len, .. } => *base_len,
+        }
+    }
+}
+
+/// Can we do this as a mixed radix with just two butterflies?
+///
+/// Loops through and finds all combinations. If more than one is found, keeps the one where the
+/// factors are closer together. For example length 20, where 10x2 and 5x4 are possible, gives 5x4.
+///
+/// `all_butterflies` is the sorted list of lengths the backend has a butterfly for.
+pub fn design_butterfly_product(len: usize, all_butterflies: &[usize]) -> Option<(usize, usize)> {
+    // If the length is below 14, or over 1024 we don't need to try this.
+    if len <= 13 || len > 1024 {
+        return None;
+    }
+
+    let mut bf_left = 0;
+    let mut bf_right = 0;
+    for (n, bf_l) in all_butterflies.iter().enumerate() {
+        if len % bf_l == 0 {
+            let bf_r = len / bf_l;
+            if all_butterflies.iter().skip(n).any(|&m| m == bf_r) {
+                bf_left = *bf_l;
+                bf_right = bf_r;
+            }
+        }
+    }
+    if bf_left == 0 {
+        return None;
+    }
+
+    Some((bf_left, bf_right))
+}
+
+/// Design a RadixN: fold any factors too big for a cross-FFT layer into the base, pick a base
+/// for what's left, and turn the rest into a list of radixes. Mirrors `design_radixn` in
+/// `src/plan.rs`, which the scalar planner uses for the same job.
+///
+/// Returns None when RadixN can't cover this length, which happens for f32 when no legal base
+/// is available. The caller falls back to mixed radix in that case.
+pub fn design_radixn(factors: &PrimeFactors, complex_per_vector: usize) -> Option<RadixNPlan> {
+    // With no factors small enough for a cross-FFT layer, the base would have to be the whole
+    // length and there would be nothing left for RadixN to do.
+    if !factors.has_factors_leq(MAX_RADIXN_FACTOR) {
+        return None;
+    }
+
+    let len = factors.get_product();
+    let p2 = factors.get_power_of(2);
+    let p3 = factors.get_power_of(3);
+    let p5 = factors.get_power_of(5);
+    let p7 = factors.get_power_of(7);
+
+    let mut base_len: usize = if factors.has_factors_gt(MAX_RADIXN_FACTOR) {
+        // Factors larger than a cross-FFT layer can handle *must* go in the base
+        factors.product_above(MAX_RADIXN_FACTOR)
+    } else if p7 == 0 && p5 == 0 && p3 < 2 {
+        // pure powers of two, and 3 * 2^k. Use the same bases design_radix4 does, so that the
+        // Radix4 escape below hands these over unchanged.
+        if p3 == 0 {
+            if p2 % 2 == 1 {
+                32
+            } else {
+                16
+            }
+        } else if p2 % 2 == 1 {
+            24
+        } else {
+            12
+        }
+    } else if p2 > 0 && p3 > 0 {
+        // a mixed bag of 2s and 3s
+        match p2.saturating_sub(p3) {
+            0 => 6,
+            1 => 12,
+            _ => 24,
+        }
+    } else if p3 > 2 {
+        27
+    } else if p3 > 1 {
+        9
+    } else if p7 > 0 {
+        7
+    } else {
+        assert!(p5 > 0);
+        5
+    };
+
+    // An f32 vector holds two complex numbers, so every cross-FFT layer needs an even column
+    // count. The column count starts at base_len, so an odd base is unusable: fold one of the
+    // length's factors of two into it instead. If there isn't one to spare, RadixN can't do
+    // this length at all.
+    if base_len % complex_per_vector != 0 {
+        if (len / base_len) % 2 != 0 {
+            return None;
+        }
+        base_len *= 2;
+    }
+
+    if base_len >= len || len % base_len != 0 {
+        return None;
+    }
+
+    let cross_len = len / base_len;
+
+    // Radix4 is faster than the generic driver on pure powers of four, so hand those over. It
+    // needs twice the column count RadixN does, hence the extra check on the base.
+    let cross_bits = cross_len.trailing_zeros();
+    if cross_len.is_power_of_two()
+        && cross_bits % 2 == 0
+        && base_len % (2 * complex_per_vector) == 0
+    {
+        return Some(RadixNPlan::Radix4 {
+            k: cross_bits / 2,
+            base_len,
+        });
+    }
+
+    // Split what's left into cross-FFT layers. Every factor too big for a layer went into the
+    // base above, so the split can't fail, and the same expect guards it in `src/plan.rs`.
+    Some(RadixNPlan::RadixN {
+        factors: RadixFactor::split_cross_len(cross_len)
+            .expect("Every factor RadixN can't handle should have gone into the base"),
+        base_len,
+    })
+}

--- a/src/simd_radixn.rs
+++ b/src/simd_radixn.rs
@@ -1,0 +1,679 @@
+//! The body of the SIMD `RadixN` implementations, shared by every SIMD backend.
+//!
+//! This mirrors `src/algorithm/radixn.rs`: one flat transpose down to a base FFT, then a stack of
+//! in-place cross-FFT layers over a single packed twiddle array. The only difference is that the
+//! cross-FFT layers use SIMD column butterflies instead of the scalar ones, so a whole vector of
+//! columns is processed per butterfly call.
+//!
+//! Everything here is generic over `RadixNVector`, which is the handful of vector operations the
+//! algorithm needs. A backend implements that trait once per vector type and gets the algorithm,
+//! so `SimdRadixN` is the only copy of it.
+//!
+//! Because a column butterfly consumes `COMPLEX_PER_VECTOR` columns at a time, the column count at
+//! every layer has to be a whole number of vectors. The column count starts at `base_len` and only
+//! ever grows by whole factors, so requiring `base_len % COMPLEX_PER_VECTOR == 0` is enough. That
+//! is 1 for f64 (no restriction) and 2 for f32.
+
+use std::any::TypeId;
+use std::sync::Arc;
+
+use num_complex::Complex;
+
+use crate::array_utils::{factor_transpose, workaround_transmute_mut, TransposeFactor};
+use crate::common::{FftNum, RadixFactor};
+use crate::{Direction, Fft, FftDirection, Length};
+
+/// Everything `SimdRadixN` needs from a backend's vector type.
+///
+/// Radix 2 and 4 are vector-generic in every backend, so they map straight onto the backend's
+/// vector trait. Radix 3, 5, 6 and 7 only exist as element-type-specific structs holding
+/// precomputed twiddles, so this trait pairs each vector type with its own set of them. For f64 a
+/// vector is one complex number and the plain `perform_fft_direct` is already a single column; for
+/// f32 a vector is two complex numbers and `perform_parallel_fft_direct` does two columns at once.
+///
+/// Safety: every method here requires the current machine to support the backend's SIMD
+/// instruction set.
+pub trait RadixNVector: Copy + Send + Sync + Sized {
+    const COMPLEX_PER_VECTOR: usize;
+
+    /// The scalar this vector holds. Always the same type as the `T` of the `SimdRadixN` using it.
+    type ScalarType: FftNum;
+
+    /// The backend's precomputed 90 degree rotation, which the radix 4 butterfly needs.
+    type Rotation: Copy + Send + Sync;
+
+    type Butterfly3: Send + Sync;
+    type Butterfly5: Send + Sync;
+    type Butterfly6: Send + Sync;
+    type Butterfly7: Send + Sync;
+
+    unsafe fn load(data: &[Complex<Self::ScalarType>], index: usize) -> Self;
+    unsafe fn store(data: &mut [Complex<Self::ScalarType>], value: Self, index: usize);
+
+    /// Pairwise multiply the complex numbers in `left` with the complex numbers in `right`.
+    unsafe fn mul_complex(left: Self, right: Self) -> Self;
+
+    /// Generates a chunk of twiddle factors starting at (X,Y) and incrementing X
+    /// `COMPLEX_PER_VECTOR` times.
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self;
+
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation;
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3;
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5;
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6;
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7;
+
+    /// Each of these interprets the input as rows of a `COMPLEX_PER_VECTOR`-by-N 2D array, and
+    /// computes parallel butterflies down the columns of the 2D array.
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2];
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3];
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4];
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5];
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6];
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7];
+
+    /// The three `fft_helper_*` wrappers from the backend's `*_common.rs`, which run the whole
+    /// chunk loop with the backend's target feature enabled so that things like loading twiddle
+    /// factor registers can be lifted out of the loop.
+    unsafe fn fft_helper_immut<E>(
+        input: &[E],
+        output: &mut [E],
+        scratch: &mut [E],
+        chunk_size: usize,
+        required_scratch: usize,
+        chunk_fn: impl FnMut(&[E], &mut [E], &mut [E]),
+    );
+    unsafe fn fft_helper_outofplace<E>(
+        input: &mut [E],
+        output: &mut [E],
+        scratch: &mut [E],
+        chunk_size: usize,
+        required_scratch: usize,
+        chunk_fn: impl FnMut(&mut [E], &mut [E], &mut [E]),
+    );
+    unsafe fn fft_helper_inplace<E>(
+        buffer: &mut [E],
+        scratch: &mut [E],
+        chunk_size: usize,
+        required_scratch: usize,
+        chunk_fn: impl FnMut(&mut [E], &mut [E]),
+    );
+}
+
+/// The per-layer cross-FFT kernels, holding whatever precomputed state each radix needs.
+enum InternalRadixFactor<V: RadixNVector> {
+    Factor2,
+    Factor3(V::Butterfly3),
+    Factor4(V::Rotation),
+    Factor5(V::Butterfly5),
+    Factor6(V::Butterfly6),
+    Factor7(V::Butterfly7),
+}
+
+impl<V: RadixNVector> InternalRadixFactor<V> {
+    fn radix(&self) -> usize {
+        match self {
+            InternalRadixFactor::Factor2 => 2,
+            InternalRadixFactor::Factor3(_) => 3,
+            InternalRadixFactor::Factor4(_) => 4,
+            InternalRadixFactor::Factor5(_) => 5,
+            InternalRadixFactor::Factor6(_) => 6,
+            InternalRadixFactor::Factor7(_) => 7,
+        }
+    }
+}
+
+/// FFT algorithm for lengths that factor into small radixes, SIMD accelerated version.
+/// This is designed to be used via a Planner, and not created directly.
+pub struct SimdRadixN<V: RadixNVector, T> {
+    twiddles: Box<[V]>,
+
+    base_fft: Arc<dyn Fft<T>>,
+    base_len: usize,
+
+    factors: Box<[TransposeFactor]>,
+    butterflies: Box<[InternalRadixFactor<V>]>,
+
+    len: usize,
+    direction: FftDirection,
+
+    inplace_scratch_len: usize,
+    outofplace_scratch_len: usize,
+    immut_scratch_len: usize,
+}
+
+impl<V: RadixNVector, T: FftNum> SimdRadixN<V, T> {
+    /// Constructs a SimdRadixN which computes FFTs of length `factor_product * base_fft.len()`.
+    pub fn new(factors: &[RadixFactor], base_fft: Arc<dyn Fft<T>>) -> Self {
+        // Internal sanity check: Make sure that the vector's scalar type is T.
+        // This struct has two generic parameters V and T, but T must always be V's scalar type,
+        // and they are only kept separate to help work around the lack of specialization.
+        assert_eq!(TypeId::of::<V::ScalarType>(), TypeId::of::<T>());
+
+        let base_len = base_fft.len();
+        let direction = base_fft.fft_direction();
+        let complex_per_vector = V::COMPLEX_PER_VECTOR;
+
+        // Every cross-FFT layer processes a whole vector of columns at a time. The column count
+        // starts at base_len and is only ever multiplied by a factor, so this one check covers
+        // every layer.
+        assert!(
+            factors.is_empty() || base_len % complex_per_vector == 0,
+            "SimdRadixN requires a base length divisible by {}, got {}",
+            complex_per_vector,
+            base_len
+        );
+
+        // set up our cross FFT butterfly instances. simultaneously, compute the number of twiddles
+        let mut butterflies = Vec::with_capacity(factors.len());
+        let mut cross_fft_len = base_len;
+        let mut twiddle_count = 0;
+
+        for factor in factors {
+            // twiddles are stored a vector at a time, so a layer needs one chunk per vector column
+            twiddle_count += (cross_fft_len / complex_per_vector) * (factor.radix() - 1);
+
+            butterflies.push(unsafe {
+                match factor {
+                    RadixFactor::Factor2 => InternalRadixFactor::Factor2,
+                    RadixFactor::Factor3 => {
+                        InternalRadixFactor::Factor3(V::make_butterfly3(direction))
+                    }
+                    RadixFactor::Factor4 => {
+                        InternalRadixFactor::Factor4(V::make_rotate90(direction))
+                    }
+                    RadixFactor::Factor5 => {
+                        InternalRadixFactor::Factor5(V::make_butterfly5(direction))
+                    }
+                    RadixFactor::Factor6 => {
+                        InternalRadixFactor::Factor6(V::make_butterfly6(direction))
+                    }
+                    RadixFactor::Factor7 => {
+                        InternalRadixFactor::Factor7(V::make_butterfly7(direction))
+                    }
+                }
+            });
+
+            cross_fft_len *= factor.radix();
+        }
+        let len = cross_fft_len;
+
+        // set up our list of transpose factors - it's the same list but reversed, and we want to
+        // collapse duplicates. Note that we are only de-duplicating adjacent factors: if we're
+        // passed 7 * 2 * 7, we can't collapse the sevens because the exact order matters.
+        let mut transpose_factors: Vec<TransposeFactor> = Vec::with_capacity(factors.len());
+        for f in factors.iter().rev() {
+            let mut push_new = true;
+            if let Some(last) = transpose_factors.last_mut() {
+                if last.factor == *f {
+                    last.count += 1;
+                    push_new = false;
+                }
+            }
+            if push_new {
+                transpose_factors.push(TransposeFactor {
+                    factor: *f,
+                    count: 1,
+                });
+            }
+        }
+
+        // Same packing as the scalar RadixN: all layers in one array, bottom layer first, and
+        // within a layer, (radix - 1) twiddles per column. The difference is that a "column" here
+        // is a whole vector of columns, so each entry is a twiddle chunk rather than one twiddle.
+        let mut twiddle_factors: Vec<V> = Vec::with_capacity(twiddle_count);
+        let mut cross_fft_len = base_len;
+        for factor in factors {
+            let num_vector_columns = cross_fft_len / complex_per_vector;
+            cross_fft_len *= factor.radix();
+
+            for i in 0..num_vector_columns {
+                for k in 1..factor.radix() {
+                    unsafe {
+                        twiddle_factors.push(V::make_mixedradix_twiddle_chunk(
+                            i * complex_per_vector,
+                            k,
+                            cross_fft_len,
+                            direction,
+                        ));
+                    }
+                }
+            }
+        }
+
+        // figure out how much scratch space we need to request from callers
+        let base_inplace_scratch = base_fft.get_inplace_scratch_len();
+        let inplace_scratch_len = if base_inplace_scratch > len {
+            len + base_inplace_scratch
+        } else {
+            len
+        };
+        let outofplace_scratch_len = if base_inplace_scratch > len {
+            base_inplace_scratch
+        } else {
+            0
+        };
+
+        Self {
+            twiddles: twiddle_factors.into_boxed_slice(),
+
+            base_fft,
+            base_len,
+
+            factors: transpose_factors.into_boxed_slice(),
+            butterflies: butterflies.into_boxed_slice(),
+
+            len,
+            direction,
+
+            inplace_scratch_len,
+            outofplace_scratch_len,
+            immut_scratch_len: base_inplace_scratch,
+        }
+    }
+
+    /// The flat transpose that reorders the input down to base-sized chunks.
+    #[inline(always)]
+    fn transpose(&self, input: &[Complex<T>], output: &mut [Complex<T>]) {
+        if let Some(unroll_factor) = self.factors.first() {
+            // for performance, we really, really want to unroll the transpose, but we need to make
+            // sure the output length is divisible by the unroll amount. choosing the first factor
+            // seems to reliably perform well
+            match unroll_factor.factor {
+                RadixFactor::Factor2 => {
+                    factor_transpose::<Complex<T>, 2>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor3 => {
+                    factor_transpose::<Complex<T>, 3>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor4 => {
+                    factor_transpose::<Complex<T>, 4>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor5 => {
+                    factor_transpose::<Complex<T>, 5>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor6 => {
+                    factor_transpose::<Complex<T>, 6>(self.base_len, input, output, &self.factors)
+                }
+                RadixFactor::Factor7 => {
+                    factor_transpose::<Complex<T>, 7>(self.base_len, input, output, &self.factors)
+                }
+            }
+        } else {
+            // no factors, so just pass data straight to our base
+            output.copy_from_slice(input);
+        }
+    }
+
+    /// The stack of in-place cross-FFT layers, run after the base FFTs.
+    unsafe fn cross_ffts(&self, output: &mut [Complex<T>]) {
+        let out: &mut [Complex<V::ScalarType>] = workaround_transmute_mut(output);
+
+        let mut cross_fft_len = self.base_len;
+        let mut layer_twiddles: &[V] = &self.twiddles;
+
+        for factor in self.butterflies.iter() {
+            let num_columns = cross_fft_len;
+            cross_fft_len *= factor.radix();
+
+            for data in out.chunks_exact_mut(cross_fft_len) {
+                match factor {
+                    InternalRadixFactor::Factor2 => {
+                        cross_layer::<V, 2, _>(data, layer_twiddles, num_columns, |v| {
+                            V::column_butterfly2(v)
+                        })
+                    }
+                    InternalRadixFactor::Factor3(bf) => {
+                        cross_layer::<V, 3, _>(data, layer_twiddles, num_columns, |v| {
+                            V::column_butterfly3(bf, v)
+                        })
+                    }
+                    InternalRadixFactor::Factor4(rotation) => {
+                        cross_layer::<V, 4, _>(data, layer_twiddles, num_columns, |v| {
+                            V::column_butterfly4(v, *rotation)
+                        })
+                    }
+                    InternalRadixFactor::Factor5(bf) => {
+                        cross_layer::<V, 5, _>(data, layer_twiddles, num_columns, |v| {
+                            V::column_butterfly5(bf, v)
+                        })
+                    }
+                    InternalRadixFactor::Factor6(bf) => {
+                        cross_layer::<V, 6, _>(data, layer_twiddles, num_columns, |v| {
+                            V::column_butterfly6(bf, v)
+                        })
+                    }
+                    InternalRadixFactor::Factor7(bf) => {
+                        cross_layer::<V, 7, _>(data, layer_twiddles, num_columns, |v| {
+                            V::column_butterfly7(bf, v)
+                        })
+                    }
+                }
+            }
+
+            // skip past all the twiddle factors used in this layer
+            let twiddle_offset = (num_columns / V::COMPLEX_PER_VECTOR) * (factor.radix() - 1);
+            layer_twiddles = &layer_twiddles[twiddle_offset..];
+        }
+    }
+
+    unsafe fn perform_fft_immut(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        self.transpose(input, output);
+        self.base_fft.process_with_scratch(output, scratch);
+        self.cross_ffts(output);
+    }
+
+    unsafe fn perform_fft_out_of_place(
+        &self,
+        input: &mut [Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        self.transpose(input, output);
+
+        // the input is free once the transpose is done, so use it as base scratch when we weren't
+        // handed any of our own
+        let base_scratch = if !scratch.is_empty() { scratch } else { input };
+        self.base_fft.process_with_scratch(output, base_scratch);
+
+        self.cross_ffts(output);
+    }
+}
+
+impl<V: RadixNVector, T: FftNum> Fft<T> for SimdRadixN<V, T> {
+    fn process_immutable_with_scratch(
+        &self,
+        input: &[Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        unsafe {
+            V::fft_helper_immut(
+                input,
+                output,
+                scratch,
+                self.len(),
+                self.get_immutable_scratch_len(),
+                |in_chunk, out_chunk, scratch| self.perform_fft_immut(in_chunk, out_chunk, scratch),
+            );
+        }
+    }
+    fn process_outofplace_with_scratch(
+        &self,
+        input: &mut [Complex<T>],
+        output: &mut [Complex<T>],
+        scratch: &mut [Complex<T>],
+    ) {
+        unsafe {
+            V::fft_helper_outofplace(
+                input,
+                output,
+                scratch,
+                self.len(),
+                self.get_outofplace_scratch_len(),
+                |in_chunk, out_chunk, scratch| {
+                    self.perform_fft_out_of_place(in_chunk, out_chunk, scratch)
+                },
+            );
+        }
+    }
+    fn process_with_scratch(&self, buffer: &mut [Complex<T>], scratch: &mut [Complex<T>]) {
+        unsafe {
+            V::fft_helper_inplace(
+                buffer,
+                scratch,
+                self.len(),
+                self.get_inplace_scratch_len(),
+                |chunk, scratch| {
+                    let (self_scratch, inner_scratch) = scratch.split_at_mut(self.len());
+                    self.perform_fft_out_of_place(chunk, self_scratch, inner_scratch);
+                    chunk.copy_from_slice(self_scratch);
+                },
+            )
+        }
+    }
+    #[inline(always)]
+    fn get_inplace_scratch_len(&self) -> usize {
+        self.inplace_scratch_len
+    }
+    #[inline(always)]
+    fn get_outofplace_scratch_len(&self) -> usize {
+        self.outofplace_scratch_len
+    }
+    #[inline(always)]
+    fn get_immutable_scratch_len(&self) -> usize {
+        self.immut_scratch_len
+    }
+}
+impl<V: RadixNVector, T> Length for SimdRadixN<V, T> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+impl<V: RadixNVector, T> Direction for SimdRadixN<V, T> {
+    #[inline(always)]
+    fn fft_direction(&self) -> FftDirection {
+        self.direction
+    }
+}
+
+/// One cross-FFT layer: for each vector of columns, gather RADIX rows strided by `num_columns`,
+/// apply the twiddles, run the column butterfly, scatter back.
+///
+/// Unrolled two vectors at a time, which is what the SIMD Radix4's `butterfly_4` does and is what
+/// gets the two independent dependency chains needed to keep the FMA pipeline busy.
+#[inline(always)]
+unsafe fn cross_layer<V: RadixNVector, const RADIX: usize, F>(
+    data: &mut [Complex<V::ScalarType>],
+    twiddles: &[V],
+    num_columns: usize,
+    butterfly: F,
+) where
+    F: Fn([V; RADIX]) -> [V; RADIX],
+{
+    let complex_per_vector = V::COMPLEX_PER_VECTOR;
+    let num_vector_columns = num_columns / complex_per_vector;
+    let tw_stride = RADIX - 1;
+
+    debug_assert!(twiddles.len() >= num_vector_columns * tw_stride);
+
+    // The row-0 twiddle is always 1, so it's neither stored nor applied.
+    let gather = |data: &[Complex<V::ScalarType>], idx: usize, tw_base: usize| -> [V; RADIX] {
+        // row 0 first, so the array is fully initialized without `array::from_fn`, which is
+        // newer than the crate MSRV
+        let mut rows = [V::load(data, idx); RADIX];
+        for (r, row) in rows.iter_mut().enumerate().skip(1) {
+            let v = V::load(data, idx + r * num_columns);
+            *row = V::mul_complex(v, *twiddles.get_unchecked(tw_base + r - 1));
+        }
+        rows
+    };
+
+    let mut vcol = 0;
+    while vcol + 2 <= num_vector_columns {
+        let idx = vcol * complex_per_vector;
+
+        let a = gather(data, idx, vcol * tw_stride);
+        let b = gather(data, idx + complex_per_vector, (vcol + 1) * tw_stride);
+
+        let a = butterfly(a);
+        let b = butterfly(b);
+
+        for (r, (a_row, b_row)) in a.iter().zip(b.iter()).enumerate() {
+            V::store(data, *a_row, idx + r * num_columns);
+            V::store(data, *b_row, idx + complex_per_vector + r * num_columns);
+        }
+
+        vcol += 2;
+    }
+
+    // an odd vector column count leaves one behind
+    if vcol < num_vector_columns {
+        let idx = vcol * complex_per_vector;
+        let a = butterfly(gather(data, idx, vcol * tw_stride));
+        for (r, a_row) in a.iter().enumerate() {
+            V::store(data, *a_row, idx + r * num_columns);
+        }
+    }
+}
+
+/// The test bodies, shared the same way the algorithm is. Every backend runs all of them, from a
+/// thin test function per body that names its own vector types. The bodies that exercise both
+/// element types take both vector types, so `V32` is always the f32 vector and `V64` the f64 one.
+#[cfg(test)]
+pub mod test_bodies {
+    use super::*;
+    use crate::test_utils::{check_fft_algorithm, construct_base};
+    use num_traits::Float;
+    use rand::distributions::uniform::SampleUniform;
+
+    const FACTOR_LIST: &[RadixFactor] = &[
+        RadixFactor::Factor2,
+        RadixFactor::Factor3,
+        RadixFactor::Factor4,
+        RadixFactor::Factor5,
+        RadixFactor::Factor6,
+        RadixFactor::Factor7,
+    ];
+
+    /// Every empty, one-factor and two-factor recipe over each of `bases`, both directions.
+    pub fn factor_pairs<V>(bases: &[usize])
+    where
+        V: RadixNVector,
+        V::ScalarType: Float + SampleUniform,
+    {
+        for base in bases {
+            let base_forward = construct_base(*base, FftDirection::Forward);
+            let base_inverse = construct_base(*base, FftDirection::Inverse);
+
+            check::<V>(&[], Arc::clone(&base_forward));
+            check::<V>(&[], Arc::clone(&base_inverse));
+
+            for factor_a in FACTOR_LIST {
+                check::<V>(&[*factor_a], Arc::clone(&base_forward));
+                check::<V>(&[*factor_a], Arc::clone(&base_inverse));
+
+                for factor_b in FACTOR_LIST {
+                    let factors = &[*factor_a, *factor_b];
+                    check::<V>(factors, Arc::clone(&base_forward));
+                    check::<V>(factors, Arc::clone(&base_inverse));
+                }
+            }
+        }
+    }
+
+    /// The base doesn't have to be a scratch-free butterfly. A composite base is a recursive
+    /// recipe that needs its own scratch, which is the case `design_radixn` hits whenever a length
+    /// has factors above 7 (for example 11 * 13 = 143).
+    pub fn composite_base<V32, V64>()
+    where
+        V32: RadixNVector<ScalarType = f32>,
+        V64: RadixNVector<ScalarType = f64>,
+    {
+        let mut planner64 = crate::FftPlannerScalar::<f64>::new();
+        let mut planner32 = crate::FftPlannerScalar::<f32>::new();
+
+        for direction in [FftDirection::Forward, FftDirection::Inverse] {
+            // odd base, f64 only
+            for base_len in [143, 55, 65] {
+                let base = planner64.plan_fft(base_len, direction);
+                assert!(
+                    base.get_inplace_scratch_len() > 0,
+                    "base {} was expected to need scratch",
+                    base_len
+                );
+                check::<V64>(&[RadixFactor::Factor6, RadixFactor::Factor4], base);
+            }
+
+            // even base, usable by both element types
+            for base_len in [22, 26, 110] {
+                let base = planner32.plan_fft(base_len, direction);
+                assert!(
+                    base.get_inplace_scratch_len() > 0,
+                    "base {} was expected to need scratch",
+                    base_len
+                );
+                check::<V32>(&[RadixFactor::Factor3, RadixFactor::Factor4], base);
+
+                let base = planner64.plan_fft(base_len, direction);
+                check::<V64>(&[RadixFactor::Factor3, RadixFactor::Factor4], base);
+            }
+        }
+    }
+
+    /// The recipes the spike was benchmarked on, so the layer shapes that actually matter stay
+    /// covered. The benchmarked lengths used much bigger bases, but the base is just a butterfly
+    /// that the other tests already cover, so the smallest legal one is used here. That keeps the
+    /// naive `Dft` the result is checked against affordable.
+    pub fn large_recipes<V32, V64>()
+    where
+        V32: RadixNVector<ScalarType = f32>,
+        V64: RadixNVector<ScalarType = f64>,
+    {
+        use RadixFactor::*;
+        // (factors, f64 base, f32 base). f32 needs an even base, so it gets its own.
+        let cases: [(&[RadixFactor], usize, usize); 5] = [
+            (&[Factor6, Factor6, Factor6], 1, 2),          // 216, 432
+            (&[Factor6, Factor5, Factor5], 1, 2),          // 150, 300
+            (&[Factor6, Factor6, Factor4], 1, 2),          // 144, 288
+            (&[Factor6, Factor6, Factor3], 1, 2),          // 108, 216
+            (&[Factor6, Factor6, Factor6, Factor4], 1, 2), // 864, 1728
+        ];
+        recipes::<V32, V64>(&cases);
+    }
+
+    /// The deepest benchmarked recipe, six layers. The smallest legal base still leaves 14400
+    /// (f64) and 28800 (f32) points, and the naive `Dft` they are checked against takes minutes
+    /// on a debug build, so this one is kept out of the normal run. Run it with
+    /// `cargo test --release -- --ignored radixn_six_layers`.
+    pub fn six_layers<V32, V64>()
+    where
+        V32: RadixNVector<ScalarType = f32>,
+        V64: RadixNVector<ScalarType = f64>,
+    {
+        use RadixFactor::*;
+        let cases: [(&[RadixFactor], usize, usize); 1] = [(
+            &[Factor6, Factor6, Factor5, Factor5, Factor4, Factor4],
+            1,
+            2,
+        )]; // 14400, 28800
+        recipes::<V32, V64>(&cases);
+    }
+
+    /// Runs each (factors, f64 base, f32 base) case in both directions.
+    fn recipes<V32, V64>(cases: &[(&[RadixFactor], usize, usize)])
+    where
+        V32: RadixNVector<ScalarType = f32>,
+        V64: RadixNVector<ScalarType = f64>,
+    {
+        for (factors, base64, base32) in cases {
+            for direction in [FftDirection::Forward, FftDirection::Inverse] {
+                check::<V64>(factors, construct_base(*base64, direction));
+                check::<V32>(factors, construct_base(*base32, direction));
+            }
+        }
+    }
+
+    fn check<V>(factors: &[RadixFactor], base_fft: Arc<dyn Fft<V::ScalarType>>)
+    where
+        V: RadixNVector,
+        V::ScalarType: Float + SampleUniform,
+    {
+        let len = base_fft.len() * factors.iter().map(|f| f.radix()).product::<usize>();
+        let direction = base_fft.fft_direction();
+        let fft: SimdRadixN<V, V::ScalarType> = SimdRadixN::new(factors, base_fft);
+
+        check_fft_algorithm::<V::ScalarType>(&fft, len, direction);
+    }
+}

--- a/src/simd_radixn.rs
+++ b/src/simd_radixn.rs
@@ -321,34 +321,46 @@ impl<V: RadixNVector, T: FftNum> SimdRadixN<V, T> {
             let num_columns = cross_fft_len;
             cross_fft_len *= factor.radix();
 
-            for data in out.chunks_exact_mut(cross_fft_len) {
-                match factor {
-                    InternalRadixFactor::Factor2 => {
+            // Dispatch once per layer rather than once per chunk, so each layer runs a single
+            // monomorphized loop over its chunks. Mirrors the scalar `RadixN`.
+            match factor {
+                InternalRadixFactor::Factor2 => {
+                    for data in out.chunks_exact_mut(cross_fft_len) {
                         cross_layer::<V, 2, _>(data, layer_twiddles, num_columns, |v| {
                             V::column_butterfly2(v)
                         })
                     }
-                    InternalRadixFactor::Factor3(bf) => {
+                }
+                InternalRadixFactor::Factor3(bf) => {
+                    for data in out.chunks_exact_mut(cross_fft_len) {
                         cross_layer::<V, 3, _>(data, layer_twiddles, num_columns, |v| {
                             V::column_butterfly3(bf, v)
                         })
                     }
-                    InternalRadixFactor::Factor4(rotation) => {
+                }
+                InternalRadixFactor::Factor4(rotation) => {
+                    for data in out.chunks_exact_mut(cross_fft_len) {
                         cross_layer::<V, 4, _>(data, layer_twiddles, num_columns, |v| {
                             V::column_butterfly4(v, *rotation)
                         })
                     }
-                    InternalRadixFactor::Factor5(bf) => {
+                }
+                InternalRadixFactor::Factor5(bf) => {
+                    for data in out.chunks_exact_mut(cross_fft_len) {
                         cross_layer::<V, 5, _>(data, layer_twiddles, num_columns, |v| {
                             V::column_butterfly5(bf, v)
                         })
                     }
-                    InternalRadixFactor::Factor6(bf) => {
+                }
+                InternalRadixFactor::Factor6(bf) => {
+                    for data in out.chunks_exact_mut(cross_fft_len) {
                         cross_layer::<V, 6, _>(data, layer_twiddles, num_columns, |v| {
                             V::column_butterfly6(bf, v)
                         })
                     }
-                    InternalRadixFactor::Factor7(bf) => {
+                }
+                InternalRadixFactor::Factor7(bf) => {
+                    for data in out.chunks_exact_mut(cross_fft_len) {
                         cross_layer::<V, 7, _>(data, layer_twiddles, num_columns, |v| {
                             V::column_butterfly7(bf, v)
                         })

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -7,6 +7,7 @@ mod sse_vector;
 pub mod sse_butterflies;
 pub mod sse_prime_butterflies;
 pub mod sse_radix4;
+pub mod sse_radixn;
 
 mod sse_utils;
 

--- a/src/sse/sse_common.rs
+++ b/src/sse/sse_common.rs
@@ -144,6 +144,65 @@ macro_rules! boilerplate_fft_sse_oop {
     };
 }
 
+// The `RadixNVector::fft_helper_*` methods, which are the same forwarding calls for every SSE
+// vector type: they hand the chunk loop to the target-feature-enabled wrappers below.
+macro_rules! sse_radixn_fft_helpers {
+    () => {
+        #[inline(always)]
+        unsafe fn fft_helper_immut<E>(
+            input: &[E],
+            output: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&[E], &mut [E], &mut [E]),
+        ) {
+            super::sse_common::sse_fft_helper_immut(
+                input,
+                output,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+        #[inline(always)]
+        unsafe fn fft_helper_outofplace<E>(
+            input: &mut [E],
+            output: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&mut [E], &mut [E], &mut [E]),
+        ) {
+            super::sse_common::sse_fft_helper_outofplace(
+                input,
+                output,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+        #[inline(always)]
+        unsafe fn fft_helper_inplace<E>(
+            buffer: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&mut [E], &mut [E]),
+        ) {
+            super::sse_common::sse_fft_helper_inplace(
+                buffer,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+    };
+}
+
 // A wrapper for the FFT helper functions that make sure the entire thing happens with the benefit of the SSE target feature,
 // so that things like loading twiddle factor registers etc can be lifted out of the loop
 #[target_feature(enable = "sse4.1")]

--- a/src/sse/sse_planner.rs
+++ b/src/sse/sse_planner.rs
@@ -4,17 +4,24 @@ use std::collections::HashMap;
 
 use std::sync::Arc;
 
-use crate::{common::FftNum, fft_cache::FftCache, FftDirection};
+use crate::{
+    common::{FftNum, RadixFactor},
+    fft_cache::FftCache,
+    FftDirection,
+};
 
 use crate::algorithm::*;
 use crate::sse::sse_butterflies::*;
 use crate::sse::sse_prime_butterflies;
 use crate::sse::sse_radix4::*;
+use crate::sse::sse_radixn::*;
 use crate::Fft;
 
 use crate::math_utils::{PrimeFactor, PrimeFactors};
+use crate::simd_planner::{self, RadixNPlan};
 
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
+
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
@@ -50,6 +57,10 @@ pub enum Recipe {
         k: u32,
         base_fft: Arc<Recipe>,
     },
+    RadixN {
+        factors: Box<[RadixFactor]>,
+        base_fft: Arc<Recipe>,
+    },
     Butterfly1,
     Butterfly2,
     Butterfly3,
@@ -74,6 +85,9 @@ impl Recipe {
         match self {
             Recipe::Dft(length) => *length,
             Recipe::Radix4 { k, base_fft } => base_fft.len() * (1 << (k * 2)),
+            Recipe::RadixN { factors, base_fft } => {
+                base_fft.len() * factors.iter().map(|f| f.radix()).product::<usize>()
+            }
             Recipe::Butterfly1 => 1,
             Recipe::Butterfly2 => 2,
             Recipe::Butterfly3 => 3,
@@ -268,6 +282,16 @@ impl<T: FftNum> FftPlannerSse<T> {
                     panic!("Not f32 or f64");
                 }
             }
+            Recipe::RadixN { factors, base_fft } => {
+                let base_fft = self.build_fft(&base_fft, direction);
+                if id_t == id_f32 {
+                    Arc::new(SseRadixN::<f32, T>::new(factors, base_fft)) as Arc<dyn Fft<T>>
+                } else if id_t == id_f64 {
+                    Arc::new(SseRadixN::<f64, T>::new(factors, base_fft)) as Arc<dyn Fft<T>>
+                } else {
+                    panic!("Not f32 or f64");
+                }
+            }
             Recipe::Butterfly1 => {
                 if id_t == id_f32 {
                     Arc::new(SseF32Butterfly1::new(direction)) as Arc<dyn Fft<T>>
@@ -446,47 +470,54 @@ impl<T: FftNum> FftPlannerSse<T> {
             fft_instance
         } else if factors.is_prime() {
             self.design_prime(len)
+        } else if len.trailing_zeros() >= MIN_RADIX4_BITS
+            && factors.get_other_factors().is_empty()
+            && factors.get_power_of_three() < 2
+        {
+            // pure powers of two, and 3 * 2^k, are Radix4's job. It's a specialised RadixN, and
+            // measurably faster than the generic driver on the shapes it covers.
+            self.design_radix4(factors)
+        } else if let Some(butterfly_product) = self.design_butterfly_product(len) {
+            butterfly_product
+        } else if let Some(radixn) = self.design_radixn(&factors) {
+            radixn
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
-            if factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2 {
-                self.design_radix4(factors)
-            } else {
-                let non_power_of_two = factors
-                    .remove_factors(PrimeFactor {
-                        value: 2,
-                        count: len.trailing_zeros(),
-                    })
-                    .unwrap();
-                let power_of_two = PrimeFactors::compute(1 << len.trailing_zeros());
-                self.design_mixed_radix(power_of_two, non_power_of_two)
-            }
+            // RadixN couldn't take this one, so fall back to peeling the power of two off the
+            // front and mixed-radixing the rest.
+            let non_power_of_two = factors
+                .remove_factors(PrimeFactor {
+                    value: 2,
+                    count: len.trailing_zeros(),
+                })
+                .unwrap();
+            let power_of_two = PrimeFactors::compute(1 << len.trailing_zeros());
+            self.design_mixed_radix(power_of_two, non_power_of_two)
         } else {
-            // Can we do this as a mixed radix with just two butterflies?
-            // Loop through and find all combinations
-            // If more than one is found, keep the one where the factors are closer together.
-            // For example length 20 where 10x2 and 5x4 are possible, we use 5x4.
-            let mut bf_left = 0;
-            let mut bf_right = 0;
-            // If the length is below 14, or over 1024 we don't need to try this.
-            if len > 13 && len <= 1024 {
-                for (n, bf_l) in self.all_butterflies.iter().enumerate() {
-                    if len % bf_l == 0 {
-                        let bf_r = len / bf_l;
-                        if self.all_butterflies.iter().skip(n).any(|&m| m == bf_r) {
-                            bf_left = *bf_l;
-                            bf_right = bf_r;
-                        }
-                    }
-                }
-                if bf_left > 0 {
-                    let fact_l = PrimeFactors::compute(bf_left);
-                    let fact_r = PrimeFactors::compute(bf_right);
-                    return self.design_mixed_radix(fact_l, fact_r);
-                }
-            }
-            // Not possible with just butterflies, go with the general solution.
             let (left_factors, right_factors) = factors.partition_factors();
             self.design_mixed_radix(left_factors, right_factors)
         }
+    }
+
+    // Can we do this as a mixed radix with just two butterflies?
+    fn design_butterfly_product(&mut self, len: usize) -> Option<Arc<Recipe>> {
+        let (bf_left, bf_right) =
+            simd_planner::design_butterfly_product(len, &self.all_butterflies)?;
+
+        let fact_l = PrimeFactors::compute(bf_left);
+        let fact_r = PrimeFactors::compute(bf_right);
+        Some(self.design_mixed_radix(fact_l, fact_r))
+    }
+
+    // Design a RadixN, or the Radix4 that some of its shapes are better served by. Returns None
+    // when RadixN can't cover this length, and the caller falls back to mixed radix.
+    fn design_radixn(&mut self, factors: &PrimeFactors) -> Option<Arc<Recipe>> {
+        let plan = simd_planner::design_radixn(factors, simd_planner::complex_per_vector::<T>())?;
+
+        let base_fft = self.design_fft_for_len(plan.base_len());
+        Some(match plan {
+            RadixNPlan::Radix4 { k, .. } => Arc::new(Recipe::Radix4 { k, base_fft }),
+            RadixNPlan::RadixN { factors, .. } => Arc::new(Recipe::RadixN { factors, base_fft }),
+        })
     }
 
     fn design_mixed_radix(
@@ -644,6 +675,13 @@ mod unit_tests {
         }
     }
 
+    fn is_radixn(plan: &Recipe) -> bool {
+        match plan {
+            &Recipe::RadixN { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_mixedradixsmall(plan: &Recipe) -> bool {
         match plan {
             &Recipe::MixedRadixSmall { .. } => true,
@@ -722,7 +760,19 @@ mod unit_tests {
 
     #[test]
     fn test_plan_sse_mixedradix() {
-        // Products of several different primes should become MixedRadix
+        // Products of several primes that are all too big for a RadixN cross-FFT layer should
+        // become MixedRadix
+        let mut planner = FftPlannerSse::<f64>::new().unwrap();
+        for len in [11 * 11 * 13, 11 * 13 * 17, 17 * 19 * 23, 11 * 13 * 17 * 19] {
+            let plan = planner.design_fft_for_len(len);
+            assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
+            assert_eq!(plan.len(), len, "Recipe reports wrong length");
+        }
+    }
+
+    #[test]
+    fn test_plan_sse_radixn() {
+        // Products of several small primes should become RadixN
         let mut planner = FftPlannerSse::<f64>::new().unwrap();
         for pow2 in 2..5 {
             for pow3 in 2..5 {
@@ -733,7 +783,7 @@ mod unit_tests {
                             * 5usize.pow(pow5)
                             * 7usize.pow(pow7);
                         let plan = planner.design_fft_for_len(len);
-                        assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
+                        assert!(is_radixn(&plan), "Expected RadixN, got {:?}", plan);
                         assert_eq!(plan.len(), len, "Recipe reports wrong length");
                     }
                 }
@@ -742,10 +792,27 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_plan_sse_radixn_f32_needs_an_even_base() {
+        // An f32 vector holds two complex numbers, so RadixN needs an even column count and can
+        // never take an odd length. Those have to keep falling back to mixed radix.
+        let mut planner32 = FftPlannerSse::<f32>::new().unwrap();
+        let mut planner64 = FftPlannerSse::<f64>::new().unwrap();
+        for len in [1215, 10125, 3125] {
+            let plan32 = planner32.design_fft_for_len(len);
+            assert!(!is_radixn(&plan32), "Expected no RadixN, got {:?}", plan32);
+            assert_eq!(plan32.len(), len, "Recipe reports wrong length");
+
+            let plan64 = planner64.design_fft_for_len(len);
+            assert!(is_radixn(&plan64), "Expected RadixN, got {:?}", plan64);
+            assert_eq!(plan64.len(), len, "Recipe reports wrong length");
+        }
+    }
+
+    #[test]
     fn test_plan_sse_mixedradixsmall() {
         // Products of two "small" lengths < 31 that have a common divisor >1, and isn't a power of 2 should be MixedRadixSmall
         let mut planner = FftPlannerSse::<f64>::new().unwrap();
-        for len in [5 * 20, 5 * 25].iter() {
+        for len in [5 * 20, 6 * 9, 12 * 15, 10 * 15].iter() {
             let plan = planner.design_fft_for_len(*len);
             assert!(
                 is_mixedradixsmall(&plan),

--- a/src/sse/sse_prime_butterflies.rs
+++ b/src/sse/sse_prime_butterflies.rs
@@ -78,7 +78,7 @@ fn make_twiddles<const TW: usize, T: FftNum>(len: usize, direction: FftDirection
     })
 }
 
-struct SseF32Butterfly7<T> {
+pub struct SseF32Butterfly7<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 3],
     twiddles_im: [__m128; 3],
@@ -89,7 +89,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly7, 7, |this: &SseF32Butterfly7
 impl<T: FftNum> SseF32Butterfly7<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(7, direction);
         Self {
@@ -182,7 +182,7 @@ impl<T: FftNum> SseF32Butterfly7<T> {
     }
 }
 
-struct SseF64Butterfly7<T> {
+pub struct SseF64Butterfly7<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 3],
     twiddles_im: [__m128d; 3],
@@ -193,7 +193,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly7, 7, |this: &SseF64Butterfly7
 impl<T: FftNum> SseF64Butterfly7<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(7, direction);
         unsafe {Self {
@@ -257,7 +257,7 @@ impl<T: FftNum> SseF64Butterfly7<T> {
     }
 }
 
-struct SseF32Butterfly11<T> {
+pub struct SseF32Butterfly11<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 5],
     twiddles_im: [__m128; 5],
@@ -268,7 +268,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly11, 11, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly11<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(11, direction);
         Self {
@@ -411,7 +411,7 @@ impl<T: FftNum> SseF32Butterfly11<T> {
     }
 }
 
-struct SseF64Butterfly11<T> {
+pub struct SseF64Butterfly11<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 5],
     twiddles_im: [__m128d; 5],
@@ -422,7 +422,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly11, 11, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly11<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(11, direction);
         unsafe {Self {
@@ -528,7 +528,7 @@ impl<T: FftNum> SseF64Butterfly11<T> {
     }
 }
 
-struct SseF32Butterfly13<T> {
+pub struct SseF32Butterfly13<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 6],
     twiddles_im: [__m128; 6],
@@ -539,7 +539,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly13, 13, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly13<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(13, direction);
         Self {
@@ -713,7 +713,7 @@ impl<T: FftNum> SseF32Butterfly13<T> {
     }
 }
 
-struct SseF64Butterfly13<T> {
+pub struct SseF64Butterfly13<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 6],
     twiddles_im: [__m128d; 6],
@@ -724,7 +724,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly13, 13, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly13<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(13, direction);
         unsafe {Self {
@@ -857,7 +857,7 @@ impl<T: FftNum> SseF64Butterfly13<T> {
     }
 }
 
-struct SseF32Butterfly17<T> {
+pub struct SseF32Butterfly17<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 8],
     twiddles_im: [__m128; 8],
@@ -868,7 +868,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly17, 17, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly17<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(17, direction);
         Self {
@@ -1116,7 +1116,7 @@ impl<T: FftNum> SseF32Butterfly17<T> {
     }
 }
 
-struct SseF64Butterfly17<T> {
+pub struct SseF64Butterfly17<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 8],
     twiddles_im: [__m128d; 8],
@@ -1127,7 +1127,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly17, 17, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly17<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(17, direction);
         unsafe {Self {
@@ -1326,7 +1326,7 @@ impl<T: FftNum> SseF64Butterfly17<T> {
     }
 }
 
-struct SseF32Butterfly19<T> {
+pub struct SseF32Butterfly19<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 9],
     twiddles_im: [__m128; 9],
@@ -1337,7 +1337,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly19, 19, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly19<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(19, direction);
         Self {
@@ -1628,7 +1628,7 @@ impl<T: FftNum> SseF32Butterfly19<T> {
     }
 }
 
-struct SseF64Butterfly19<T> {
+pub struct SseF64Butterfly19<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 9],
     twiddles_im: [__m128d; 9],
@@ -1639,7 +1639,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly19, 19, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly19<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(19, direction);
         unsafe {Self {
@@ -1877,7 +1877,7 @@ impl<T: FftNum> SseF64Butterfly19<T> {
     }
 }
 
-struct SseF32Butterfly23<T> {
+pub struct SseF32Butterfly23<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 11],
     twiddles_im: [__m128; 11],
@@ -1888,7 +1888,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly23, 23, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly23<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(23, direction);
         Self {
@@ -2277,7 +2277,7 @@ impl<T: FftNum> SseF32Butterfly23<T> {
     }
 }
 
-struct SseF64Butterfly23<T> {
+pub struct SseF64Butterfly23<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 11],
     twiddles_im: [__m128d; 11],
@@ -2288,7 +2288,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly23, 23, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly23<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(23, direction);
         unsafe {Self {
@@ -2616,7 +2616,7 @@ impl<T: FftNum> SseF64Butterfly23<T> {
     }
 }
 
-struct SseF32Butterfly29<T> {
+pub struct SseF32Butterfly29<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 14],
     twiddles_im: [__m128; 14],
@@ -2627,7 +2627,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly29, 29, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly29<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(29, direction);
         Self {
@@ -3193,7 +3193,7 @@ impl<T: FftNum> SseF32Butterfly29<T> {
     }
 }
 
-struct SseF64Butterfly29<T> {
+pub struct SseF64Butterfly29<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 14],
     twiddles_im: [__m128d; 14],
@@ -3204,7 +3204,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly29, 29, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly29<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(29, direction);
         unsafe {Self {
@@ -3697,7 +3697,7 @@ impl<T: FftNum> SseF64Butterfly29<T> {
     }
 }
 
-struct SseF32Butterfly31<T> {
+pub struct SseF32Butterfly31<T> {
     direction: FftDirection,
     twiddles_re: [__m128; 15],
     twiddles_im: [__m128; 15],
@@ -3708,7 +3708,7 @@ boilerplate_fft_sse_f32_butterfly!(SseF32Butterfly31, 31, |this: &SseF32Butterfl
 impl<T: FftNum> SseF32Butterfly31<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(31, direction);
         Self {
@@ -4341,7 +4341,7 @@ impl<T: FftNum> SseF32Butterfly31<T> {
     }
 }
 
-struct SseF64Butterfly31<T> {
+pub struct SseF64Butterfly31<T> {
     direction: FftDirection,
     twiddles_re: [__m128d; 15],
     twiddles_im: [__m128d; 15],
@@ -4352,7 +4352,7 @@ boilerplate_fft_sse_f64_butterfly!(SseF64Butterfly31, 31, |this: &SseF64Butterfl
 impl<T: FftNum> SseF64Butterfly31<T> {
     /// Safety: The current machine must support the sse4.1 instruction set
     #[target_feature(enable = "sse4.1")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(31, direction);
         unsafe {Self {

--- a/src/sse/sse_radixn.rs
+++ b/src/sse/sse_radixn.rs
@@ -1,0 +1,224 @@
+//! The SSE side of `SimdRadixN`.
+//!
+//! The algorithm itself lives in `src/simd_radixn.rs`, shared by every SIMD backend. All that is
+//! left here is the `RadixNVector` impl for each vector type: the SSE loads, stores and vector
+//! math, and the element-type-specific butterfly structs for radix 3, 5, 6 and 7.
+
+use std::arch::x86_64::{__m128, __m128d};
+
+use num_complex::Complex;
+
+use crate::simd_radixn::{RadixNVector, SimdRadixN};
+use crate::FftDirection;
+
+use super::sse_butterflies::{
+    SseF32Butterfly3, SseF32Butterfly5, SseF32Butterfly6, SseF64Butterfly3, SseF64Butterfly5,
+    SseF64Butterfly6,
+};
+use super::sse_prime_butterflies::{SseF32Butterfly7, SseF64Butterfly7};
+use super::sse_vector::{Rotation90, SseArray, SseArrayMut, SseVector};
+use super::SseNum;
+
+/// FFT algorithm for lengths that factor into small radixes, SSE accelerated version.
+/// This is designed to be used via a Planner, and not created directly.
+pub type SseRadixN<S, T> = SimdRadixN<<S as SseNum>::VectorType, T>;
+
+impl RadixNVector for __m128d {
+    const COMPLEX_PER_VECTOR: usize = 1;
+
+    type ScalarType = f64;
+    type Rotation = Rotation90<Self>;
+
+    type Butterfly3 = SseF64Butterfly3<f64>;
+    type Butterfly5 = SseF64Butterfly5<f64>;
+    type Butterfly6 = SseF64Butterfly6<f64>;
+    type Butterfly7 = SseF64Butterfly7<f64>;
+
+    #[inline(always)]
+    unsafe fn load(data: &[Complex<f64>], index: usize) -> Self {
+        data.load_complex(index)
+    }
+    #[inline(always)]
+    unsafe fn store(mut data: &mut [Complex<f64>], value: Self, index: usize) {
+        data.store_complex(value, index)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        SseVector::mul_complex(left, right)
+    }
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        SseVector::make_mixedradix_twiddle_chunk(x, y, len, direction)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation {
+        SseVector::make_rotate90(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3 {
+        SseF64Butterfly3::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5 {
+        SseF64Butterfly5::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6 {
+        SseF64Butterfly6::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7 {
+        SseF64Butterfly7::new(direction)
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        SseVector::column_butterfly2(rows)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3] {
+        bf.perform_fft_direct(rows[0], rows[1], rows[2])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4] {
+        SseVector::column_butterfly4(rows, rotation)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5] {
+        bf.perform_fft_direct(rows[0], rows[1], rows[2], rows[3], rows[4])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6] {
+        bf.perform_fft_direct(rows)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7] {
+        bf.perform_fft_direct(rows)
+    }
+
+    sse_radixn_fft_helpers!();
+}
+
+impl RadixNVector for __m128 {
+    const COMPLEX_PER_VECTOR: usize = 2;
+
+    type ScalarType = f32;
+    type Rotation = Rotation90<Self>;
+
+    type Butterfly3 = SseF32Butterfly3<f32>;
+    type Butterfly5 = SseF32Butterfly5<f32>;
+    type Butterfly6 = SseF32Butterfly6<f32>;
+    type Butterfly7 = SseF32Butterfly7<f32>;
+
+    #[inline(always)]
+    unsafe fn load(data: &[Complex<f32>], index: usize) -> Self {
+        data.load_complex(index)
+    }
+    #[inline(always)]
+    unsafe fn store(mut data: &mut [Complex<f32>], value: Self, index: usize) {
+        data.store_complex(value, index)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        SseVector::mul_complex(left, right)
+    }
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        SseVector::make_mixedradix_twiddle_chunk(x, y, len, direction)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation {
+        SseVector::make_rotate90(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3 {
+        SseF32Butterfly3::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5 {
+        SseF32Butterfly5::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6 {
+        SseF32Butterfly6::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7 {
+        SseF32Butterfly7::new(direction)
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        SseVector::column_butterfly2(rows)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3] {
+        bf.perform_parallel_fft_direct(rows[0], rows[1], rows[2])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4] {
+        SseVector::column_butterfly4(rows, rotation)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5] {
+        bf.perform_parallel_fft_direct(rows[0], rows[1], rows[2], rows[3], rows[4])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6] {
+        bf.perform_parallel_fft_direct(rows[0], rows[1], rows[2], rows[3], rows[4], rows[5])
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7] {
+        bf.perform_parallel_fft_direct(rows)
+    }
+
+    sse_radixn_fft_helpers!();
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::simd_radixn::test_bodies;
+
+    #[test]
+    fn test_sse_radixn_f64() {
+        // f64 fits one complex per vector, so every base length is legal
+        test_bodies::factor_pairs::<__m128d>(&[1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn test_sse_radixn_f32() {
+        // f32 fits two complex per vector, so the base length has to be even
+        test_bodies::factor_pairs::<__m128>(&[2, 4, 6]);
+    }
+
+    #[test]
+    fn test_sse_radixn_composite_base() {
+        test_bodies::composite_base::<__m128, __m128d>();
+    }
+
+    #[test]
+    fn test_sse_radixn_large_recipes() {
+        test_bodies::large_recipes::<__m128, __m128d>();
+    }
+
+    #[test]
+    #[ignore]
+    fn test_sse_radixn_six_layers() {
+        test_bodies::six_layers::<__m128, __m128d>();
+    }
+}

--- a/src/wasm_simd/mod.rs
+++ b/src/wasm_simd/mod.rs
@@ -7,6 +7,7 @@ mod wasm_simd_vector;
 pub mod wasm_simd_butterflies;
 pub mod wasm_simd_prime_butterflies;
 pub mod wasm_simd_radix4;
+pub mod wasm_simd_radixn;
 
 mod wasm_simd_utils;
 
@@ -17,6 +18,7 @@ use core::arch::wasm32::v128;
 
 pub use self::wasm_simd_butterflies::*;
 pub use self::wasm_simd_radix4::*;
+pub use self::wasm_simd_radixn::*;
 use self::wasm_simd_vector::WasmVector;
 use self::wasm_simd_vector::WasmVector32;
 use self::wasm_simd_vector::WasmVector64;

--- a/src/wasm_simd/wasm_simd_common.rs
+++ b/src/wasm_simd/wasm_simd_common.rs
@@ -145,6 +145,65 @@ macro_rules! boilerplate_fft_wasm_simd_oop {
     };
 }
 
+// The `RadixNVector::fft_helper_*` methods, which are the same forwarding calls for every WASM
+// SIMD vector type: they hand the chunk loop to the target-feature-enabled wrappers below.
+macro_rules! wasm_simd_radixn_fft_helpers {
+    () => {
+        #[inline(always)]
+        unsafe fn fft_helper_immut<E>(
+            input: &[E],
+            output: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&[E], &mut [E], &mut [E]),
+        ) {
+            super::wasm_simd_common::wasm_simd_fft_helper_immut(
+                input,
+                output,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+        #[inline(always)]
+        unsafe fn fft_helper_outofplace<E>(
+            input: &mut [E],
+            output: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&mut [E], &mut [E], &mut [E]),
+        ) {
+            super::wasm_simd_common::wasm_simd_fft_helper_outofplace(
+                input,
+                output,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+        #[inline(always)]
+        unsafe fn fft_helper_inplace<E>(
+            buffer: &mut [E],
+            scratch: &mut [E],
+            chunk_size: usize,
+            required_scratch: usize,
+            chunk_fn: impl FnMut(&mut [E], &mut [E]),
+        ) {
+            super::wasm_simd_common::wasm_simd_fft_helper_inplace(
+                buffer,
+                scratch,
+                chunk_size,
+                required_scratch,
+                chunk_fn,
+            )
+        }
+    };
+}
+
 // A wrapper for the FFT helper functions that make sure the entire thing happens with the benefit of the Wasm SIMD target feature,
 // so that things like loading twiddle factor registers etc can be lifted out of the loop
 #[target_feature(enable = "simd128")]

--- a/src/wasm_simd/wasm_simd_planner.rs
+++ b/src/wasm_simd/wasm_simd_planner.rs
@@ -4,12 +4,15 @@ use crate::algorithm::{
     BluesteinsAlgorithm, Dft, GoodThomasAlgorithm, GoodThomasAlgorithmSmall, MixedRadix,
     MixedRadixSmall, RadersAlgorithm,
 };
+use crate::common::RadixFactor;
 use crate::math_utils::PrimeFactor;
+use crate::simd_planner::{self, RadixNPlan};
 use crate::wasm_simd::*;
 use crate::{fft_cache::FftCache, math_utils::PrimeFactors, Fft, FftDirection, FftNum};
 use std::{any::TypeId, collections::HashMap, sync::Arc};
 
 const MIN_RADIX4_BITS: u32 = 6; // smallest size to consider radix 4 an option is 2^6 = 64
+
 const MAX_RADER_PRIME_FACTOR: usize = 23; // don't use Raders if the inner fft length has prime factor larger than this
 
 /// A Recipe is a structure that describes the design of a FFT, without actually creating it.
@@ -45,6 +48,10 @@ pub enum Recipe {
         k: u32,
         base_fft: Arc<Recipe>,
     },
+    RadixN {
+        factors: Box<[RadixFactor]>,
+        base_fft: Arc<Recipe>,
+    },
     Butterfly1,
     Butterfly2,
     Butterfly3,
@@ -69,6 +76,9 @@ impl Recipe {
         match self {
             Recipe::Dft(length) => *length,
             Recipe::Radix4 { k, base_fft } => base_fft.len() * (1 << (k * 2)),
+            Recipe::RadixN { factors, base_fft } => {
+                base_fft.len() * factors.iter().map(|f| f.radix()).product::<usize>()
+            }
             Recipe::Butterfly1 => 1,
             Recipe::Butterfly2 => 2,
             Recipe::Butterfly3 => 3,
@@ -237,6 +247,16 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
                     Arc::new(WasmSimdRadix4::<f32, T>::new(*k, base_fft)) as Arc<dyn Fft<T>>
                 } else if id_t == id_f64 {
                     Arc::new(WasmSimdRadix4::<f64, T>::new(*k, base_fft)) as Arc<dyn Fft<T>>
+                } else {
+                    panic!("Not f32 or f64");
+                }
+            }
+            Recipe::RadixN { factors, base_fft } => {
+                let base_fft = self.build_fft(&base_fft, direction);
+                if id_t == id_f32 {
+                    Arc::new(WasmSimdRadixN::<f32, T>::new(factors, base_fft)) as Arc<dyn Fft<T>>
+                } else if id_t == id_f64 {
+                    Arc::new(WasmSimdRadixN::<f64, T>::new(factors, base_fft)) as Arc<dyn Fft<T>>
                 } else {
                     panic!("Not f32 or f64");
                 }
@@ -418,48 +438,56 @@ impl<T: FftNum> FftPlannerWasmSimd<T> {
             fft_instance
         } else if factors.is_prime() {
             self.design_prime(len)
+        } else if len.trailing_zeros() >= MIN_RADIX4_BITS
+            && factors.get_other_factors().is_empty()
+            && factors.get_power_of_three() < 2
+        {
+            // pure powers of two, and 3 * 2^k, are Radix4's job. It's a specialised RadixN, and
+            // measurably faster than the generic driver on the shapes it covers.
+            self.design_radix4(factors)
+        } else if let Some(butterfly_product) = self.design_butterfly_product(len) {
+            butterfly_product
+        } else if let Some(radixn) = self.design_radixn(&factors) {
+            radixn
         } else if len.trailing_zeros() >= MIN_RADIX4_BITS {
-            if factors.get_other_factors().is_empty() && factors.get_power_of_three() < 2 {
-                self.design_radix4(factors)
-            } else {
-                let non_power_of_two = factors
-                    .remove_factors(PrimeFactor {
-                        value: 2,
-                        count: len.trailing_zeros(),
-                    })
-                    .unwrap();
-                let power_of_two = PrimeFactors::compute(1 << len.trailing_zeros());
-                self.design_mixed_radix(power_of_two, non_power_of_two)
-            }
+            // RadixN couldn't take this one, so fall back to peeling the power of two off the
+            // front and mixed-radixing the rest.
+            let non_power_of_two = factors
+                .remove_factors(PrimeFactor {
+                    value: 2,
+                    count: len.trailing_zeros(),
+                })
+                .unwrap();
+            let power_of_two = PrimeFactors::compute(1 << len.trailing_zeros());
+            self.design_mixed_radix(power_of_two, non_power_of_two)
         } else {
-            // Can we do this as a mixed radix with just two butterflies?
-            // Loop through and find all combinations
-            // If more than one is found, keep the one where the factors are closer together.
-            // For example length 20 where 10x2 and 5x4 are possible, we use 5x4.
-            let mut bf_left = 0;
-            let mut bf_right = 0;
-            // If the length is below 14, or over 1024 we don't need to try this.
-            if len > 13 && len <= 1024 {
-                for (n, bf_l) in self.all_butterflies.iter().enumerate() {
-                    if len % bf_l == 0 {
-                        let bf_r = len / bf_l;
-                        if self.all_butterflies.iter().skip(n).any(|&m| m == bf_r) {
-                            bf_left = *bf_l;
-                            bf_right = bf_r;
-                        }
-                    }
-                }
-                if bf_left > 0 {
-                    let fact_l = PrimeFactors::compute(bf_left);
-                    let fact_r = PrimeFactors::compute(bf_right);
-                    return self.design_mixed_radix(fact_l, fact_r);
-                }
-            }
-            // Not possible with just butterflies, go with the general solution.
             let (left_factors, right_factors) = factors.partition_factors();
             self.design_mixed_radix(left_factors, right_factors)
         }
     }
+
+    // Can we do this as a mixed radix with just two butterflies?
+    fn design_butterfly_product(&mut self, len: usize) -> Option<Arc<Recipe>> {
+        let (bf_left, bf_right) =
+            simd_planner::design_butterfly_product(len, &self.all_butterflies)?;
+
+        let fact_l = PrimeFactors::compute(bf_left);
+        let fact_r = PrimeFactors::compute(bf_right);
+        Some(self.design_mixed_radix(fact_l, fact_r))
+    }
+
+    // Design a RadixN, or the Radix4 that some of its shapes are better served by. Returns None
+    // when RadixN can't cover this length, and the caller falls back to mixed radix.
+    fn design_radixn(&mut self, factors: &PrimeFactors) -> Option<Arc<Recipe>> {
+        let plan = simd_planner::design_radixn(factors, simd_planner::complex_per_vector::<T>())?;
+
+        let base_fft = self.design_fft_for_len(plan.base_len());
+        Some(match plan {
+            RadixNPlan::Radix4 { k, .. } => Arc::new(Recipe::Radix4 { k, base_fft }),
+            RadixNPlan::RadixN { factors, .. } => Arc::new(Recipe::RadixN { factors, base_fft }),
+        })
+    }
+
     fn design_mixed_radix(
         &mut self,
         left_factors: PrimeFactors,
@@ -616,6 +644,13 @@ mod unit_tests {
         }
     }
 
+    fn is_radixn(plan: &Recipe) -> bool {
+        match plan {
+            &Recipe::RadixN { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_mixedradixsmall(plan: &Recipe) -> bool {
         match plan {
             &Recipe::MixedRadixSmall { .. } => true,
@@ -645,7 +680,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_trivial() {
+    fn test_plan_wasm_simd_trivial() {
         // Length 0 and 1 should use Dft
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
         for len in 0..1 {
@@ -656,7 +691,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_largepoweroftwo() {
+    fn test_plan_wasm_simd_largepoweroftwo() {
         // Powers of 2 above 6 should use Radix4
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
         for pow in 6..32 {
@@ -668,7 +703,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_butterflies() {
+    fn test_plan_wasm_simd_butterflies() {
         // Check that all butterflies are used
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
         assert_eq!(*planner.design_fft_for_len(2), Recipe::Butterfly2);
@@ -693,8 +728,20 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_mixedradix() {
-        // Products of several different primes should become MixedRadix
+    fn test_plan_wasm_simd_mixedradix() {
+        // Products of several primes that are all too big for a RadixN cross-FFT layer should
+        // become MixedRadix
+        let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
+        for len in [11 * 11 * 13, 11 * 13 * 17, 17 * 19 * 23, 11 * 13 * 17 * 19] {
+            let plan = planner.design_fft_for_len(len);
+            assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
+            assert_eq!(plan.len(), len, "Recipe reports wrong length");
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_plan_wasm_simd_radixn() {
+        // Products of several small primes should become RadixN
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
         for pow2 in 2..5 {
             for pow3 in 2..5 {
@@ -705,7 +752,7 @@ mod unit_tests {
                             * 5usize.pow(pow5)
                             * 7usize.pow(pow7);
                         let plan = planner.design_fft_for_len(len);
-                        assert!(is_mixedradix(&plan), "Expected MixedRadix, got {:?}", plan);
+                        assert!(is_radixn(&plan), "Expected RadixN, got {:?}", plan);
                         assert_eq!(plan.len(), len, "Recipe reports wrong length");
                     }
                 }
@@ -714,10 +761,27 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_mixedradixsmall() {
+    fn test_plan_wasm_simd_radixn_f32_needs_an_even_base() {
+        // An f32 vector holds two complex numbers, so RadixN needs an even column count and can
+        // never take an odd length. Those have to keep falling back to mixed radix.
+        let mut planner32 = FftPlannerWasmSimd::<f32>::new().unwrap();
+        let mut planner64 = FftPlannerWasmSimd::<f64>::new().unwrap();
+        for len in [1215, 10125, 3125] {
+            let plan32 = planner32.design_fft_for_len(len);
+            assert!(!is_radixn(&plan32), "Expected no RadixN, got {:?}", plan32);
+            assert_eq!(plan32.len(), len, "Recipe reports wrong length");
+
+            let plan64 = planner64.design_fft_for_len(len);
+            assert!(is_radixn(&plan64), "Expected RadixN, got {:?}", plan64);
+            assert_eq!(plan64.len(), len, "Recipe reports wrong length");
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_plan_wasm_simd_mixedradixsmall() {
         // Products of two "small" lengths < 31 that have a common divisor >1, and isn't a power of 2 should be MixedRadixSmall
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
-        for len in [5 * 20, 5 * 25].iter() {
+        for len in [5 * 20, 6 * 9, 12 * 15, 10 * 15].iter() {
             let plan = planner.design_fft_for_len(*len);
             assert!(
                 is_mixedradixsmall(&plan),
@@ -729,7 +793,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_goodthomasbutterfly() {
+    fn test_plan_wasm_simd_goodthomasbutterfly() {
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
         for len in [3 * 7, 5 * 7, 11 * 13, 2 * 29].iter() {
             let plan = planner.design_fft_for_len(*len);
@@ -743,7 +807,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_plan_sse_bluestein_vs_rader() {
+    fn test_plan_wasm_simd_bluestein_vs_rader() {
         let difficultprimes: [usize; 11] = [59, 83, 107, 149, 167, 173, 179, 359, 719, 1439, 2879];
         let easyprimes: [usize; 24] = [
             53, 61, 67, 71, 73, 79, 89, 97, 101, 103, 109, 113, 127, 131, 137, 139, 151, 157, 163,
@@ -768,7 +832,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_sse_fft_cache() {
+    fn test_wasm_simd_fft_cache() {
         {
             // Check that FFTs are reused if they're both forward
             let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
@@ -796,7 +860,7 @@ mod unit_tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_sse_recipe_cache() {
+    fn test_wasm_simd_recipe_cache() {
         // Check that all butterflies are used
         let mut planner = FftPlannerWasmSimd::<f64>::new().unwrap();
         let fft_a = planner.design_fft_for_len(1234);

--- a/src/wasm_simd/wasm_simd_prime_butterflies.rs
+++ b/src/wasm_simd/wasm_simd_prime_butterflies.rs
@@ -78,7 +78,7 @@ fn make_twiddles<const TW: usize, T: FftNum>(len: usize, direction: FftDirection
     })
 }
 
-struct WasmSimdF32Butterfly7<T> {
+pub struct WasmSimdF32Butterfly7<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 3],
     twiddles_im: [WasmVector32; 3],
@@ -89,7 +89,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly7, 7, |this: &WasmS
 impl<T: FftNum> WasmSimdF32Butterfly7<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(7, direction);
         Self {
@@ -182,7 +182,7 @@ impl<T: FftNum> WasmSimdF32Butterfly7<T> {
     }
 }
 
-struct WasmSimdF64Butterfly7<T> {
+pub struct WasmSimdF64Butterfly7<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 3],
     twiddles_im: [WasmVector64; 3],
@@ -193,7 +193,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly7, 7, |this: &WasmS
 impl<T: FftNum> WasmSimdF64Butterfly7<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(7, direction);
         unsafe {Self {
@@ -257,7 +257,7 @@ impl<T: FftNum> WasmSimdF64Butterfly7<T> {
     }
 }
 
-struct WasmSimdF32Butterfly11<T> {
+pub struct WasmSimdF32Butterfly11<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 5],
     twiddles_im: [WasmVector32; 5],
@@ -268,7 +268,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly11, 11, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly11<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(11, direction);
         Self {
@@ -411,7 +411,7 @@ impl<T: FftNum> WasmSimdF32Butterfly11<T> {
     }
 }
 
-struct WasmSimdF64Butterfly11<T> {
+pub struct WasmSimdF64Butterfly11<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 5],
     twiddles_im: [WasmVector64; 5],
@@ -422,7 +422,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly11, 11, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly11<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(11, direction);
         unsafe {Self {
@@ -528,7 +528,7 @@ impl<T: FftNum> WasmSimdF64Butterfly11<T> {
     }
 }
 
-struct WasmSimdF32Butterfly13<T> {
+pub struct WasmSimdF32Butterfly13<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 6],
     twiddles_im: [WasmVector32; 6],
@@ -539,7 +539,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly13, 13, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly13<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(13, direction);
         Self {
@@ -713,7 +713,7 @@ impl<T: FftNum> WasmSimdF32Butterfly13<T> {
     }
 }
 
-struct WasmSimdF64Butterfly13<T> {
+pub struct WasmSimdF64Butterfly13<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 6],
     twiddles_im: [WasmVector64; 6],
@@ -724,7 +724,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly13, 13, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly13<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(13, direction);
         unsafe {Self {
@@ -857,7 +857,7 @@ impl<T: FftNum> WasmSimdF64Butterfly13<T> {
     }
 }
 
-struct WasmSimdF32Butterfly17<T> {
+pub struct WasmSimdF32Butterfly17<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 8],
     twiddles_im: [WasmVector32; 8],
@@ -868,7 +868,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly17, 17, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly17<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(17, direction);
         Self {
@@ -1116,7 +1116,7 @@ impl<T: FftNum> WasmSimdF32Butterfly17<T> {
     }
 }
 
-struct WasmSimdF64Butterfly17<T> {
+pub struct WasmSimdF64Butterfly17<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 8],
     twiddles_im: [WasmVector64; 8],
@@ -1127,7 +1127,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly17, 17, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly17<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(17, direction);
         unsafe {Self {
@@ -1326,7 +1326,7 @@ impl<T: FftNum> WasmSimdF64Butterfly17<T> {
     }
 }
 
-struct WasmSimdF32Butterfly19<T> {
+pub struct WasmSimdF32Butterfly19<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 9],
     twiddles_im: [WasmVector32; 9],
@@ -1337,7 +1337,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly19, 19, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly19<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(19, direction);
         Self {
@@ -1628,7 +1628,7 @@ impl<T: FftNum> WasmSimdF32Butterfly19<T> {
     }
 }
 
-struct WasmSimdF64Butterfly19<T> {
+pub struct WasmSimdF64Butterfly19<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 9],
     twiddles_im: [WasmVector64; 9],
@@ -1639,7 +1639,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly19, 19, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly19<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(19, direction);
         unsafe {Self {
@@ -1877,7 +1877,7 @@ impl<T: FftNum> WasmSimdF64Butterfly19<T> {
     }
 }
 
-struct WasmSimdF32Butterfly23<T> {
+pub struct WasmSimdF32Butterfly23<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 11],
     twiddles_im: [WasmVector32; 11],
@@ -1888,7 +1888,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly23, 23, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly23<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(23, direction);
         Self {
@@ -2277,7 +2277,7 @@ impl<T: FftNum> WasmSimdF32Butterfly23<T> {
     }
 }
 
-struct WasmSimdF64Butterfly23<T> {
+pub struct WasmSimdF64Butterfly23<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 11],
     twiddles_im: [WasmVector64; 11],
@@ -2288,7 +2288,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly23, 23, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly23<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(23, direction);
         unsafe {Self {
@@ -2616,7 +2616,7 @@ impl<T: FftNum> WasmSimdF64Butterfly23<T> {
     }
 }
 
-struct WasmSimdF32Butterfly29<T> {
+pub struct WasmSimdF32Butterfly29<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 14],
     twiddles_im: [WasmVector32; 14],
@@ -2627,7 +2627,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly29, 29, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly29<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(29, direction);
         Self {
@@ -3193,7 +3193,7 @@ impl<T: FftNum> WasmSimdF32Butterfly29<T> {
     }
 }
 
-struct WasmSimdF64Butterfly29<T> {
+pub struct WasmSimdF64Butterfly29<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 14],
     twiddles_im: [WasmVector64; 14],
@@ -3204,7 +3204,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly29, 29, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly29<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(29, direction);
         unsafe {Self {
@@ -3697,7 +3697,7 @@ impl<T: FftNum> WasmSimdF64Butterfly29<T> {
     }
 }
 
-struct WasmSimdF32Butterfly31<T> {
+pub struct WasmSimdF32Butterfly31<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector32; 15],
     twiddles_im: [WasmVector32; 15],
@@ -3708,7 +3708,7 @@ boilerplate_fft_wasm_simd_f32_butterfly!(WasmSimdF32Butterfly31, 31, |this: &Was
 impl<T: FftNum> WasmSimdF32Butterfly31<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles(31, direction);
         Self {
@@ -4341,7 +4341,7 @@ impl<T: FftNum> WasmSimdF32Butterfly31<T> {
     }
 }
 
-struct WasmSimdF64Butterfly31<T> {
+pub struct WasmSimdF64Butterfly31<T> {
     direction: FftDirection,
     twiddles_re: [WasmVector64; 15],
     twiddles_im: [WasmVector64; 15],
@@ -4352,7 +4352,7 @@ boilerplate_fft_wasm_simd_f64_butterfly!(WasmSimdF64Butterfly31, 31, |this: &Was
 impl<T: FftNum> WasmSimdF64Butterfly31<T> {
     /// Safety: The current machine must support the simd128 instruction set
     #[target_feature(enable = "simd128")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles(31, direction);
         unsafe {Self {

--- a/src/wasm_simd/wasm_simd_radixn.rs
+++ b/src/wasm_simd/wasm_simd_radixn.rs
@@ -1,0 +1,239 @@
+//! The WASM SIMD side of `SimdRadixN`.
+//!
+//! The algorithm itself lives in `src/simd_radixn.rs`, shared by every SIMD backend. All that is
+//! left here is the `RadixNVector` impl for each vector type: the WASM SIMD loads, stores and
+//! vector math, and the element-type-specific butterfly structs for radix 3, 5, 6 and 7.
+
+use num_complex::Complex;
+
+use crate::simd_radixn::{RadixNVector, SimdRadixN};
+use crate::FftDirection;
+
+use super::wasm_simd_butterflies::{
+    WasmSimdF32Butterfly3, WasmSimdF32Butterfly5, WasmSimdF32Butterfly6, WasmSimdF64Butterfly3,
+    WasmSimdF64Butterfly5, WasmSimdF64Butterfly6,
+};
+use super::wasm_simd_prime_butterflies::{WasmSimdF32Butterfly7, WasmSimdF64Butterfly7};
+use super::wasm_simd_vector::{
+    Rotation90, WasmSimdArray, WasmSimdArrayMut, WasmVector, WasmVector32, WasmVector64,
+};
+use super::WasmNum;
+
+/// FFT algorithm for lengths that factor into small radixes, WASM SIMD accelerated version.
+/// This is designed to be used via a Planner, and not created directly.
+pub type WasmSimdRadixN<S, T> = SimdRadixN<<S as WasmNum>::VectorType, T>;
+
+impl RadixNVector for WasmVector64 {
+    const COMPLEX_PER_VECTOR: usize = 1;
+
+    type ScalarType = f64;
+    type Rotation = Rotation90<Self>;
+
+    type Butterfly3 = WasmSimdF64Butterfly3<f64>;
+    type Butterfly5 = WasmSimdF64Butterfly5<f64>;
+    type Butterfly6 = WasmSimdF64Butterfly6<f64>;
+    type Butterfly7 = WasmSimdF64Butterfly7<f64>;
+
+    #[inline(always)]
+    unsafe fn load(data: &[Complex<f64>], index: usize) -> Self {
+        data.load_complex(index)
+    }
+    #[inline(always)]
+    unsafe fn store(mut data: &mut [Complex<f64>], value: Self, index: usize) {
+        data.store_complex(value, index)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        WasmVector::mul_complex(left, right)
+    }
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        WasmVector::make_mixedradix_twiddle_chunk(x, y, len, direction)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation {
+        WasmVector::make_rotate90(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3 {
+        WasmSimdF64Butterfly3::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5 {
+        WasmSimdF64Butterfly5::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6 {
+        WasmSimdF64Butterfly6::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7 {
+        WasmSimdF64Butterfly7::new(direction)
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        WasmVector::column_butterfly2(rows)
+    }
+    // Butterflies 3, 5 and 6 are written against raw `v128` while `WasmVector64` is a newtype over
+    // it, so their results come back needing rewrapping. Butterfly 7 already speaks the wrapper
+    // types and needs none of it.
+    #[inline(always)]
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3] {
+        bf.perform_fft_direct(rows[0].0, rows[1].0, rows[2].0)
+            .map(f64::wrap)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4] {
+        WasmVector::column_butterfly4(rows, rotation)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5] {
+        bf.perform_fft_direct(rows[0].0, rows[1].0, rows[2].0, rows[3].0, rows[4].0)
+            .map(f64::wrap)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6] {
+        bf.perform_fft_direct([
+            rows[0].0, rows[1].0, rows[2].0, rows[3].0, rows[4].0, rows[5].0,
+        ])
+        .map(f64::wrap)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7] {
+        bf.perform_fft_direct(rows)
+    }
+
+    wasm_simd_radixn_fft_helpers!();
+}
+
+impl RadixNVector for WasmVector32 {
+    const COMPLEX_PER_VECTOR: usize = 2;
+
+    type ScalarType = f32;
+    type Rotation = Rotation90<Self>;
+
+    type Butterfly3 = WasmSimdF32Butterfly3<f32>;
+    type Butterfly5 = WasmSimdF32Butterfly5<f32>;
+    type Butterfly6 = WasmSimdF32Butterfly6<f32>;
+    type Butterfly7 = WasmSimdF32Butterfly7<f32>;
+
+    #[inline(always)]
+    unsafe fn load(data: &[Complex<f32>], index: usize) -> Self {
+        data.load_complex(index)
+    }
+    #[inline(always)]
+    unsafe fn store(mut data: &mut [Complex<f32>], value: Self, index: usize) {
+        data.store_complex(value, index)
+    }
+
+    #[inline(always)]
+    unsafe fn mul_complex(left: Self, right: Self) -> Self {
+        WasmVector::mul_complex(left, right)
+    }
+    #[inline(always)]
+    unsafe fn make_mixedradix_twiddle_chunk(
+        x: usize,
+        y: usize,
+        len: usize,
+        direction: FftDirection,
+    ) -> Self {
+        WasmVector::make_mixedradix_twiddle_chunk(x, y, len, direction)
+    }
+
+    #[inline(always)]
+    unsafe fn make_rotate90(direction: FftDirection) -> Self::Rotation {
+        WasmVector::make_rotate90(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly3(direction: FftDirection) -> Self::Butterfly3 {
+        WasmSimdF32Butterfly3::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly5(direction: FftDirection) -> Self::Butterfly5 {
+        WasmSimdF32Butterfly5::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly6(direction: FftDirection) -> Self::Butterfly6 {
+        WasmSimdF32Butterfly6::new(direction)
+    }
+    #[inline(always)]
+    unsafe fn make_butterfly7(direction: FftDirection) -> Self::Butterfly7 {
+        WasmSimdF32Butterfly7::new(direction)
+    }
+
+    #[inline(always)]
+    unsafe fn column_butterfly2(rows: [Self; 2]) -> [Self; 2] {
+        WasmVector::column_butterfly2(rows)
+    }
+    // See the f64 impl for why butterflies 3, 5 and 6 rewrap their results and 7 doesn't.
+    #[inline(always)]
+    unsafe fn column_butterfly3(bf: &Self::Butterfly3, rows: [Self; 3]) -> [Self; 3] {
+        bf.perform_parallel_fft_direct(rows[0].0, rows[1].0, rows[2].0)
+            .map(f32::wrap)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly4(rows: [Self; 4], rotation: Self::Rotation) -> [Self; 4] {
+        WasmVector::column_butterfly4(rows, rotation)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly5(bf: &Self::Butterfly5, rows: [Self; 5]) -> [Self; 5] {
+        bf.perform_parallel_fft_direct(rows[0].0, rows[1].0, rows[2].0, rows[3].0, rows[4].0)
+            .map(f32::wrap)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly6(bf: &Self::Butterfly6, rows: [Self; 6]) -> [Self; 6] {
+        bf.perform_parallel_fft_direct(
+            rows[0].0, rows[1].0, rows[2].0, rows[3].0, rows[4].0, rows[5].0,
+        )
+        .map(f32::wrap)
+    }
+    #[inline(always)]
+    unsafe fn column_butterfly7(bf: &Self::Butterfly7, rows: [Self; 7]) -> [Self; 7] {
+        bf.perform_parallel_fft_direct(rows)
+    }
+
+    wasm_simd_radixn_fft_helpers!();
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::simd_radixn::test_bodies;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn test_wasm_simd_radixn_f64() {
+        // f64 fits one complex per vector, so every base length is legal
+        test_bodies::factor_pairs::<WasmVector64>(&[1, 2, 3, 4, 5, 6]);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_simd_radixn_f32() {
+        // f32 fits two complex per vector, so the base length has to be even
+        test_bodies::factor_pairs::<WasmVector32>(&[2, 4, 6]);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_simd_radixn_composite_base() {
+        test_bodies::composite_base::<WasmVector32, WasmVector64>();
+    }
+
+    #[wasm_bindgen_test]
+    fn test_wasm_simd_radixn_large_recipes() {
+        test_bodies::large_recipes::<WasmVector32, WasmVector64>();
+    }
+
+    #[wasm_bindgen_test]
+    #[ignore]
+    fn test_wasm_simd_radixn_six_layers() {
+        test_bodies::six_layers::<WasmVector32, WasmVector64>();
+    }
+}

--- a/tools/gen_simd_butterflies/src/templates/prime_template.hbs.rs
+++ b/tools/gen_simd_butterflies/src/templates/prime_template.hbs.rs
@@ -69,7 +69,7 @@ fn make_twiddles<const TW: usize, T: FftNum>(len: usize, direction: FftDirection
 }
 
 {{#each lengths}}
-struct {{this.struct_name_32}}<T> {
+pub struct {{this.struct_name_32}}<T> {
     direction: FftDirection,
     twiddles_re: [{{../arch.vector_f32}}; {{this.twiddle_len}}],
     twiddles_im: [{{../arch.vector_f32}}; {{this.twiddle_len}}],
@@ -80,7 +80,7 @@ boilerplate_fft_{{../arch.name_snakecase}}_f32_butterfly!({{this.struct_name_32}
 impl<T: FftNum> {{this.struct_name_32}}<T> {
     /// Safety: The current machine must support the {{../arch.cpu_feature_name}} instruction set
     #[target_feature(enable = "{{../arch.cpu_feature_name}}")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f32::<T>();
         let twiddles = make_twiddles({{this.len}}, direction);
         Self {
@@ -123,7 +123,7 @@ impl<T: FftNum> {{this.struct_name_32}}<T> {
     }
 }
 
-struct {{this.struct_name_64}}<T> {
+pub struct {{this.struct_name_64}}<T> {
     direction: FftDirection,
     twiddles_re: [{{../arch.vector_f64}}; {{this.twiddle_len}}],
     twiddles_im: [{{../arch.vector_f64}}; {{this.twiddle_len}}],
@@ -134,7 +134,7 @@ boilerplate_fft_{{../arch.name_snakecase}}_f64_butterfly!({{this.struct_name_64}
 impl<T: FftNum> {{this.struct_name_64}}<T> {
     /// Safety: The current machine must support the {{../arch.cpu_feature_name}} instruction set
     #[target_feature(enable = "{{../arch.cpu_feature_name}}")]
-    unsafe fn new(direction: FftDirection) -> Self {
+    pub unsafe fn new(direction: FftDirection) -> Self {
         assert_f64::<T>();
         let twiddles = make_twiddles({{this.len}}, direction);
         unsafe {Self {


### PR DESCRIPTION
Adds a vectorised RadixN to the NEON, SSE and wasm_simd backends, written once against a shared
`SimdVector` trait. No planner changes: wiring it up lands in a separate PR so the plan changes
can be measured on their own.

- `src/simd/simd_radixn.rs`: shared `SimdRadixN<V, T>`, generic over f32 and f64, base may be a
  composite recipe that needs scratch. The three `*_radixn.rs` files are thin type aliases plus
  tests
- `src/simd/simd_vector.rs`: the `SimdVector` trait the algorithm is written against, implemented
  once per vector type next to each backend's own vector trait impls
- prime butterfly structs and constructors made `pub` for sibling modules, via the shared
  generator template
- `split_cross_len` and `get_power_of` factored into `math_utils.rs`, so `plan.rs` shares them
- RadixN is only reachable from its own tests until the planner PR, hence the `allow(dead_code)`